### PR TITLE
Fix: give the string constants the values Apple gives them

### DIFF
--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -36,7 +36,7 @@
 #import "CAMediaTimingFunction+FrameworkPrivate.h"
 #import "CALayer+FrameworkPrivate.h"
 
-NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
+NSString *const kCAAnimationDiscrete = @"discrete";
 
 @interface CAAnimation ()
 @property (retain) NSPointerArray *layers;

--- a/Source/CAFilter.m
+++ b/Source/CAFilter.m
@@ -27,49 +27,49 @@
 #import <Foundation/Foundation.h>
 #import "QuartzCore/CAFilter.h"
 
-NSString *const kCAFilterClear = @"kCAFilterClear";
-NSString *const kCAFilterCopy = @"kCAFilterCopy";
-NSString *const kCAFilterDestAtop = @"kCAFilterDestAtop";
-NSString *const kCAFilterDestIn = @"kCAFilterDestIn";
-NSString *const kCAFilterDestOut = @"kCAFilterDestOut";
-NSString *const kCAFilterDestOver = @"kCAFilterDestOver";
+NSString *const kCAFilterClear = @"clear";
+NSString *const kCAFilterCopy = @"copy";
+NSString *const kCAFilterDestAtop = @"destAtop";
+NSString *const kCAFilterDestIn = @"destIn";
+NSString *const kCAFilterDestOut = @"destOut";
+NSString *const kCAFilterDestOver = @"destOver";
 NSString *const kCAFilterFog = @"kCAFilterFog";
-NSString *const kCAFilterGaussianBlur = @"kCAFilterGaussianBlur";
-NSString *const kCAFilterLanczos = @"kCAFilterLanczos";
+NSString *const kCAFilterGaussianBlur = @"gaussianBlur";
+NSString *const kCAFilterLanczos = @"lanczos";
 NSString *const kCAFilterLighting = @"kCAFilterLighting";
-NSString *const kCAFilterLinear = @"kCAFilterLinear";
-NSString *const kCAFilterMultiply = @"kCAFilterMultiply";
-NSString *const kCAFilterMultiplyColor = @"kCAFilterMultiplyColor";
+NSString *const kCAFilterLinear = @"linear";
+NSString *const kCAFilterMultiply = @"multiply";
+NSString *const kCAFilterMultiplyColor = @"multiplyColor";
 NSString *const kCAFilterMultiplyGradient = @"kCAFilterMultiplyGradient";
-NSString *const kCAFilterNearest = @"kCAFilterNearest";
-NSString *const kCAFilterPageCurl = @"kCAFilterPageCurl";
-NSString *const kCAFilterPlusL = @"kCAFilterPlusL";
-NSString *const kCAFilterSourceAtop = @"kCAFilterSourceAtop";
-NSString *const kCAFilterSourceIn = @"kCAFilterSourceIn";
-NSString *const kCAFilterSourceOut = @"kCAFilterSourceOut";
-NSString *const kCAFilterSourceOver = @"kCAFilterSourceOver";
-NSString *const kCAFilterTrilinear = @"kCAFilterTrilinear";
-NSString *const kCAFilterXor = @"kCAFilterXor";
+NSString *const kCAFilterNearest = @"nearest";
+NSString *const kCAFilterPageCurl = @"pageCurl";
+NSString *const kCAFilterPlusL = @"plusL";
+NSString *const kCAFilterSourceAtop = @"sourceAtop";
+NSString *const kCAFilterSourceIn = @"sourceIn";
+NSString *const kCAFilterSourceOut = @"sourceOut";
+NSString *const kCAFilterSourceOver = @"sourceOver";
+NSString *const kCAFilterTrilinear = @"trilinear";
+NSString *const kCAFilterXor = @"xor";
 
