### PR TITLE
Feature: convert geometry between layers, and the affine transform

### DIFF
--- a/Headers/QuartzCore/CATransform3D.h
+++ b/Headers/QuartzCore/CATransform3D.h
@@ -32,6 +32,7 @@
 
 #if GNUSTEP
 #import <CoreGraphics/CGBase.h>
+#import <CoreGraphics/CGAffineTransform.h>
 #endif
 
 CA_EXTERN_C_BEGIN
@@ -65,6 +66,16 @@ CATransform3D CATransform3DRotate(CATransform3D t, CGFloat radians, CGFloat x, C
 CATransform3D CATransform3DConcat(CATransform3D a, CATransform3D b);
 
 CATransform3D CATransform3DInvert(CATransform3D t);
+
+/* Returns a transform with the same effect as the affine transform 'm'. */
+CATransform3D CATransform3DMakeAffineTransform(CGAffineTransform m);
+
+/* Returns true if 't' can be represented exactly by an affine transform. */
+bool CATransform3DIsAffine(CATransform3D t);
+
+/* Returns the affine transform represented by 't'.  If 't' is not affine the
+   returned value is undefined. */
+CGAffineTransform CATransform3DGetAffineTransform(CATransform3D t);
 
 #ifdef __OBJC__
 #import <Foundation/NSValue.h>

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -71,6 +71,24 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 - (void)setModelLayer: (id)modelLayer;
 @end
 
+
+/* The 2D part of a layer transform, as an affine transform. */
+static CGAffineTransform
+CALayerAffineOf(CATransform3D t)
+{
+  return CGAffineTransformMake(t.m11, t.m12, t.m21, t.m22, t.m41, t.m42);
+}
+
+/* Apply `t` about `pivot` rather than about the origin. */
+static CGPoint
+CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
+{
+  CGPoint q = CGPointMake(p.x - pivot.x, p.y - pivot.y);
+
+  q = CGPointApplyAffineTransform(q, t);
+  return CGPointMake(q.x + pivot.x, q.y + pivot.y);
+}
+
 @implementation CALayer
 
 @synthesize delegate=_delegate;
@@ -1248,12 +1266,193 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   [super setValue: value forUndefinedKey: key];
 }
 
