### PR TITLE
CALayer: fix inverted isPresentationLayer

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -677,7 +677,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
 - (BOOL) isPresentationLayer
 {
-  return !_presentationLayer;
+  return _modelLayer != nil;
 }
 
 - (CALayer *) superlayer


### PR DESCRIPTION
## Summary

`-isPresentationLayer` returned `!_presentationLayer`, so a **model** layer that
had not yet lazily created its presentation replica (the common case) reported
`YES`. `-superlayer` then took the presentation branch:

```objc
return [[[self modelLayer] superlayer] presentationLayer];
```

with a `nil` `modelLayer`, losing the real superlayer (breaking `-rootLayer`
and ancestor walks until a presentation layer happens to be instantiated).

## Fix

A presentation layer is the one whose `_modelLayer` is set — see
`-presentationLayer`, which does `[_presentationLayer setModelLayer: self]` and
then `assert([_presentationLayer isPresentationLayer])`. A model layer has
`_modelLayer == nil`. Return `_modelLayer != nil`.

## Validation

Built `libQuartzCore` (clang, gnustep-2.0, against libs-corebase + libs-opal +
libs-gui); `CALayer.m` compiles cleanly with the change. The fix is a one-line
logic correction whose correctness follows directly from `-presentationLayer`'s
own contract (it sets the replica's `modelLayer` and asserts the replica is a
presentation layer).