-NSString *const kCAFilterColorInvert = @"kCAFilterColorInvert";
-NSString *const kCAFilterColorMatrix = @"kCAFilterColorMatrix";
-NSString *const kCAFilterColorMonochrome = @"kCAFilterColorMonochrome";
-NSString *const kCAFilterColorHueRotate = @"kCAFilterColorHueRotate";
-NSString *const kCAFilterColorSaturate = @"kCAFilterColorSaturate";
-NSString *const kCAFilterPlusD = @"kCAFilterPlusD";
+NSString *const kCAFilterColorInvert = @"colorInvert";
+NSString *const kCAFilterColorMatrix = @"colorMatrix";
+NSString *const kCAFilterColorMonochrome = @"colorMonochrome";
+NSString *const kCAFilterColorHueRotate = @"colorHueRotate";
+NSString *const kCAFilterColorSaturate = @"colorSaturate";
+NSString *const kCAFilterPlusD = @"plusD";
 
-NSString *const kCAFilterNormalBlendMode = @"kCAFilterNormalBlendMode";
-NSString *const kCAFilterMultiplyBlendMode = @"kCAFilterMultiplyBlendMode";
-NSString *const kCAFilterScreenBlendMode = @"kCAFilterScreenBlendMode";
-NSString *const kCAFilterOverlayBlendMode = @"kCAFilterOverlayBlendMode";
-NSString *const kCAFilterDarkenBlendMode = @"kCAFilterDarkenBlendMode";
-NSString *const kCAFilterLightenBlendMode = @"kCAFilterLightenBlendMode";
-NSString *const kCAFilterColorDodgeBlendMode = @"kCAFilterColorDodgeBlendMode";
-NSString *const kCAFilterColorBurnBlendMode = @"kCAFilterColorBurnBlendMode";
-NSString *const kCAFilterSoftLightBlendMode = @"kCAFilterSoftLightBlendMode";
-NSString *const kCAFilterHardLightBlendMode = @"kCAFilterHardLightBlendMode";
-NSString *const kCAFilterDifferenceBlendMode = @"kCAFilterDifferenceBlendMode";
-NSString *const kCAFilterExclusionBlendMode = @"kCAFilterExclusionBlendMode";
+NSString *const kCAFilterNormalBlendMode = @"normalBlendMode";
+NSString *const kCAFilterMultiplyBlendMode = @"multiplyBlendMode";
+NSString *const kCAFilterScreenBlendMode = @"screenBlendMode";
+NSString *const kCAFilterOverlayBlendMode = @"overlayBlendMode";
+NSString *const kCAFilterDarkenBlendMode = @"darkenBlendMode";
+NSString *const kCAFilterLightenBlendMode = @"lightenBlendMode";
+NSString *const kCAFilterColorDodgeBlendMode = @"colorDodgeBlendMode";
+NSString *const kCAFilterColorBurnBlendMode = @"colorBurnBlendMode";
+NSString *const kCAFilterSoftLightBlendMode = @"softLightBlendMode";
+NSString *const kCAFilterHardLightBlendMode = @"hardLightBlendMode";
+NSString *const kCAFilterDifferenceBlendMode = @"differenceBlendMode";
+NSString *const kCAFilterExclusionBlendMode = @"exclusionBlendMode";
 
 @implementation CAFilter
 @end

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -47,18 +47,18 @@
 
 static CFTimeInterval currentFrameBeginTime = 0;
 