+/* Geometry conversion.
+ *
+ * A point is carried from a layer to the space its superlayer uses, and the
+ * other way, one level at a time; a conversion between any two layers is the
+ * first walked up to its root and the second walked back down.  Going up, the
+ * point is taken relative to the layer's bounds origin and anchor point, put
+ * through the layer's own transform and offset by its position, and then, if
+ * the superlayer carries a sublayer transform, put through that about the
+ * superlayer's anchor point.  Going down reverses each of those steps.
+ *
+ * A layer with no superlayer is its own root, so two layers in different trees
+ * convert through the root each of them has.
+ */
+
+/* The point moved from this layer's space into its superlayer's space. */
+- (CGPoint) _pointToSuperlayer: (CGPoint)p
+{
+  CGRect        b = [self bounds];
+  CGPoint       anchor = [self anchorPoint];
+  CGPoint       position = [self position];
+  CALayer      *above = [self superlayer];
+  CGPoint       q;
+
+  q = CGPointMake(p.x - b.origin.x - anchor.x * b.size.width,
+                  p.y - b.origin.y - anchor.y * b.size.height);
+  q = CGPointApplyAffineTransform(q, CALayerAffineOf([self transform]));
+  q = CGPointMake(q.x + position.x, q.y + position.y);
+
+  if (above != nil)
+    {
+      CATransform3D st = [above sublayerTransform];
+
+      if (!CATransform3DIsIdentity(st))
+        {
+          CGRect  sb = [above bounds];
+          CGPoint sa = [above anchorPoint];
+
+          q = CALayerApplyAbout(CALayerAffineOf(st), q,
+                CGPointMake(sa.x * sb.size.width, sa.y * sb.size.height));
+        }
+    }
+  return q;
+}
+
+/* The reverse: a point in the superlayer's space moved into this layer's. */
+- (CGPoint) _pointFromSuperlayer: (CGPoint)p
+{
+  CGRect        b = [self bounds];
+  CGPoint       anchor = [self anchorPoint];
+  CGPoint       position = [self position];
+  CALayer      *above = [self superlayer];
+  CGPoint       q = p;
+
+  if (above != nil)
+    {
+      CATransform3D st = [above sublayerTransform];
+
+      if (!CATransform3DIsIdentity(st))
+        {
+          CGRect  sb = [above bounds];
+          CGPoint sa = [above anchorPoint];
+
+          q = CALayerApplyAbout(CGAffineTransformInvert(CALayerAffineOf(st)), q,
+                CGPointMake(sa.x * sb.size.width, sa.y * sb.size.height));
+        }
+    }
+
+  q = CGPointMake(q.x - position.x, q.y - position.y);
+  q = CGPointApplyAffineTransform(q,
+        CGAffineTransformInvert(CALayerAffineOf([self transform])));
+  return CGPointMake(q.x + b.origin.x + anchor.x * b.size.width,
+                     q.y + b.origin.y + anchor.y * b.size.height);
+}
+
+- (CGPoint) _pointToRoot: (CGPoint)p
+{
+  CALayer *layer = self;
+  CGPoint  q = p;
+
+  while (layer != nil)
+    {
+      q = [layer _pointToSuperlayer: q];
+      layer = [layer superlayer];
+    }
+  return q;
+}
+
+- (CGPoint) _pointFromRoot: (CGPoint)p
+{
+  CGPoint q = p;
+
+  if ([self superlayer] != nil)
+    {
+      q = [[self superlayer] _pointFromRoot: q];
+    }
+  return [self _pointFromSuperlayer: q];
+}
+
+- (CGPoint) convertPoint: (CGPoint)p fromLayer: (CALayer *)layer
+{
+  return [self _pointFromRoot: [layer _pointToRoot: p]];
+}
+
+- (CGPoint) convertPoint: (CGPoint)p toLayer: (CALayer *)layer
+{
+  CGPoint q = [self _pointToRoot: p];
+
+  if (layer == nil)
+    {
+      return q;
+    }
+  return [layer _pointFromRoot: q];
+}
+
+/* A rectangle converts as the bounding box of the four converted corners,
+ * since a transform on the way may rotate or skew it. */
+- (CGRect) _boxOfCorners: (CGPoint *)c
+{
+  CGFloat minX, maxX, minY, maxY;
+  int     i;
+
+  minX = maxX = c[0].x;
+  minY = maxY = c[0].y;
+  for (i = 1; i < 4; i++)
+    {
+      if (c[i].x < minX) minX = c[i].x;
+      if (c[i].x > maxX) maxX = c[i].x;
+      if (c[i].y < minY) minY = c[i].y;
+      if (c[i].y > maxY) maxY = c[i].y;
+    }
+  return CGRectMake(minX, minY, maxX - minX, maxY - minY);
+}
+
+- (CGRect) convertRect: (CGRect)r fromLayer: (CALayer *)layer
+{
+  CGPoint c[4];
+
+  r = CGRectStandardize(r);
+  c[0] = [self convertPoint: CGPointMake(CGRectGetMinX(r), CGRectGetMinY(r))
+                  fromLayer: layer];
+  c[1] = [self convertPoint: CGPointMake(CGRectGetMaxX(r), CGRectGetMinY(r))
+                  fromLayer: layer];
+  c[2] = [self convertPoint: CGPointMake(CGRectGetMaxX(r), CGRectGetMaxY(r))
+                  fromLayer: layer];
+  c[3] = [self convertPoint: CGPointMake(CGRectGetMinX(r), CGRectGetMaxY(r))
+                  fromLayer: layer];
+  return [self _boxOfCorners: c];
+}
+
+- (CGRect) convertRect: (CGRect)r toLayer: (CALayer *)layer
+{
+  CGPoint c[4];
+
+  r = CGRectStandardize(r);
+  c[0] = [self convertPoint: CGPointMake(CGRectGetMinX(r), CGRectGetMinY(r))
+                    toLayer: layer];
+  c[1] = [self convertPoint: CGPointMake(CGRectGetMaxX(r), CGRectGetMinY(r))
+                    toLayer: layer];
+  c[2] = [self convertPoint: CGPointMake(CGRectGetMaxX(r), CGRectGetMaxY(r))
+                    toLayer: layer];
+  c[3] = [self convertPoint: CGPointMake(CGRectGetMinX(r), CGRectGetMaxY(r))
+                    toLayer: layer];
+  return [self _boxOfCorners: c];
+}
+
+/* The affine part of the layer transform.  A transform that is not affine has
+ * no affine equivalent, and is reported as the identity rather than as the six
+ * elements that happen to sit in those places. */
+- (CGAffineTransform) affineTransform
+{
+  CATransform3D t = [self transform];
+
+  if (!CATransform3DIsAffine(t))
+    {
+      return CGAffineTransformIdentity;
+    }
+  return CATransform3DGetAffineTransform(t);
+}
+
+/* Setting it replaces the whole transform rather than concatenating. */
+- (void) setAffineTransform: (CGAffineTransform)affineTransform
+{
+  [self setTransform: CATransform3DMakeAffineTransform(affineTransform)];
+}
+
 /* Unimplemented functions: */
 #if 0
