### PR TITLE
tests: add tests for the Core Animation string constants

### DIFF
--- a/Tests/quartzcore/constants/TestInfo
+++ b/Tests/quartzcore/constants/TestInfo
@@ -1,0 +1,3 @@
+# The constants below are exported by Apple but not declared in its public
+# headers, so this file cannot be compiled against them.
+APPLE_SKIP_TESTS="private.m"

--- a/Tests/quartzcore/constants/constants.m
+++ b/Tests/quartzcore/constants/constants.m
@@ -1,0 +1,105 @@
+/* The value of each Core Animation string constant.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("Core Animation string constants")
+
+  testHopeful = YES;
+
+  PASS([kCAAnimationDiscrete isEqualToString: @"discrete"],
+       "kCAAnimationDiscrete is \"discrete\"");
+  PASS([kCAFillModeBackwards isEqualToString: @"backwards"],
+       "kCAFillModeBackwards is \"backwards\"");
+  PASS([kCAFillModeBoth isEqualToString: @"both"],
+       "kCAFillModeBoth is \"both\"");
+  PASS([kCAFillModeForwards isEqualToString: @"forwards"],
+       "kCAFillModeForwards is \"forwards\"");
+  PASS([kCAFillModeRemoved isEqualToString: @"removed"],
+       "kCAFillModeRemoved is \"removed\"");
+  PASS([kCAFillRuleEvenOdd isEqualToString: @"even-odd"],
+       "kCAFillRuleEvenOdd is \"even-odd\"");
+  PASS([kCAFillRuleNonZero isEqualToString: @"non-zero"],
+       "kCAFillRuleNonZero is \"non-zero\"");
+  PASS([kCAGravityBottom isEqualToString: @"bottom"],
+       "kCAGravityBottom is \"bottom\"");
+  PASS([kCAGravityBottomLeft isEqualToString: @"bottomLeft"],
+       "kCAGravityBottomLeft is \"bottomLeft\"");
+  PASS([kCAGravityBottomRight isEqualToString: @"bottomRight"],
+       "kCAGravityBottomRight is \"bottomRight\"");
+  PASS([kCAGravityCenter isEqualToString: @"center"],
+       "kCAGravityCenter is \"center\"");
+  PASS([kCAGravityLeft isEqualToString: @"left"],
+       "kCAGravityLeft is \"left\"");
+  PASS([kCAGravityResize isEqualToString: @"resize"],
+       "kCAGravityResize is \"resize\"");
+  PASS([kCAGravityResizeAspect isEqualToString: @"resizeAspect"],
+       "kCAGravityResizeAspect is \"resizeAspect\"");
+  PASS([kCAGravityResizeAspectFill isEqualToString: @"resizeAspectFill"],
+       "kCAGravityResizeAspectFill is \"resizeAspectFill\"");
+  PASS([kCAGravityRight isEqualToString: @"right"],
+       "kCAGravityRight is \"right\"");
+  PASS([kCAGravityTop isEqualToString: @"top"],
+       "kCAGravityTop is \"top\"");
+  PASS([kCAGravityTopLeft isEqualToString: @"topLeft"],
+       "kCAGravityTopLeft is \"topLeft\"");
+  PASS([kCAGravityTopRight isEqualToString: @"topRight"],
+       "kCAGravityTopRight is \"topRight\"");
+  PASS([kCALineCapButt isEqualToString: @"butt"],
+       "kCALineCapButt is \"butt\"");
+  PASS([kCALineCapRound isEqualToString: @"round"],
+       "kCALineCapRound is \"round\"");
+  PASS([kCALineCapSquare isEqualToString: @"square"],
+       "kCALineCapSquare is \"square\"");
+  PASS([kCALineJoinBevel isEqualToString: @"bevel"],
+       "kCALineJoinBevel is \"bevel\"");
+  PASS([kCALineJoinMiter isEqualToString: @"miter"],
+       "kCALineJoinMiter is \"miter\"");
+  PASS([kCALineJoinRound isEqualToString: @"round"],
+       "kCALineJoinRound is \"round\"");
+  PASS([kCAMediaTimingFunctionDefault isEqualToString: @"default"],
+       "kCAMediaTimingFunctionDefault is \"default\"");
+  PASS([kCAMediaTimingFunctionEaseIn isEqualToString: @"easeIn"],
+       "kCAMediaTimingFunctionEaseIn is \"easeIn\"");
+  PASS([kCAMediaTimingFunctionEaseInEaseOut isEqualToString: @"easeInEaseOut"],
+       "kCAMediaTimingFunctionEaseInEaseOut is \"easeInEaseOut\"");
+  PASS([kCAMediaTimingFunctionEaseOut isEqualToString: @"easeOut"],
+       "kCAMediaTimingFunctionEaseOut is \"easeOut\"");
+  PASS([kCAMediaTimingFunctionLinear isEqualToString: @"linear"],
+       "kCAMediaTimingFunctionLinear is \"linear\"");
+  PASS([kCAValueFunctionRotateX isEqualToString: @"rotateX"],
+       "kCAValueFunctionRotateX is \"rotateX\"");
+  PASS([kCAValueFunctionRotateY isEqualToString: @"rotateY"],
+       "kCAValueFunctionRotateY is \"rotateY\"");
+  PASS([kCAValueFunctionRotateZ isEqualToString: @"rotateZ"],
+       "kCAValueFunctionRotateZ is \"rotateZ\"");
+  PASS([kCAValueFunctionScale isEqualToString: @"scale"],
+       "kCAValueFunctionScale is \"scale\"");
+  PASS([kCAValueFunctionScaleX isEqualToString: @"scaleX"],
+       "kCAValueFunctionScaleX is \"scaleX\"");
+  PASS([kCAValueFunctionScaleY isEqualToString: @"scaleY"],
+       "kCAValueFunctionScaleY is \"scaleY\"");
+  PASS([kCAValueFunctionScaleZ isEqualToString: @"scaleZ"],
+       "kCAValueFunctionScaleZ is \"scaleZ\"");
+  PASS([kCAValueFunctionTranslate isEqualToString: @"translate"],
+       "kCAValueFunctionTranslate is \"translate\"");
+  PASS([kCAValueFunctionTranslateX isEqualToString: @"translateX"],
+       "kCAValueFunctionTranslateX is \"translateX\"");
+  PASS([kCAValueFunctionTranslateY isEqualToString: @"translateY"],
+       "kCAValueFunctionTranslateY is \"translateY\"");
+  PASS([kCAValueFunctionTranslateZ isEqualToString: @"translateZ"],
+       "kCAValueFunctionTranslateZ is \"translateZ\"");
+
+  testHopeful = NO;
+
+  END_SET("Core Animation string constants")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/constants/private.m
+++ b/Tests/quartzcore/constants/private.m
@@ -1,0 +1,102 @@
+/* The value of each string constant that Apple exports but does not declare
+   in its public headers, which is why this file is not compiled against them.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("string constants Apple does not publish")
+
+  testHopeful = YES;
+
+  PASS([kCAFillModeFrozen isEqualToString: @"frozen"],
+       "kCAFillModeFrozen is \"frozen\"");
+  PASS([kCAFilterClear isEqualToString: @"clear"],
+       "kCAFilterClear is \"clear\"");
+  PASS([kCAFilterColorBurnBlendMode isEqualToString: @"colorBurnBlendMode"],
+       "kCAFilterColorBurnBlendMode is \"colorBurnBlendMode\"");
+  PASS([kCAFilterColorDodgeBlendMode isEqualToString: @"colorDodgeBlendMode"],
+       "kCAFilterColorDodgeBlendMode is \"colorDodgeBlendMode\"");
+  PASS([kCAFilterColorHueRotate isEqualToString: @"colorHueRotate"],
+       "kCAFilterColorHueRotate is \"colorHueRotate\"");
+  PASS([kCAFilterColorInvert isEqualToString: @"colorInvert"],
+       "kCAFilterColorInvert is \"colorInvert\"");
+  PASS([kCAFilterColorMatrix isEqualToString: @"colorMatrix"],
+       "kCAFilterColorMatrix is \"colorMatrix\"");
+  PASS([kCAFilterColorMonochrome isEqualToString: @"colorMonochrome"],
+       "kCAFilterColorMonochrome is \"colorMonochrome\"");
+  PASS([kCAFilterColorSaturate isEqualToString: @"colorSaturate"],
+       "kCAFilterColorSaturate is \"colorSaturate\"");
+  PASS([kCAFilterCopy isEqualToString: @"copy"],
+       "kCAFilterCopy is \"copy\"");
+  PASS([kCAFilterDarkenBlendMode isEqualToString: @"darkenBlendMode"],
+       "kCAFilterDarkenBlendMode is \"darkenBlendMode\"");
+  PASS([kCAFilterDestAtop isEqualToString: @"destAtop"],
+       "kCAFilterDestAtop is \"destAtop\"");
+  PASS([kCAFilterDestIn isEqualToString: @"destIn"],
+       "kCAFilterDestIn is \"destIn\"");
+  PASS([kCAFilterDestOut isEqualToString: @"destOut"],
+       "kCAFilterDestOut is \"destOut\"");
+  PASS([kCAFilterDestOver isEqualToString: @"destOver"],
+       "kCAFilterDestOver is \"destOver\"");
+  PASS([kCAFilterDifferenceBlendMode isEqualToString: @"differenceBlendMode"],
+       "kCAFilterDifferenceBlendMode is \"differenceBlendMode\"");
+  PASS([kCAFilterExclusionBlendMode isEqualToString: @"exclusionBlendMode"],
+       "kCAFilterExclusionBlendMode is \"exclusionBlendMode\"");
+  PASS([kCAFilterGaussianBlur isEqualToString: @"gaussianBlur"],
+       "kCAFilterGaussianBlur is \"gaussianBlur\"");
+  PASS([kCAFilterHardLightBlendMode isEqualToString: @"hardLightBlendMode"],
+       "kCAFilterHardLightBlendMode is \"hardLightBlendMode\"");
+  PASS([kCAFilterLanczos isEqualToString: @"lanczos"],
+       "kCAFilterLanczos is \"lanczos\"");
+  PASS([kCAFilterLightenBlendMode isEqualToString: @"lightenBlendMode"],
+       "kCAFilterLightenBlendMode is \"lightenBlendMode\"");
+  PASS([kCAFilterLinear isEqualToString: @"linear"],
+       "kCAFilterLinear is \"linear\"");
+  PASS([kCAFilterMultiply isEqualToString: @"multiply"],
+       "kCAFilterMultiply is \"multiply\"");
+  PASS([kCAFilterMultiplyBlendMode isEqualToString: @"multiplyBlendMode"],
+       "kCAFilterMultiplyBlendMode is \"multiplyBlendMode\"");
+  PASS([kCAFilterMultiplyColor isEqualToString: @"multiplyColor"],
+       "kCAFilterMultiplyColor is \"multiplyColor\"");
+  PASS([kCAFilterNearest isEqualToString: @"nearest"],
+       "kCAFilterNearest is \"nearest\"");
+  PASS([kCAFilterNormalBlendMode isEqualToString: @"normalBlendMode"],
+       "kCAFilterNormalBlendMode is \"normalBlendMode\"");
+  PASS([kCAFilterOverlayBlendMode isEqualToString: @"overlayBlendMode"],
+       "kCAFilterOverlayBlendMode is \"overlayBlendMode\"");
+  PASS([kCAFilterPageCurl isEqualToString: @"pageCurl"],
+       "kCAFilterPageCurl is \"pageCurl\"");
+  PASS([kCAFilterPlusD isEqualToString: @"plusD"],
+       "kCAFilterPlusD is \"plusD\"");
+  PASS([kCAFilterPlusL isEqualToString: @"plusL"],
+       "kCAFilterPlusL is \"plusL\"");
+  PASS([kCAFilterScreenBlendMode isEqualToString: @"screenBlendMode"],
+       "kCAFilterScreenBlendMode is \"screenBlendMode\"");
+  PASS([kCAFilterSoftLightBlendMode isEqualToString: @"softLightBlendMode"],
+       "kCAFilterSoftLightBlendMode is \"softLightBlendMode\"");
+  PASS([kCAFilterSourceAtop isEqualToString: @"sourceAtop"],
+       "kCAFilterSourceAtop is \"sourceAtop\"");
+  PASS([kCAFilterSourceIn isEqualToString: @"sourceIn"],
+       "kCAFilterSourceIn is \"sourceIn\"");
+  PASS([kCAFilterSourceOut isEqualToString: @"sourceOut"],
+       "kCAFilterSourceOut is \"sourceOut\"");
+  PASS([kCAFilterSourceOver isEqualToString: @"sourceOver"],
+       "kCAFilterSourceOver is \"sourceOver\"");
+  PASS([kCAFilterTrilinear isEqualToString: @"trilinear"],
+       "kCAFilterTrilinear is \"trilinear\"");
+  PASS([kCAFilterXor isEqualToString: @"xor"],
+       "kCAFilterXor is \"xor\"");
+
+  testHopeful = NO;
+
+  END_SET("string constants Apple does not publish")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Nothing pins the value of the Core Animation string constants, and each is defined as its own C name: kCALineJoinMiter is "kCALineJoinMiter" where Apple gives it "miter". These values are what a layer property is set to and compared against, and what is written into an archive, so code written against the documented strings does not work here.

This adds Tests/quartzcore/constants. constants.m covers the fill modes and fill rules, the line caps and joins, the gravities, the timing function names, the value function names and kCAAnimationDiscrete. private.m covers the filter names and kCAFillModeFrozen, which Apple exports without declaring, so it is named in APPLE_SKIP_TESTS. Expected values were read from Apple's QuartzCore on a macOS runner.

All 80 assertions are hopeful, since every constant differs. kCAFilterFog, kCAFilterLighting and kCAFilterMultiplyGradient have no Apple counterpart, so they are left untested. kCATransition and the five transition names beside it are declared but defined nowhere, so they cannot be referenced yet.

From Tests/quartzcore:

    gnustep-tests constants

80 dashed hopes and no failures.
