### PR TITLE
fix(build): hoist GL_GLEXT_PROTOTYPES out of __APPLE__ branch

### DIFF
--- a/Source/CABackingStore.h
+++ b/Source/CABackingStore.h
@@ -38,8 +38,15 @@
 #if GNUSTEP
 #import <CoreGraphics/CoreGraphics.h>
 #endif
-#if (__APPLE__)
+/* GL_GLEXT_PROTOTYPES must be defined BEFORE <GL/gl.h> is included so that
+ * when gl.h transitively pulls in glext.h, the OpenGL 2.0+ prototypes
+ * (glUseProgram etc.) are declared. Previously this define was inside the
+ * __APPLE__ branch, so the Linux build of CARenderer.m saw an undefined
+ * glUseProgram and failed on modern clang (which treats implicit function
+ * declarations as errors).
+ */
 #define GL_GLEXT_PROTOTYPES 1
+#if (__APPLE__)
 #import <OpenGL/OpenGL.h>
 #import <OpenGL/gl.h>
 #import <OpenGL/glu.h>


### PR DESCRIPTION
## Problem

On Linux with clang 16+ (clang 18.1.3 on Ubuntu 24.04), building `Source/CARenderer.m` fails with:

```
CARenderer.m:451:11: error: call to undeclared function 'glUseProgram';
  ISO C99 and later do not support implicit function declarations
```

and a handful of similar errors for other GL 2.0+ entry points.

## Root cause

`Source/CABackingStore.h` sets `GL_GLEXT_PROTOTYPES` **only inside the `__APPLE__` branch**:

```c
#if (__APPLE__)
#define GL_GLEXT_PROTOTYPES 1
#import <OpenGL/OpenGL.h>
#import <OpenGL/gl.h>
#import <OpenGL/glu.h>
#else
#import <GL/gl.h>    // no GL_GLEXT_PROTOTYPES defined here!
#import <GL/glu.h>
#endif
```

On Linux, `<GL/gl.h>` then transitively includes `<GL/glext.h>` — but since `GL_GLEXT_PROTOTYPES` isn't set at that point, glext.h sets its own include guard `__gl_glext_h_` **without emitting any OpenGL 2.0+ prototype declarations**. CARenderer.m's later `#import <GL/glext.h>` with `GL_GLEXT_PROTOTYPES` set is then a no-op because of the guard, and `glUseProgram` and friends end up as implicit declarations.

Older clang (≤15) treated implicit declarations as a warning; clang 16 promoted it to an error by default, which is what finally surfaced the latent bug.

## Fix

Move `#define GL_GLEXT_PROTOTYPES 1` **above** the `__APPLE__` split, so every backend has it set before the first time any glext.h is traversed. All OpenGL 2.0+ prototypes are then emitted on first entry, and the later glext.h imports in CARenderer.m continue to work.

## Platform impact

- **Linux/Mesa:** CARenderer.m now compiles cleanly against clang 16+ and Mesa's headers.
- **macOS:** unchanged — the `#define` was already set on this path; hoisting it is a no-op.
- **Windows:** unchanged — current MSYS2 clang builds don't go through this include chain.

## Test plan

- [x] Ubuntu 24.04 + clang 18.1.3 + Mesa `libgl1-mesa-dev` 25.2: `libs-quartzcore` framework builds cleanly
- [x] Verified preprocessor output: `glUseProgram`, `glCreateShader`, `glLinkProgram`, `glGetUniformLocation` etc. are all declared at the point of use
- [ ] macOS spot-check (don't have a Mac; the changed line is platform-agnostic)