-- (CGPoint) convertPoint: (CGPoint)p fromLayer: (CALayer *)l;
-- (CGPoint) convertPoint: (CGPoint)p toLayer: (CALayer *)l;
-- (CGRect) convertRect: (CGRect)p fromLayer: (CALayer *)l;
-- (CGRect) convertRect: (CGRect)p toLayer: (CALayer *)l;
 - (void)setNeedsLayout;
 - (void)layoutIfNeeded;
 

--- a/Source/CATransform3D.m
+++ b/Source/CATransform3D.m
@@ -223,6 +223,29 @@ CATransform3D CATransform3DInvert(CATransform3D t)
     }
 }
 
+CATransform3D CATransform3DMakeAffineTransform(CGAffineTransform m)
+{
+  CATransform3D t = CATransform3DIdentity;
+  t.m11 = m.a;  t.m12 = m.b;
+  t.m21 = m.c;  t.m22 = m.d;
+  t.m41 = m.tx; t.m42 = m.ty;
+  return t;
+}
+
+bool CATransform3DIsAffine(CATransform3D t)
+{
+  return t.m13 == 0 && t.m14 == 0
+      && t.m23 == 0 && t.m24 == 0
+      && t.m31 == 0 && t.m32 == 0 && t.m34 == 0
+      && t.m43 == 0
+      && t.m33 == 1 && t.m44 == 1;
+}
+
+CGAffineTransform CATransform3DGetAffineTransform(CATransform3D t)
+{
+  return CGAffineTransformMake(t.m11, t.m12, t.m21, t.m22, t.m41, t.m42);
+}
+
 @implementation NSValue (CATransform3D)
 
 + (NSValue *) valueWithCATransform3D:(CATransform3D)transform

--- a/Tests/quartzcore/CALayer/conversion.m
+++ b/Tests/quartzcore/CALayer/conversion.m
@@ -45,8 +45,6 @@ layerWithBounds(CGRect bounds, CGPoint position)
 int
 main(int argc, char **argv)
 {
-  CREATE_AUTORELEASE_POOL(arp);
-
   START_SET("a point between a layer and its superlayer")
     CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
                                       CGPointMake(100, 100));
@@ -290,6 +288,5 @@ main(int argc, char **argv)
     PASS(t.m33 == 1, "the z scale of the replaced transform is gone");
   END_SET("setting the affine transform")
 
-  DESTROY(arp);
   return 0;
 }

