### PR TITLE
Fix: copy what an animation subclass holds, and start a spring properly

### DIFF
--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -374,7 +374,8 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
   if (!theCopy)
     return nil;
 
-  static NSString * keys[] = {@"additive", @"cumulative", @"valueFunction"};
+  static NSString * keys[] = {@"keyPath", @"additive", @"cumulative",
+    @"valueFunction"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       id value = [self valueForKey: keys[i]];
@@ -611,6 +612,26 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize fromValue=_fromValue;
 @synthesize byValue=_byValue;
 @synthesize toValue=_toValue;
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  static NSString * keys[] = {@"fromValue", @"byValue", @"toValue"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id value = [self valueForKey: keys[i]];
+      if (value)
+        {
+          [theCopy setValue: value
+                     forKey: keys[i]];
+        }
+    }
+
+  return theCopy;
+}
 
 - (void) dealloc
 {
@@ -1007,6 +1028,26 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
 
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  static NSString * keys[] = {@"calculationMode", @"values"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id value = [self valueForKey: keys[i]];
+      if (value)
+        {
+          [theCopy setValue: value
+                     forKey: keys[i]];
+        }
+    }
+
+  return theCopy;
+}
+
 @end
 
 @implementation CASpringAnimation
@@ -1015,6 +1056,70 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize damping = _damping;
 @synthesize initialVelocity = _initialVelocity;
 @synthesize settlingDuration = _settlingDuration;
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"mass"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+  if ([key isEqualToString: @"stiffness"])
+    {
+      return [NSNumber numberWithFloat: 100.0];
+    }
+  if ([key isEqualToString: @"damping"])
+    {
+      return [NSNumber numberWithFloat: 10.0];
+    }
+  if ([key isEqualToString: @"initialVelocity"])
+    {
+      return [NSNumber numberWithFloat: 0.0];
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  self = [super init];
+  if (!self)
+    return nil;
+
+  static NSString * keys[] = {@"mass", @"stiffness", @"damping",
+    @"initialVelocity"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id defaultValue = [[self class] defaultValueForKey: keys[i]];
+      if (defaultValue)
+        {
+          [self setValue: defaultValue
+                  forKey: keys[i]];
+        }
+    }
+
+  return self;
+}
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  static NSString * keys[] = {@"mass", @"stiffness", @"damping",
+    @"initialVelocity"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id value = [self valueForKey: keys[i]];
+      if (value)
+        {
+          [theCopy setValue: value
+                     forKey: keys[i]];
+        }
+    }
+
+  return theCopy;
+}
 @end
 
 @implementation CATransition


### PR DESCRIPTION
-copyWithZone: loses most of an animation's state. CAAnimation copies the properties it declares itself; CAPropertyAnimation copies its additive and cumulative flags and its value function but not its key path; and CABasicAnimation, CAKeyframeAnimation and CASpringAnimation do not implement it at all. A copy of a basic animation has no key path and no from, to or by value, while its duration and repeat count are copied. A spring animation also starts with a mass, stiffness and damping of 0 where Apple uses 1, 100 and 10.

This copies the key path with the rest of a property animation, adds -copyWithZone: to the three subclasses, and sets the spring defaults to Apple's values.

Two of the hopeful assertions in #31 stay dashed. A keyframe animation's calculation mode should start as linear, which needs the kCAAnimationLinear constant #26 adds. And a spring's settling duration stays 0: Apple computes 1.4727 for a default spring, and the formula behind that value is not documented.

With the tests from #31 applied, from Tests/quartzcore:

    gnustep-tests CAAnimation

7 of those 36 assertions are dashed hopes before this change and 2 after, taking the suite from 56 to 61 passed.