-NSString *const kCAGravityResize = @"CAGravityResize";
-NSString *const kCAGravityResizeAspect = @"CAGravityResizeAspect";
-NSString *const kCAGravityResizeAspectFill = @"CAGravityResizeAspectFill";
-NSString *const kCAGravityCenter = @"CAGravityCenter";
-NSString *const kCAGravityTop = @"CAGravityTop";
-NSString *const kCAGravityBottom = @"CAGravityBottom";
-NSString *const kCAGravityLeft = @"CAGravityLeft";
-NSString *const kCAGravityRight = @"CAGravityRight";
-NSString *const kCAGravityTopLeft = @"CAGravityTopLeft";
-NSString *const kCAGravityTopRight = @"CAGravityTopRight";
-NSString *const kCAGravityBottomLeft = @"CAGravityBottomLeft";
-NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
+NSString *const kCAGravityResize = @"resize";
+NSString *const kCAGravityResizeAspect = @"resizeAspect";
+NSString *const kCAGravityResizeAspectFill = @"resizeAspectFill";
+NSString *const kCAGravityCenter = @"center";
+NSString *const kCAGravityTop = @"top";
+NSString *const kCAGravityBottom = @"bottom";
+NSString *const kCAGravityLeft = @"left";
+NSString *const kCAGravityRight = @"right";
+NSString *const kCAGravityTopLeft = @"topLeft";
+NSString *const kCAGravityTopRight = @"topRight";
+NSString *const kCAGravityBottomLeft = @"bottomLeft";
+NSString *const kCAGravityBottomRight = @"bottomRight";
 
 @interface CALayer()
 @property (nonatomic, assign) CALayer * superlayer;

--- a/Source/CAMediaTiming.m
+++ b/Source/CAMediaTiming.m
@@ -26,10 +26,10 @@
 
 #import "QuartzCore/CAMediaTiming.h"
 