--- a/Tests/quartzcore/CALayer/conversion.m
+++ b/Tests/quartzcore/CALayer/conversion.m
@@ -1,0 +1,295 @@
+/* Converting points and rectangles between layers, and the affine part of a
+   layer transform.  Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CATransform3D.h>
+
+#define TOL 1e-4
+
+static BOOL
+pointIs(CGPoint p, CGFloat x, CGFloat y)
+{
+  return (fabs(p.x - x) < TOL && fabs(p.y - y) < TOL) ? YES : NO;
+}
+
+static BOOL
+rectIs(CGRect r, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
+{
+  return (fabs(r.origin.x - x) < TOL && fabs(r.origin.y - y) < TOL
+       && fabs(r.size.width - w) < TOL && fabs(r.size.height - h) < TOL)
+    ? YES : NO;
+}
+
+static BOOL
+affineIs(CGAffineTransform t, CGFloat a, CGFloat b, CGFloat c, CGFloat d,
+         CGFloat tx, CGFloat ty)
+{
+  return (fabs(t.a - a) < TOL && fabs(t.b - b) < TOL
+       && fabs(t.c - c) < TOL && fabs(t.d - d) < TOL
+       && fabs(t.tx - tx) < TOL && fabs(t.ty - ty) < TOL) ? YES : NO;
+}
+
+static CALayer *
+layerWithBounds(CGRect bounds, CGPoint position)
+{
+  CALayer *l = [CALayer layer];
+
+  [l setBounds: bounds];
+  [l setPosition: position];
+  return l;
+}
+
+int
+main(int argc, char **argv)
+{
+  CREATE_AUTORELEASE_POOL(arp);
+
+  START_SET("a point between a layer and its superlayer")
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                     CGPointMake(100, 50));
+
+    [parent addSublayer: child];
+
+    PASS(pointIs([child convertPoint: CGPointMake(0, 0) toLayer: parent],
+                 75, 25),
+      "the child origin lands at its offset in the parent");
+    PASS(pointIs([child convertPoint: CGPointMake(50, 50) toLayer: parent],
+                 125, 75),
+      "the far corner of the child lands past it");
+    PASS(pointIs([parent convertPoint: CGPointMake(0, 0) toLayer: child],
+                 -75, -25),
+      "the parent origin lands before the child origin");
+    PASS(pointIs([child convertPoint: CGPointMake(0, 0) fromLayer: parent],
+                 -75, -25),
+      "converting from the parent is the same as the parent converting to it");
+    PASS(pointIs([parent convertPoint: CGPointMake(0, 0) fromLayer: child],
+                 75, 25),
+      "converting from the child is the same as the child converting to it");
+  END_SET("a point between a layer and its superlayer")
+
+  START_SET("a rectangle between a layer and its superlayer")
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                     CGPointMake(100, 50));
+
+    [parent addSublayer: child];
+
+    PASS(rectIs([child convertRect: CGRectMake(0, 0, 10, 20) toLayer: parent],
+                75, 25, 10, 20),
+      "a rectangle keeps its size and moves by the offset");
+    PASS(rectIs([parent convertRect: CGRectMake(0, 0, 10, 20) toLayer: child],
+                -75, -25, 10, 20),
+      "and the same the other way");
+  END_SET("a rectangle between a layer and its superlayer")
+
+  START_SET("a layer converts to itself unchanged")
+    CALayer *l = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                 CGPointMake(100, 50));
+
+    PASS(pointIs([l convertPoint: CGPointMake(3, 4) toLayer: l], 3, 4),
+      "a point converted to the same layer is unchanged");
+    PASS(rectIs([l convertRect: CGRectMake(3, 4, 5, 6) toLayer: l], 3, 4, 5, 6),
+      "a rectangle converted to the same layer is unchanged");
+  END_SET("a layer converts to itself unchanged")
+
+  START_SET("the superlayer bounds origin does not move a child")
+    CALayer *parent = layerWithBounds(CGRectMake(10, 20, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                     CGPointMake(100, 50));
+
+    [parent addSublayer: child];
+
+    PASS(pointIs([child convertPoint: CGPointMake(0, 0) toLayer: parent],
+                 75, 25),
+      "a bounds origin on the parent leaves the conversion alone");
+  END_SET("the superlayer bounds origin does not move a child")
+
+  START_SET("the layer's own transform applies")
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                     CGPointMake(100, 50));
+
+    [child setTransform: CATransform3DMakeScale(2, 2, 1)];
+    [parent addSublayer: child];
+
+    PASS(pointIs([child convertPoint: CGPointMake(0, 0) toLayer: parent],
+                 50, 0),
+      "a scaled child spreads its origin away from the anchor point");
+    PASS(pointIs([child convertPoint: CGPointMake(50, 50) toLayer: parent],
+                 150, 100),
+      "and its far corner the other way");
+    PASS(rectIs([child convertRect: CGRectMake(0, 0, 10, 20) toLayer: parent],
+                50, 0, 20, 40),
+      "a rectangle is scaled as well as moved");
+  END_SET("the layer's own transform applies")
+
+  START_SET("the superlayer's sublayer transform applies")
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                     CGPointMake(100, 50));
+
+    [parent setSublayerTransform: CATransform3DMakeTranslation(10, 20, 0)];
+    [parent addSublayer: child];
+
+    PASS(pointIs([child convertPoint: CGPointMake(0, 0) toLayer: parent],
+                 85, 45),
+      "the sublayer transform of the parent moves the child");
+  END_SET("the superlayer's sublayer transform applies")
+
+  START_SET("a sublayer transform and a child transform together")
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                     CGPointMake(100, 50));
+
+    [parent setSublayerTransform: CATransform3DMakeScale(2, 2, 1)];
+    [child setTransform: CATransform3DMakeTranslation(5, 6, 0)];
+    [parent addSublayer: child];
+
+    /* The sublayer transform applies about the parent's anchor point, so the
+       child is thrown well outside the parent's bounds. */
+    PASS(pointIs([child convertPoint: CGPointMake(0, 0) toLayer: parent],
+                 60, -38),
+      "both transforms apply, the parent's about its anchor point");
+  END_SET("a sublayer transform and a child transform together")
+
+  START_SET("a rotated child converts a rectangle to its bounding box")
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *child = layerWithBounds(CGRectMake(0, 0, 100, 100),
+                                     CGPointMake(100, 100));
+
+    [child setTransform: CATransform3DMakeRotation(M_PI / 4, 0, 0, 1)];
+    [parent addSublayer: child];
+
+    PASS(rectIs([child convertRect: CGRectMake(0, 0, 100, 100) toLayer: parent],
+                100 - 50 * M_SQRT2, 100 - 50 * M_SQRT2,
+                100 * M_SQRT2, 100 * M_SQRT2),
+      "the rectangle of a rotated layer is the box its corners span");
+    PASS(pointIs([child convertPoint: CGPointMake(50, 50) toLayer: parent],
+                 100, 100),
+      "the centre of a rotated layer stays where it is");
+  END_SET("a rotated child converts a rectangle to its bounding box")
+
+  START_SET("conversions across the tree")
+    CALayer *g0 = layerWithBounds(CGRectMake(0, 0, 400, 400),
+                                  CGPointMake(200, 200));
+    CALayer *g1 = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                  CGPointMake(100, 100));
+    CALayer *g2 = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                  CGPointMake(25, 25));
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *s1 = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                  CGPointMake(25, 25));
+    CALayer *s2 = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                  CGPointMake(125, 25));
+
+    [g0 addSublayer: g1];
+    [g1 addSublayer: g2];
+    [parent addSublayer: s1];
+    [parent addSublayer: s2];
+
+    PASS(pointIs([g2 convertPoint: CGPointMake(0, 0) toLayer: g0], 0, 0),
+      "a grandchild converts through both of its parents");
+    PASS(pointIs([g0 convertPoint: CGPointMake(0, 0) toLayer: g2], 0, 0),
+      "and back down again");
+    PASS(pointIs([s1 convertPoint: CGPointMake(0, 0) toLayer: s2], -100, 0),
+      "one sibling converts into the other");
+  END_SET("conversions across the tree")
+
+  START_SET("layers that share no tree")
+    CALayer *u1 = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                  CGPointMake(25, 25));
+    CALayer *u2 = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                  CGPointMake(500, 500));
+    CALayer *parent = layerWithBounds(CGRectMake(0, 0, 200, 200),
+                                      CGPointMake(100, 100));
+    CALayer *d = layerWithBounds(CGRectMake(0, 0, 50, 50),
+                                 CGPointMake(100, 50));
+
+    PASS(pointIs([u1 convertPoint: CGPointMake(0, 0) toLayer: u2], -475, -475),
+      "two layers in different trees convert through the root of each");
+
+    [parent addSublayer: d];
+    PASS(pointIs([d convertPoint: CGPointMake(0, 0) toLayer: parent], 75, 25),
+      "an attached layer converts through its parent");
+    [d removeFromSuperlayer];
+    PASS(pointIs([d convertPoint: CGPointMake(0, 0) toLayer: parent], 75, 25),
+      "a detached layer converts as if it were a root of its own");
+  END_SET("layers that share no tree")
+
+  START_SET("the affine part of the transform")
+    CALayer *l = [CALayer layer];
+    CATransform3D perspective = CATransform3DIdentity;
+
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 0, 0),
+      "a new layer reports the identity");
+
+    [l setTransform: CATransform3DMakeScale(2, 3, 1)];
+    PASS(affineIs([l affineTransform], 2, 0, 0, 3, 0, 0),
+      "a two-dimensional scale is reported as itself");
+
+    [l setTransform: CATransform3DMakeTranslation(3, 4, 0)];
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 3, 4),
+      "a two-dimensional translation is reported as itself");
+
+    [l setTransform: CATransform3DMakeRotation(M_PI / 4, 0, 0, 1)];
+    PASS(affineIs([l affineTransform], M_SQRT1_2, M_SQRT1_2,
+                  -M_SQRT1_2, M_SQRT1_2, 0, 0),
+      "a rotation about z is reported as itself");
+
+    /* A transform that is not affine has no affine equivalent, and the
+       identity is reported rather than the elements in those places. */
+    [l setTransform: CATransform3DMakeScale(2, 3, 4)];
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 0, 0),
+      "a scale in z reports the identity");
+
+    [l setTransform: CATransform3DMakeRotation(M_PI / 2, 1, 0, 0)];
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 0, 0),
+      "a rotation about x reports the identity");
+
+    [l setTransform: CATransform3DMakeTranslation(0, 0, 5)];
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 0, 0),
+      "a translation in z reports the identity");
+
+    perspective.m34 = -1.0 / 500;
+    [l setTransform: perspective];
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 0, 0),
+      "a perspective transform reports the identity");
+  END_SET("the affine part of the transform")
+
+  START_SET("setting the affine transform")
+    CALayer *l = [CALayer layer];
+    CATransform3D t;
+
+    [l setAffineTransform: CGAffineTransformMake(2, 3, 4, 5, 6, 7)];
+    PASS(affineIs([l affineTransform], 2, 3, 4, 5, 6, 7),
+      "the affine transform reads back what was set");
+
+    t = [l transform];
+    PASS(t.m11 == 2 && t.m12 == 3 && t.m21 == 4 && t.m22 == 5
+      && t.m41 == 6 && t.m42 == 7 && t.m33 == 1 && t.m44 == 1,
+      "it is held in the six places of the layer transform");
+
+    /* Setting it replaces the transform rather than concatenating with it. */
+    [l setTransform: CATransform3DMakeScale(9, 9, 9)];
+    [l setAffineTransform: CGAffineTransformMakeTranslation(1, 2)];
+    PASS(affineIs([l affineTransform], 1, 0, 0, 1, 1, 2),
+      "setting it replaces the transform that was there");
+    t = [l transform];
+    PASS(t.m33 == 1, "the z scale of the replaced transform is gone");
+  END_SET("setting the affine transform")
+
+  DESTROY(arp);
+  return 0;
+}

