### PR TITLE
Fix: give a shape layer the values Apple gives it

### DIFF
--- a/Headers/QuartzCore/CAShapeLayer.h
+++ b/Headers/QuartzCore/CAShapeLayer.h
@@ -41,10 +41,10 @@
   NSArray *_lineDashPattern;
 }
 
-@property CGPathRef path;
-@property CGColorRef fillColor;
+@property (nonatomic, assign) CGPathRef path; /* retained by CG */
+@property (nonatomic, assign) CGColorRef fillColor; /* retained by CG */
 @property(copy) NSString *fillRule;
-@property CGColorRef strokeColor;
+@property (nonatomic, assign) CGColorRef strokeColor; /* retained by CG */
 @property CGFloat strokeStart;
 @property CGFloat strokeEnd;
 @property CGFloat lineWidth;

--- a/Source/CAShapeLayer.m
+++ b/Source/CAShapeLayer.m
@@ -49,4 +49,165 @@ NSString *const kCALineCapSquare = @"kCALineCapSquare";
 @synthesize lineJoin = _lineJoin;
 @synthesize lineDashPhase = _lineDashPhase;
 @synthesize lineDashPattern = _lineDashPattern;
+
+/* The three setters below notify by hand, as CALayer's colour setters do. */
++ (BOOL) automaticallyNotifiesObserversForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"path"]
+      || [key isEqualToString: @"fillColor"]
+      || [key isEqualToString: @"strokeColor"])
+    {
+      return NO;
+    }
+
+  return [super automaticallyNotifiesObserversForKey: key];
+}
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"fillColor"])
+    {
+      /* opaque black, as for the colours CALayer hands out */
+      return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
+    }
+  if ([key isEqualToString: @"fillRule"])
+    {
+      return kCAFillRuleNonZero;
+    }
+  if ([key isEqualToString: @"strokeEnd"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+  if ([key isEqualToString: @"lineWidth"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+  if ([key isEqualToString: @"miterLimit"])
+    {
+      return [NSNumber numberWithFloat: 10.0];
+    }
+  if ([key isEqualToString: @"lineCap"])
+    {
+      return kCALineCapButt;
+    }
+  if ([key isEqualToString: @"lineJoin"])
+    {
+      return kCALineJoinMiter;
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  if ((self = [super init]) != nil)
+    {
+      Class cls = [self class];
+
+      [self setFillColor: (CGColorRef)[cls defaultValueForKey: @"fillColor"]];
+      [self setFillRule: [cls defaultValueForKey: @"fillRule"]];
+      [self setStrokeEnd:
+        [[cls defaultValueForKey: @"strokeEnd"] floatValue]];
+      [self setLineWidth:
+        [[cls defaultValueForKey: @"lineWidth"] floatValue]];
+      [self setMiterLimit:
+        [[cls defaultValueForKey: @"miterLimit"] floatValue]];
+      [self setLineCap: [cls defaultValueForKey: @"lineCap"]];
+      [self setLineJoin: [cls defaultValueForKey: @"lineJoin"]];
+    }
+  return self;
+}
+
+/* Core Graphics types are not KVC-compliant, so the three below are reached
+   by key the same way CALayer reaches its own colours. */
+- (id) valueForUndefinedKey: (NSString *)key
+{
+  if ([key isEqualToString: @"path"])
+    {
+      return (id)[self path];
+    }
+  if ([key isEqualToString: @"fillColor"])
+    {
+      return (id)[self fillColor];
+    }
+  if ([key isEqualToString: @"strokeColor"])
+    {
+      return (id)[self strokeColor];
+    }
+
+  return [super valueForUndefinedKey: key];
+}
+
+- (void) setValue: (id)value forUndefinedKey: (NSString *)key
+{
+  if ([key isEqualToString: @"path"])
+    {
+      [self setPath: (CGPathRef)value];
+      return;
+    }
+  if ([key isEqualToString: @"fillColor"])
+    {
+      [self setFillColor: (CGColorRef)value];
+      return;
+    }
+  if ([key isEqualToString: @"strokeColor"])
+    {
+      [self setStrokeColor: (CGColorRef)value];
+      return;
+    }
+
+  [super setValue: value forUndefinedKey: key];
+}
+
+- (void) dealloc
+{
+  CGPathRelease(_path);
+  CGColorRelease(_fillColor);
+  CGColorRelease(_strokeColor);
+  [_fillRule release];
+  [_lineCap release];
+  [_lineJoin release];
+  [_lineDashPattern release];
+
+  [super dealloc];
+}
+
+/* The two colours and the path are owned by the layer, as they are on
+   CALayer, so the caller may release its own reference. */
+- (void) setPath: (CGPathRef)path
+{
+  if (path == _path)
+    return;
+
+  [self willChangeValueForKey: @"path"];
+  CGPathRetain(path);
+  CGPathRelease(_path);
+  _path = path;
+  [self didChangeValueForKey: @"path"];
+}
+
+- (void) setFillColor: (CGColorRef)fillColor
+{
+  if (fillColor == _fillColor)
+    return;
+
+  [self willChangeValueForKey: @"fillColor"];
+  CGColorRetain(fillColor);
+  CGColorRelease(_fillColor);
+  _fillColor = fillColor;
+  [self didChangeValueForKey: @"fillColor"];
+}
+
+- (void) setStrokeColor: (CGColorRef)strokeColor
+{
+  if (strokeColor == _strokeColor)
+    return;
+
+  [self willChangeValueForKey: @"strokeColor"];
+  CGColorRetain(strokeColor);
+  CGColorRelease(_strokeColor);
+  _strokeColor = strokeColor;
+  [self didChangeValueForKey: @"strokeColor"];
+}
+
 @end


### PR DESCRIPTION
CAShapeLayer's implementation is a bare @synthesize block, so a new shape layer sets none of its defaults: a line width and miter limit of 0, an equal stroke start and end, and no fill colour, fill rule, line cap or line join. The class has no dealloc, so the copied strings, the dash pattern, the path and the colours are never released, and the path and colours are not retained when set, so releasing one after passing it to the layer leaves a dangling pointer.

This adds +defaultValueForKey: for the seven keys that have a default and applies them from -init, retains the path and the two colours in setters written the way CALayer writes its own, and releases them in a new dealloc. Those three properties are now declared nonatomic assign, as CALayer declares its colours.

Core Graphics types are not KVC-compliant, so the three also get the valueForUndefinedKey:/setValue:forUndefinedKey: pair CALayer already has for its own colours. Without it they cannot be reached by key, and -init cannot set them.

With the tests from #27 applied, from Tests/quartzcore:

    gnustep-tests CAShapeLayer

8 of those 25 assertions are dashed hopes before this change and none after, taking the suite from 44 to 52 passed.
