### PR TITLE
Feature: add the missing Core Animation name constants

### DIFF
--- a/Headers/QuartzCore/AppleSupport.h
+++ b/Headers/QuartzCore/AppleSupport.h
@@ -60,9 +60,16 @@
 #define CAPropertyAnimation GSCAPropertyAnimation
 #define CABasicAnimation GSCABasicAnimation
 #define CAKeyframeAnimation GSCAKeyframeAnimation
+#define kCAAnimationLinear kGSCAAnimationLinear
 #define kCAAnimationDiscrete GSCAAnimationDiscrete
+#define kCAAnimationPaced kGSCAAnimationPaced
+#define kCAAnimationCubic kGSCAAnimationCubic
+#define kCAAnimationCubicPaced kGSCAAnimationCubicPaced
 #define CATransition GSCATransition
+#define kCATransitionFade kGSCATransitionFade
 #define kCATransitionMoveIn kGSCATransitionMoveIn
+#define kCATransitionPush kGSCATransitionPush
+#define kCATransitionReveal kGSCATransitionReveal
 #define kCATransitionFromTop kGSCATransitionFromTop
 #define kCATransitionFromBottom kGSCATransitionFromBottom
 #define kCATransitionFromLeft kGSCATransitionFromLeft
@@ -96,6 +103,8 @@
 #define kCAGravityTopRight kGSCAGravityTopRight
 #define kCAGravityBottomLeft kGSCAGravityBottomLeft
 #define kCAGravityBottomRight kGSCAGravityBottomRight
+#define kCAOnOrderIn kGSCAOnOrderIn
+#define kCAOnOrderOut kGSCAOnOrderOut
 #define kCATransition kGSCATransition
 
 #define CALayer GSCALayer

--- a/Headers/QuartzCore/AppleSupportRevert.h
+++ b/Headers/QuartzCore/AppleSupportRevert.h
@@ -37,9 +37,16 @@
 #undef CAPropertyAnimation
 #undef CABasicAnimation
 #undef CAKeyframeAnimation
+#undef kCAAnimationLinear
 #undef kCAAnimationDiscrete
+#undef kCAAnimationPaced
+#undef kCAAnimationCubic
+#undef kCAAnimationCubicPaced
 #undef CATransition
+#undef kCATransitionFade
 #undef kCATransitionMoveIn
+#undef kCATransitionPush
+#undef kCATransitionReveal
 #undef kCATransitionFromTop
 #undef kCATransitionFromBottom
 #undef kCATransitionFromLeft
@@ -73,6 +80,8 @@
 #undef kCAGravityTopRight
 #undef kCAGravityBottomLeft
 #undef kCAGravityBottomRight
+#undef kCAOnOrderIn
+#undef kCAOnOrderOut
 #undef kCATransition
 
 #undef CALayer

--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -126,7 +126,11 @@
 @end
 
 /* calculationMode constants */
+extern NSString *const kCAAnimationLinear;
 extern NSString *const kCAAnimationDiscrete;
+extern NSString *const kCAAnimationPaced;
+extern NSString *const kCAAnimationCubic;
+extern NSString *const kCAAnimationCubicPaced;
 
 /* *********************************** */
 
@@ -141,7 +145,10 @@ extern NSString *const kCAAnimationDiscrete;
 @end
 
 /* transition types */
+extern NSString *const kCATransitionFade;
 extern NSString *const kCATransitionMoveIn;
+extern NSString *const kCATransitionPush;
+extern NSString *const kCATransitionReveal;
 
 /* transition subtypes */
 extern NSString *const kCATransitionFromTop;

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -46,6 +46,10 @@ extern NSString *const kCAGravityTopLeft;
 extern NSString *const kCAGravityTopRight;
 extern NSString *const kCAGravityBottomLeft;
 extern NSString *const kCAGravityBottomRight;
+
+/* action keys */
+extern NSString *const kCAOnOrderIn;
+extern NSString *const kCAOnOrderOut;
 extern NSString *const kCATransition;
 
 @class CAAnimation;

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -36,9 +36,16 @@
 #import "CAMediaTimingFunction+FrameworkPrivate.h"
 #import "CALayer+FrameworkPrivate.h"
 
