### PR TITLE
Fix: make CAMediaTimingFunction.h self-contained

### DIFF
--- a/Headers/QuartzCore/CAMediaTimingFunction.h
+++ b/Headers/QuartzCore/CAMediaTimingFunction.h
@@ -28,6 +28,7 @@
 */
 
 #import <Foundation/NSObject.h>
+#import <CoreGraphics/CGBase.h>
 
 extern NSString *const kCAMediaTimingFunctionDefault;
 extern NSString *const kCAMediaTimingFunctionEaseInEaseOut;


### PR DESCRIPTION
CAMediaTimingFunction.h declares CGFloat ivars but imports only <Foundation/NSObject.h>, so including the header on its own fails with "unknown type name 'CGFloat'". Import <CoreGraphics/CGBase.h> for CGFloat, as the sibling CATransform3D.h already does.

Lets #14 drop the <Foundation/NSGeometry.h> workaround it needs today.