-NSString *const kCAFillModeRemoved = @"kCAFillModeRemoved";
-NSString *const kCAFillModeForwards = @"kCAFillModeForwards";
-NSString *const kCAFillModeBackwards = @"kCAFillModeBackwards";
-NSString *const kCAFillModeBoth = @"kCAFillModeBoth";
-NSString *const kCAFillModeFrozen = @"kCAFillModeFrozen";
+NSString *const kCAFillModeRemoved = @"removed";
+NSString *const kCAFillModeForwards = @"forwards";
+NSString *const kCAFillModeBackwards = @"backwards";
+NSString *const kCAFillModeBoth = @"both";
+NSString *const kCAFillModeFrozen = @"frozen";
 
 /* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CAMediaTimingFunction.m
+++ b/Source/CAMediaTimingFunction.m
@@ -35,11 +35,11 @@
 #import "QuartzCore/CAMediaTimingFunction.h"
 #import "CAMediaTimingFunction+FrameworkPrivate.h"
 
-NSString *const kCAMediaTimingFunctionDefault = @"kCAMediaTimingFunctionDefault";
-NSString *const kCAMediaTimingFunctionEaseInEaseOut = @"kCAMediaTimingFunctionEaseInEaseOut";
-NSString *const kCAMediaTimingFunctionEaseIn = @"kCAMediaTimingFunctionEaseIn";
-NSString *const kCAMediaTimingFunctionEaseOut = @"kCAMediaTimingFunctionEaseOut";
-NSString *const kCAMediaTimingFunctionLinear = @"kCAMediaTimingFunctionLinear";
+NSString *const kCAMediaTimingFunctionDefault = @"default";
+NSString *const kCAMediaTimingFunctionEaseInEaseOut = @"easeInEaseOut";
+NSString *const kCAMediaTimingFunctionEaseIn = @"easeIn";
+NSString *const kCAMediaTimingFunctionEaseOut = @"easeOut";
+NSString *const kCAMediaTimingFunctionLinear = @"linear";
 
 
 // start and end point are implicitly (0.0, 0.0) and (1.0, 1.0)

--- a/Source/CAShapeLayer.m
+++ b/Source/CAShapeLayer.m
@@ -25,16 +25,16 @@
 
 #import "QuartzCore/CAShapeLayer.h"
 
-NSString *const kCAFillRuleNonZero = @"kCAFillRuleNonZero";
-NSString *const kCAFillRuleEvenOdd = @"kCAFillRuleEvenOdd";
+NSString *const kCAFillRuleNonZero = @"non-zero";
+NSString *const kCAFillRuleEvenOdd = @"even-odd";
                                     
-NSString *const kCALineJoinMiter = @"kCALineJoinMiter";
-NSString *const kCALineJoinRound = @"kCALineJoinRound";
-NSString *const kCALineJoinBevel = @"kCALineJoinBevel";
+NSString *const kCALineJoinMiter = @"miter";
+NSString *const kCALineJoinRound = @"round";
+NSString *const kCALineJoinBevel = @"bevel";
                                     
-NSString *const kCALineCapButt = @"kCALineCapButt";
-NSString *const kCALineCapRound = @"kCALineCapRound";
-NSString *const kCALineCapSquare = @"kCALineCapSquare";
+NSString *const kCALineCapButt = @"butt";
+NSString *const kCALineCapRound = @"round";
+NSString *const kCALineCapSquare = @"square";
 
 @implementation CAShapeLayer
 @synthesize path = _path;

--- a/Source/CAValueFunction.m
+++ b/Source/CAValueFunction.m
@@ -30,16 +30,16 @@
 
 @end
 
-NSString *const kCAValueFunctionRotateX = @"kCAValueFunctionRotateX";
-NSString *const kCAValueFunctionRotateY = @"kCAValueFunctionRotateY";
-NSString *const kCAValueFunctionRotateZ = @"kCAValueFunctionRotateZ";
+NSString *const kCAValueFunctionRotateX = @"rotateX";
+NSString *const kCAValueFunctionRotateY = @"rotateY";
+NSString *const kCAValueFunctionRotateZ = @"rotateZ";
                                             
-NSString *const kCAValueFunctionScale = @"kCAValueFunctionScale";
-NSString *const kCAValueFunctionScaleX = @"kCAValueFunctionScaleX";
-NSString *const kCAValueFunctionScaleY = @"kCAValueFunctionScaleY";
-NSString *const kCAValueFunctionScaleZ = @"kCAValueFunctionScaleZ";
+NSString *const kCAValueFunctionScale = @"scale";
+NSString *const kCAValueFunctionScaleX = @"scaleX";
+NSString *const kCAValueFunctionScaleY = @"scaleY";
+NSString *const kCAValueFunctionScaleZ = @"scaleZ";
                                             
-NSString *const kCAValueFunctionTranslate = @"kCAValueFunctionTranslate";
-NSString *const kCAValueFunctionTranslateX = @"kCAValueFunctionTranslateX";
-NSString *const kCAValueFunctionTranslateY = @"kCAValueFunctionTranslateY";
-NSString *const kCAValueFunctionTranslateZ = @"kCAValueFunctionTranslateZ";
+NSString *const kCAValueFunctionTranslate = @"translate";
+NSString *const kCAValueFunctionTranslateX = @"translateX";
+NSString *const kCAValueFunctionTranslateY = @"translateY";
+NSString *const kCAValueFunctionTranslateZ = @"translateZ";


### PR DESCRIPTION
Every Core Animation string constant is defined as its own C name rather than the string Apple gives it: kCALineJoinMiter is "kCALineJoinMiter" instead of "miter", kCAGravityCenter is "CAGravityCenter" instead of "center", kCAFillRuleNonZero is "kCAFillRuleNonZero" instead of "non-zero". These values are what a layer property is set to and compared against, and what a lookup by name matches on, so a name written against the documented values does not resolve: `[CAMediaTimingFunction functionWithName: @"linear"]` answers nil.

This gives all 80 of them Apple's value, across the filter names, the gravities, the fill modes and rules, the line caps and joins, the timing function names, the value function names and kCAAnimationDiscrete. No source in the tree compares any of them against a literal, so only the values change.

Two notes. Apple reuses a value between families, so kCALineCapRound and kCALineJoinRound are both "round"; they are in different namespaces there too. And kCAFilterFog, kCAFilterLighting and kCAFilterMultiplyGradient keep the values they had: Apple exports nothing for them to match, so the value cannot matter, and one that reads as the constant name is more use when debugging than an invented short name.

With the tests from #23 applied, from Tests/quartzcore:

    gnustep-tests constants

80 dashed hopes before this change and 80 passed after, taking the suite to 107 passed.
