### PR TITLE
Fix: divide by the determinant in CATransform3DInvert

### DIFF
--- a/Source/CATransform3D.m
+++ b/Source/CATransform3D.m
@@ -214,6 +214,11 @@ CATransform3D CATransform3DInvert(CATransform3D t)
       m.m43 = - determinant3x3(t.m11, t.m12, t.m13, t.m21, t.m22, t.m23, t.m41, t.m42, t.m43);
       m.m44 =   determinant3x3(t.m11, t.m12, t.m13, t.m21, t.m22, t.m23, t.m31, t.m32, t.m33);
 
+      m.m11 /= determinant;  m.m12 /= determinant;  m.m13 /= determinant;  m.m14 /= determinant;
+      m.m21 /= determinant;  m.m22 /= determinant;  m.m23 /= determinant;  m.m24 /= determinant;
+      m.m31 /= determinant;  m.m32 /= determinant;  m.m33 /= determinant;  m.m34 /= determinant;
+      m.m41 /= determinant;  m.m42 /= determinant;  m.m43 /= determinant;  m.m44 /= determinant;
+
       return m;
     }
   else


### PR DESCRIPTION
CATransform3DInvert computed the adjugate of the matrix but never divided by the determinant, so it returned the adjugate rather than the inverse: inverting CATransform3DMakeScale(2, 2, 2) gave a diagonal of 4, 4, 4, 8 instead of 0.5, 0.5, 0.5, 1. Divide each element by the determinant.

This makes the hopeful assertion in the CATransform3D tests (#12) pass. Checked against Apple QuartzCore on a macOS runner.