+NSString *const kCAAnimationLinear = @"linear";
 NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
+NSString *const kCAAnimationPaced = @"paced";
+NSString *const kCAAnimationCubic = @"cubic";
+NSString *const kCAAnimationCubicPaced = @"cubicPaced";
 
+NSString *const kCATransitionFade = @"fade";
 NSString *const kCATransitionMoveIn = @"moveIn";
+NSString *const kCATransitionPush = @"push";
+NSString *const kCATransitionReveal = @"reveal";
 NSString *const kCATransitionFromTop = @"fromTop";
 NSString *const kCATransitionFromBottom = @"fromBottom";
 NSString *const kCATransitionFromLeft = @"fromLeft";

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -60,6 +60,8 @@ NSString *const kCAGravityTopRight = @"CAGravityTopRight";
 NSString *const kCAGravityBottomLeft = @"CAGravityBottomLeft";
 NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 
+NSString *const kCAOnOrderIn = @"onOrderIn";
+NSString *const kCAOnOrderOut = @"onOrderOut";
 NSString *const kCATransition = @"transition";
 
 @interface CALayer()

--- a/Tests/quartzcore/constants/constants.m
+++ b/Tests/quartzcore/constants/constants.m
@@ -111,6 +111,25 @@ int main(void)
   PASS([kCATransitionFromRight isEqualToString: @"fromRight"],
        "kCATransitionFromRight is \"fromRight\"");
 
+  PASS([kCAAnimationLinear isEqualToString: @"linear"],
+       "kCAAnimationLinear is \"linear\"");
+  PASS([kCAAnimationPaced isEqualToString: @"paced"],
+       "kCAAnimationPaced is \"paced\"");
+  PASS([kCAAnimationCubic isEqualToString: @"cubic"],
+       "kCAAnimationCubic is \"cubic\"");
+  PASS([kCAAnimationCubicPaced isEqualToString: @"cubicPaced"],
+       "kCAAnimationCubicPaced is \"cubicPaced\"");
+  PASS([kCATransitionFade isEqualToString: @"fade"],
+       "kCATransitionFade is \"fade\"");
+  PASS([kCATransitionPush isEqualToString: @"push"],
+       "kCATransitionPush is \"push\"");
+  PASS([kCATransitionReveal isEqualToString: @"reveal"],
+       "kCATransitionReveal is \"reveal\"");
+  PASS([kCAOnOrderIn isEqualToString: @"onOrderIn"],
+       "kCAOnOrderIn is \"onOrderIn\"");
+  PASS([kCAOnOrderOut isEqualToString: @"onOrderOut"],
+       "kCAOnOrderOut is \"onOrderOut\"");
+
   END_SET("Core Animation string constants")
 
   [pool release];


### PR DESCRIPTION
Nine of the name constants Apple defines are absent from the headers here. kCAAnimationLinear, kCAAnimationPaced, kCAAnimationCubic and kCAAnimationCubicPaced belong with a keyframe animation's calculationMode, beside the kCAAnimationDiscrete already there. kCATransitionFade, kCATransitionPush and kCATransitionReveal are transition types, where only kCATransitionMoveIn was declared. kCAOnOrderIn and kCAOnOrderOut are the layer action keys that sit beside kCATransition. Code naming any of them does not compile.

This declares them where they belong in CAAnimation.h and CALayer.h, defines them in the matching sources, and adds them to the two headers that rename the symbols for building against Apple's framework. The values are the ones Apple gives, read from its QuartzCore on a macOS runner: "linear", "paced", "cubic", "cubicPaced", "fade", "push", "reveal", "onOrderIn" and "onOrderOut". Nine assertions cover them.

The branch carries #23 and #25, whose 80 hopeful assertions are waiting on #24.

From Tests/quartzcore:

    gnustep-tests constants

None of the nine can be named at all beforehand; afterwards the suite is 42 passed, with those 80 hopes still dashed.