--- a/Tests/quartzcore/CATransform3DAffine/affine.m
+++ b/Tests/quartzcore/CATransform3DAffine/affine.m
@@ -1,0 +1,64 @@
+/* The CATransform3D <-> CGAffineTransform bridge: making a transform from an
+   affine transform, testing whether a transform is affine, and getting the
+   affine transform back.  Expected values checked against Apple QuartzCore. */
+#include "Testing.h"
+
+#include <QuartzCore/CATransform3D.h>
+#include <math.h>
+
+static BOOL eq(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+  if (d < 0) d = -d;
+  return d < 1e-4;
+}
+
+int main(void)
+{
+  START_SET("CATransform3D affine bridge")
+
+  /* Make a 3D transform from a 2D affine transform. */
+  CGAffineTransform a = CGAffineTransformMake(2, 3, 4, 5, 6, 7);
+  CATransform3D m = CATransform3DMakeAffineTransform(a);
+  PASS(eq(m.m11, 2) && eq(m.m12, 3) && eq(m.m21, 4) && eq(m.m22, 5)
+       && eq(m.m41, 6) && eq(m.m42, 7),
+       "MakeAffineTransform places the affine components");
+  PASS(eq(m.m13, 0) && eq(m.m14, 0) && eq(m.m23, 0) && eq(m.m24, 0)
+       && eq(m.m31, 0) && eq(m.m32, 0) && eq(m.m34, 0) && eq(m.m43, 0)
+       && eq(m.m33, 1) && eq(m.m44, 1),
+       "MakeAffineTransform leaves the rest as the identity");
+
+  /* IsAffine. */
+  PASS(CATransform3DIsAffine(CATransform3DIdentity),
+       "the identity is affine");
+  PASS(CATransform3DIsAffine(m),
+       "a transform built from an affine transform is affine");
+  PASS(CATransform3DIsAffine(CATransform3DMakeRotation(1, 0, 0, 1)),
+       "a rotation about z is affine");
+  PASS(!CATransform3DIsAffine(CATransform3DMakeRotation(1, 1, 0, 0)),
+       "a rotation about x is not affine");
+  PASS(!CATransform3DIsAffine(CATransform3DMakeScale(1, 1, 2)),
+       "a z scale is not affine");
+  PASS(!CATransform3DIsAffine(CATransform3DMakeTranslation(0, 0, 5)),
+       "a z translation is not affine");
+  CATransform3D pers = CATransform3DIdentity;
+  pers.m34 = -1.0/500;
+  PASS(!CATransform3DIsAffine(pers), "a perspective transform is not affine");
+
+  /* GetAffineTransform. */
+  CGAffineTransform back = CATransform3DGetAffineTransform(m);
+  PASS(eq(back.a, 2) && eq(back.b, 3) && eq(back.c, 4) && eq(back.d, 5)
+       && eq(back.tx, 6) && eq(back.ty, 7),
+       "GetAffineTransform returns the affine components");
+
+  /* Round-trip. */
+  CGAffineTransform rt = CATransform3DGetAffineTransform(
+    CATransform3DMakeAffineTransform(a));
+  PASS(eq(rt.a, a.a) && eq(rt.b, a.b) && eq(rt.c, a.c) && eq(rt.d, a.d)
+       && eq(rt.tx, a.tx) && eq(rt.ty, a.ty),
+       "an affine transform round-trips through a 3D transform");
+
+  END_SET("CATransform3D affine bridge")
+
+  return 0;
+}


### PR DESCRIPTION
CALayer.h declares -affineTransform, -setAffineTransform: and the four point and rectangle conversion methods, none of which are implemented. The four conversions are in a disabled block at the foot of CALayer.m; the other two are absent. A layer does not respond to any of the six.

A point moves between a layer and its superlayer in one step: relative to the bounds origin and the anchor point, through the layer's transform, offset by the position, and then, where the superlayer has a sublayer transform, through that about the superlayer's anchor point. A conversion between two layers walks the first up to its root and the second down from its root, so layers in different trees convert through their respective roots. A rectangle converts as the bounding box of its four converted corners, since a rotation does not map a rectangle to a rectangle. -affineTransform returns the identity when the transform is not affine, rather than the six elements in those positions, and -setAffineTransform: replaces the transform rather than concatenating.

Follows #16, which adds the affine bridge the last two use.

Tests/quartzcore/CALayer/conversion.m covers this in 35 assertions. Before the change 30 fail and the last set does not finish; after it all 35 pass and the suite is 73 passed with no failures.
