### PR TITLE
Fix: give a transaction the values Apple gives it

### DIFF
--- a/Headers/QuartzCore/CATransaction.h
+++ b/Headers/QuartzCore/CATransaction.h
@@ -31,13 +31,6 @@
 
 @interface CATransaction : NSObject
 {
-  /* The three below are no longer read.  A transaction keeps its values in
-     _values so that it can also carry keys it does not define itself; they
-     stay declared to leave the layout of the class unchanged. */
-  CFTimeInterval _animationDuration;
-  CAMediaTimingFunction *_animationTimingFunction;
-  BOOL _disableActions;
-
   NSMutableArray *_actions;
   BOOL _implicit;
   NSMutableDictionary *_values;

--- a/Headers/QuartzCore/CATransaction.h
+++ b/Headers/QuartzCore/CATransaction.h
@@ -31,12 +31,16 @@
 
 @interface CATransaction : NSObject
 {
+  /* The three below are no longer read.  A transaction keeps its values in
+     _values so that it can also carry keys it does not define itself; they
+     stay declared to leave the layout of the class unchanged. */
   CFTimeInterval _animationDuration;
   CAMediaTimingFunction *_animationTimingFunction;
   BOOL _disableActions;
 
   NSMutableArray *_actions;
   BOOL _implicit;
+  NSMutableDictionary *_values;
 }
 
 + (void) begin;

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -41,6 +41,12 @@ static NSMutableArray *transactionStack = nil;
 
 - (void) commit;
 
+/* The three keys a transaction defines itself, as typed accessors over
+   -values.  Any other key a caller sets is carried in -values alone. */
+@property (assign) CFTimeInterval animationDuration;
+@property (retain) CAMediaTimingFunction *animationTimingFunction;
+@property (assign) BOOL disableActions;
+
 @property (retain) NSMutableDictionary *values;
 @property (retain) NSMutableArray *actions;
 @property (assign, getter=isImplicit) BOOL implicit;
@@ -104,31 +110,61 @@ static NSMutableArray *transactionStack = nil;
 
 + (CFTimeInterval) animationDuration
 {
-  return [[self valueForKey: kCATransactionAnimationDuration] doubleValue];
+  return [[self topTransaction] animationDuration];
 }
 
 + (void) setAnimationDuration: (CFTimeInterval)animationDuration
+{
+  [[self topTransaction] setAnimationDuration: animationDuration];
+}
+
++ (CAMediaTimingFunction *) animationTimingFunction
+{
+  return [[self topTransaction] animationTimingFunction];
+}
+
++ (void) setAnimationTimingFunction: (CAMediaTimingFunction *)function
+{
+  [[self topTransaction] setAnimationTimingFunction: function];
+}
+
++ (BOOL) disableActions
+{
+  return [[self topTransaction] disableActions];
+}
+
++ (void) setDisableActions: (BOOL)disableActions
+{
+  [[self topTransaction] setDisableActions: disableActions];
+}
+
+- (CFTimeInterval) animationDuration
+{
+  return [[self valueForKey: kCATransactionAnimationDuration] doubleValue];
+}
+
+- (void) setAnimationDuration: (CFTimeInterval)animationDuration
 {
   [self setValue: [NSNumber numberWithDouble: animationDuration]
           forKey: kCATransactionAnimationDuration];
 }
 
-+ (CAMediaTimingFunction *) animationTimingFunction
+- (CAMediaTimingFunction *) animationTimingFunction
 {
   return [self valueForKey: kCATransactionAnimationTimingFunction];
 }
 
-+ (void) setAnimationTimingFunction: (CAMediaTimingFunction *)function
+- (void) setAnimationTimingFunction: (CAMediaTimingFunction *)function
 {
   [self setValue: function forKey: kCATransactionAnimationTimingFunction];
 }
 
-+ (BOOL) disableActions
+- (BOOL) disableActions
 {
   return [[self valueForKey: kCATransactionDisableActions] boolValue];
 }
 
-+ (void) setDisableActions: (BOOL)disableActions
+- (void) setDisableActions: (BOOL)disableActions
 {
   [self setValue: [NSNumber numberWithBool: disableActions]
           forKey: kCATransactionDisableActions];

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -41,28 +41,37 @@ static NSMutableArray *transactionStack = nil;
 
 - (void) commit;
 
-@property (assign) CFTimeInterval animationDuration;
-@property (retain) CAMediaTimingFunction *animationTimingFunction;
-@property (assign) BOOL disableActions;
+@property (retain) NSMutableDictionary *values;
 @property (retain) NSMutableArray *actions;
 @property (assign, getter=isImplicit) BOOL implicit;
 @end
 
 @implementation CATransaction
-@synthesize animationDuration=_animationDuration;
-@synthesize animationTimingFunction=_animationTimingFunction;
-@synthesize disableActions=_disableActions;
+@synthesize values=_values;
 @synthesize actions=_actions;
 @synthesize implicit=_implicit;
 
 + (void) begin
 {
+  CATransaction *enclosingTransaction;
+  CATransaction *newTransaction;
+
   if (!transactionStack)
     {
       transactionStack = [NSMutableArray new];
     }
 
-  CATransaction *newTransaction = [CATransaction new];
+  /* A transaction starts out with the values of the one it is nested in;
+     changing them affects only the new transaction. */
+  enclosingTransaction = [transactionStack lastObject];
+  newTransaction = [CATransaction new];
+  if (enclosingTransaction)
+    {
+      [[newTransaction values] removeAllObjects];
+      [[newTransaction values] addEntriesFromDictionary:
+        [enclosingTransaction values]];
+    }
+
   [transactionStack addObject: newTransaction];
   [newTransaction release];
 }
@@ -95,32 +104,34 @@ static NSMutableArray *transactionStack = nil;
 
 + (CFTimeInterval) animationDuration
 {
-  return [[self topTransaction] animationDuration];
+  return [[self valueForKey: kCATransactionAnimationDuration] doubleValue];
 }
 
 + (void) setAnimationDuration: (CFTimeInterval)animationDuration
 {
-  [[self topTransaction] setAnimationDuration: animationDuration];
+  [self setValue: [NSNumber numberWithDouble: animationDuration]
+          forKey: kCATransactionAnimationDuration];
 }
 
 + (CAMediaTimingFunction *) animationTimingFunction
 {
-  return [[self topTransaction] animationTimingFunction];
+  return [self valueForKey: kCATransactionAnimationTimingFunction];
 }
 
 + (void) setAnimationTimingFunction: (CAMediaTimingFunction *)function
 {
-  [[self topTransaction] setAnimationTimingFunction: function];
+  [self setValue: function forKey: kCATransactionAnimationTimingFunction];
 }
 
 + (BOOL) disableActions
 {
-    return [[self topTransaction] disableActions];
+  return [[self valueForKey: kCATransactionDisableActions] boolValue];
 }
 
 + (void) setDisableActions: (BOOL)disableActions
 {
-    [[self topTransaction] setDisableActions: disableActions];
+  [self setValue: [NSNumber numberWithBool: disableActions]
+          forKey: kCATransactionDisableActions];
 }
 
 + (id) valueForKey: (NSString *)key
@@ -155,19 +166,43 @@ static NSMutableArray *transactionStack = nil;
     return nil;
 
   _actions = [[NSMutableArray alloc] init];
-  _animationDuration = 0.25;
-  _animationTimingFunction = [[CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionDefault] retain];
-  _disableActions = NO;
+
+  /* The values an outermost transaction starts with.  There is no timing
+     function until one is set. */
+  _values = [[NSMutableDictionary alloc] init];
+  [_values setObject: [NSNumber numberWithDouble: 0.25]
+              forKey: kCATransactionAnimationDuration];
+  [_values setObject: [NSNumber numberWithBool: NO]
+              forKey: kCATransactionDisableActions];
 
   return self;
 }
 
 - (void) dealloc
 {
-  [_animationTimingFunction release];
+  [_values release];
   [_actions release];
 
   [super dealloc];
+}
+
+/* A transaction holds whatever keys are set on it, and reading one that was
+   never set answers nil rather than raising. */
+- (id) valueForKey: (NSString *)key
+{
+  return [_values objectForKey: key];
+}
+
+- (void) setValue: (id)value forKey: (NSString *)key
+{
+  if (value == nil)
+    {
+      [_values removeObjectForKey: key];
+    }
+  else
+    {
+      [_values setObject: value forKey: key];
+    }
 }
 
 - (void) commit
@@ -195,7 +230,7 @@ static NSMutableArray *transactionStack = nil;
       if ([action isKindOfClass: [CAAnimation class]])
         {
           CAAnimation * animation = (id)action;
-          if(![animation timingFunction])
+          if(![animation timingFunction] && [CATransaction animationTimingFunction])
             [animation setTimingFunction: [CATransaction animationTimingFunction]];
         }
 


### PR DESCRIPTION
The values a transaction carries differ from Apple's in three ways. A transaction starts with the default ease curve as its timing function, where Apple has none until one is set. A nested transaction starts from the defaults rather than from the values of the enclosing transaction. And valueForKey: and setValue:forKey: fall through to NSObject, so any key the class does not declare raises, where Apple returns nil for a key that was never set and stores any pair it is given.

A transaction now keeps its values in a dictionary, which +begin seeds from the enclosing transaction, and valueForKey:/setValue:forKey: read and write that dictionary. The typed accessors use the same keys, so both routes to a value stay in step.

The three value ivars remain declared so the class layout does not change, and -commit no longer passes an animation a nil timing function.

From Tests/quartzcore:

    gnustep-tests CATransaction
