### PR TITLE
Fix: give the timing properties the values Apple gives them

### DIFF
--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -133,7 +133,12 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
     }
   if ([key isEqualToString:@"repeatCount"])
     {
-      return [NSNumber numberWithFloat: 1.0];
+      /* Zero means no repetition was asked for, not none at all. */
+      return [NSNumber numberWithFloat: 0.0];
+    }
+  if ([key isEqualToString:@"fillMode"])
+    {
+      return kCAFillModeRemoved;
     }
   return nil;
 }
@@ -152,7 +157,7 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
 
   static NSString * keys[] = {
     @"delegate", @"removedOnCompletion", @"timingFunction",
-    /*@"duration", */@"speed", @"autoreverses", @"repeatCount"};
+    /*@"duration", */@"speed", @"autoreverses", @"repeatCount", @"fillMode"};
     /* Duration intentionally skipped so it gets picked up from transaction */
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
@@ -177,7 +182,7 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
 
   static NSString * keys[] = {
     @"delegate", @"removedOnCompletion", @"timingFunction",
-    @"duration", @"speed", @"autoreverses", @"repeatCount"};
+    @"duration", @"speed", @"autoreverses", @"repeatCount", @"fillMode"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       if ([aDecoder containsValueForKey: keys[i]])
@@ -194,7 +199,7 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
 {
   static NSString * keys[] = {
     @"delegate", @"removedOnCompletion", @"timingFunction",
-    @"duration", @"speed", @"autoreverses", @"repeatCount"};
+    @"duration", @"speed", @"autoreverses", @"repeatCount", @"fillMode"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       if ([[self class] shouldArchiveValueForKey: keys[i]])
@@ -212,7 +217,7 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
 
   static NSString * keys[] = {
     @"delegate", @"removedOnCompletion", @"timingFunction",
-    @"duration", @"speed", @"autoreverses", @"repeatCount"};
+    @"duration", @"speed", @"autoreverses", @"repeatCount", @"fillMode"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       id value = [self valueForKey: keys[i]];

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -276,11 +276,16 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
     }
   if ([key isEqualToString:@"repeatCount"])
     {
-      return [NSNumber numberWithFloat: 1.0];
+      /* Zero means no repetition was asked for, not none at all. */
+      return [NSNumber numberWithFloat: 0.0];
     }
   if ([key isEqualToString: @"beginTime"])
     {
       return [NSNumber numberWithFloat: 0.0];
+    }
+  if ([key isEqualToString: @"fillMode"])
+    {
+      return kCAFillModeRemoved;
     }
 
   return nil;
@@ -303,7 +308,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
         @"backgroundColor", @"borderColor", @"contentsScale",
 
         @"beginTime", @"duration", @"speed", @"autoreverses",
-        @"repeatCount",
+        @"repeatCount", @"fillMode",
 
         @"shadowColor", @"shadowOffset", @"shadowOpacity",
         @"shadowPath", @"shadowRadius",
@@ -839,7 +844,12 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
         {
           CAPropertyAnimation * propertyAnimation = ((CAPropertyAnimation *)animation);
 
-          if ([propertyAnimation removedOnCompletion] && [propertyAnimation activeTimeWithTimeAuthorityLocalTime: [self localTime]] > [propertyAnimation duration] * [propertyAnimation repeatCount] * ([propertyAnimation autoreverses] ? 2 : 1))
+          /* A repeat count of zero asks for no repetition, so the animation
+             still runs through once. */
+          float repetitions = [propertyAnimation repeatCount] > 0
+            ? [propertyAnimation repeatCount] : 1;
+
+          if ([propertyAnimation removedOnCompletion] && [propertyAnimation activeTimeWithTimeAuthorityLocalTime: [self localTime]] > [propertyAnimation duration] * repetitions * ([propertyAnimation autoreverses] ? 2 : 1))
             {
               /* FIXME: doesn't take into account speed */
 
@@ -1028,7 +1038,20 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 - (CFTimeInterval) convertTime: (CFTimeInterval)theTime fromLayer: (CALayer *)layer
 {
   if (layer == nil)
-    return [self localTime];
+    {
+      /* theTime is in the "media time" timespace, so bring it down into
+         ours the same way -convertTime:toLayer: brings a media time into a
+         layer.  The time given is what is being converted; the current one
+         is not. */
+      CFTimeInterval oldFrameBeginTime = currentFrameBeginTime;
+      CFTimeInterval converted;
+
+      currentFrameBeginTime = theTime;
+      converted = [self activeTime];
+      currentFrameBeginTime = oldFrameBeginTime;
+
+      return converted;
+    }
 
   /* Just make use of convertTime:toLayer: instead of reimplementing */
   return [layer convertTime: theTime toLayer: self];


### PR DESCRIPTION
The CAMediaTiming properties differ from Apple's in three ways. A layer and an animation both start with a repeat count of 1 where Apple uses 0, which Apple documents as meaning the count is ignored. Neither starts with a fill mode, where Apple starts with kCAFillModeRemoved. And -convertTime:fromLayer: with a nil layer returns the layer's own current local time, discarding the time it was given.

This sets both defaults on CALayer and CAAnimation, and converts a time out of the media timespace when the layer is nil, which is what -convertTime:toLayer: already does in the other direction.

Because a repeat count of 0 now means what Apple means by it, the check that removes a finished animation counts one repetition rather than none when the count is 0. Without that an animation would be removed as soon as it started.

With the tests from #29 applied, from Tests/quartzcore:

    gnustep-tests CAMediaTiming

6 of those 34 assertions are dashed hopes before this change and none after, taking the suite from 55 to 61 passed.
