### PR TITLE
Feature: add the CATransform3D affine transform bridge

### DIFF
--- a/Headers/QuartzCore/CATransform3D.h
+++ b/Headers/QuartzCore/CATransform3D.h
@@ -32,6 +32,7 @@
 
 #if GNUSTEP
 #import <CoreGraphics/CGBase.h>
+#import <CoreGraphics/CGAffineTransform.h>
 #endif
 
 CA_EXTERN_C_BEGIN
@@ -65,6 +66,16 @@ CATransform3D CATransform3DRotate(CATransform3D t, CGFloat radians, CGFloat x, C
 CATransform3D CATransform3DConcat(CATransform3D a, CATransform3D b);
 
 CATransform3D CATransform3DInvert(CATransform3D t);
+
+/* Returns a transform with the same effect as the affine transform 'm'. */
+CATransform3D CATransform3DMakeAffineTransform(CGAffineTransform m);
+
+/* Returns true if 't' can be represented exactly by an affine transform. */
+bool CATransform3DIsAffine(CATransform3D t);
+
+/* Returns the affine transform represented by 't'.  If 't' is not affine the
+   returned value is undefined. */
+CGAffineTransform CATransform3DGetAffineTransform(CATransform3D t);
 
 #ifdef __OBJC__
 #import <Foundation/NSValue.h>

--- a/Source/CATransform3D.m
+++ b/Source/CATransform3D.m
@@ -223,6 +223,29 @@ CATransform3D CATransform3DInvert(CATransform3D t)
     }
 }
 
+CATransform3D CATransform3DMakeAffineTransform(CGAffineTransform m)
+{
+  CATransform3D t = CATransform3DIdentity;
+  t.m11 = m.a;  t.m12 = m.b;
+  t.m21 = m.c;  t.m22 = m.d;
+  t.m41 = m.tx; t.m42 = m.ty;
+  return t;
+}
+
+bool CATransform3DIsAffine(CATransform3D t)
+{
+  return t.m13 == 0 && t.m14 == 0
+      && t.m23 == 0 && t.m24 == 0
+      && t.m31 == 0 && t.m32 == 0 && t.m34 == 0
+      && t.m43 == 0
+      && t.m33 == 1 && t.m44 == 1;
+}
+
+CGAffineTransform CATransform3DGetAffineTransform(CATransform3D t)
+{
+  return CGAffineTransformMake(t.m11, t.m12, t.m21, t.m22, t.m41, t.m42);
+}
+
 @implementation NSValue (CATransform3D)
 
 + (NSValue *) valueWithCATransform3D:(CATransform3D)transform

--- a/Tests/quartzcore/CATransform3DAffine/affine.m
+++ b/Tests/quartzcore/CATransform3DAffine/affine.m
@@ -1,0 +1,64 @@
+/* The CATransform3D <-> CGAffineTransform bridge: making a transform from an
+   affine transform, testing whether a transform is affine, and getting the
+   affine transform back.  Expected values checked against Apple QuartzCore. */
+#include "Testing.h"
+
+#include <QuartzCore/CATransform3D.h>
+#include <math.h>
+
+static BOOL eq(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+  if (d < 0) d = -d;
+  return d < 1e-4;
+}
+
+int main(void)
+{
+  START_SET("CATransform3D affine bridge")
+
+  /* Make a 3D transform from a 2D affine transform. */
+  CGAffineTransform a = CGAffineTransformMake(2, 3, 4, 5, 6, 7);
+  CATransform3D m = CATransform3DMakeAffineTransform(a);
+  PASS(eq(m.m11, 2) && eq(m.m12, 3) && eq(m.m21, 4) && eq(m.m22, 5)
+       && eq(m.m41, 6) && eq(m.m42, 7),
+       "MakeAffineTransform places the affine components");
+  PASS(eq(m.m13, 0) && eq(m.m14, 0) && eq(m.m23, 0) && eq(m.m24, 0)
+       && eq(m.m31, 0) && eq(m.m32, 0) && eq(m.m34, 0) && eq(m.m43, 0)
+       && eq(m.m33, 1) && eq(m.m44, 1),
+       "MakeAffineTransform leaves the rest as the identity");
+
+  /* IsAffine. */
+  PASS(CATransform3DIsAffine(CATransform3DIdentity),
+       "the identity is affine");
+  PASS(CATransform3DIsAffine(m),
+       "a transform built from an affine transform is affine");
+  PASS(CATransform3DIsAffine(CATransform3DMakeRotation(1, 0, 0, 1)),
+       "a rotation about z is affine");
+  PASS(!CATransform3DIsAffine(CATransform3DMakeRotation(1, 1, 0, 0)),
+       "a rotation about x is not affine");
+  PASS(!CATransform3DIsAffine(CATransform3DMakeScale(1, 1, 2)),
+       "a z scale is not affine");
+  PASS(!CATransform3DIsAffine(CATransform3DMakeTranslation(0, 0, 5)),
+       "a z translation is not affine");
+  CATransform3D pers = CATransform3DIdentity;
+  pers.m34 = -1.0/500;
+  PASS(!CATransform3DIsAffine(pers), "a perspective transform is not affine");
+
+  /* GetAffineTransform. */
+  CGAffineTransform back = CATransform3DGetAffineTransform(m);
+  PASS(eq(back.a, 2) && eq(back.b, 3) && eq(back.c, 4) && eq(back.d, 5)
+       && eq(back.tx, 6) && eq(back.ty, 7),
+       "GetAffineTransform returns the affine components");
+
+  /* Round-trip. */
+  CGAffineTransform rt = CATransform3DGetAffineTransform(
+    CATransform3DMakeAffineTransform(a));
+  PASS(eq(rt.a, a.a) && eq(rt.b, a.b) && eq(rt.c, a.c) && eq(rt.d, a.d)
+       && eq(rt.tx, a.tx) && eq(rt.ty, a.ty),
+       "an affine transform round-trips through a 3D transform");
+
+  END_SET("CATransform3D affine bridge")
+
+  return 0;
+}


### PR DESCRIPTION
GNUstep's `CATransform3D` lacked the `CGAffineTransform` bridge that Apple provides. This adds the three functions:

- `CATransform3DMakeAffineTransform(CGAffineTransform m)` - places the affine components a,b,c,d,tx,ty at m11,m12,m21,m22,m41,m42 and leaves the rest as the identity.
- `CATransform3DIsAffine(CATransform3D t)` - true when the transform has no z or perspective terms (m13,m14,m23,m24,m31,m32,m34,m43 are zero and m33,m44 are one), so a rotation about z is affine while one about x is not.
- `CATransform3DGetAffineTransform(CATransform3D t)` - returns those six components.

The header also imports `CoreGraphics/CGAffineTransform.h` (under the GNUstep guard) for the `CGAffineTransform` type.

Verified against Apple QuartzCore: `MakeAffineTransform(2,3,4,5,6,7)` yields m11=2/m12=3/m21=4/m22=5/m41=6/m42=7 with the rest identity; `IsAffine` is true for the identity, an affine-built transform and a z-rotation, and false for an x-rotation, a z-scale, a z-translation and a perspective transform; `GetAffineTransform` returns the six components and round-trips.

The tests use the `Tests/quartzcore` harness added in #12, so please merge that first.