### PR TITLE
Fix: archive an animation instead of recursing until the stack ends

### DIFF
--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -374,7 +374,8 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
   if (!theCopy)
     return nil;
 
-  static NSString * keys[] = {@"additive", @"cumulative", @"valueFunction"};
+  static NSString * keys[] = {@"keyPath", @"additive", @"cumulative",
+    @"valueFunction"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       id value = [self valueForKey: keys[i]];
@@ -611,6 +612,26 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize fromValue=_fromValue;
 @synthesize byValue=_byValue;
 @synthesize toValue=_toValue;
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  static NSString * keys[] = {@"fromValue", @"byValue", @"toValue"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id value = [self valueForKey: keys[i]];
+      if (value)
+        {
+          [theCopy setValue: value
+                     forKey: keys[i]];
+        }
+    }
+
+  return theCopy;
+}
 
 - (void) dealloc
 {
@@ -1007,6 +1028,26 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
 
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  static NSString * keys[] = {@"calculationMode", @"values"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id value = [self valueForKey: keys[i]];
+      if (value)
+        {
+          [theCopy setValue: value
+                     forKey: keys[i]];
+        }
+    }
+
+  return theCopy;
+}
+
 @end
 
 @implementation CASpringAnimation
@@ -1015,6 +1056,70 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize damping = _damping;
 @synthesize initialVelocity = _initialVelocity;
 @synthesize settlingDuration = _settlingDuration;
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"mass"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+  if ([key isEqualToString: @"stiffness"])
+    {
+      return [NSNumber numberWithFloat: 100.0];
+    }
+  if ([key isEqualToString: @"damping"])
+    {
+      return [NSNumber numberWithFloat: 10.0];
+    }
+  if ([key isEqualToString: @"initialVelocity"])
+    {
+      return [NSNumber numberWithFloat: 0.0];
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  self = [super init];
+  if (!self)
+    return nil;
+
+  static NSString * keys[] = {@"mass", @"stiffness", @"damping",
+    @"initialVelocity"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id defaultValue = [[self class] defaultValueForKey: keys[i]];
+      if (defaultValue)
+        {
+          [self setValue: defaultValue
+                  forKey: keys[i]];
+        }
+    }
+
+  return self;
+}
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  static NSString * keys[] = {@"mass", @"stiffness", @"damping",
+    @"initialVelocity"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      id value = [self valueForKey: keys[i]];
+      if (value)
+        {
+          [theCopy setValue: value
+                     forKey: keys[i]];
+        }
+    }
+
+  return theCopy;
+}
 @end
 
 @implementation CATransition

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -199,14 +199,17 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
     {
       if ([[self class] shouldArchiveValueForKey: keys[i]])
         {
-          [self encodeWithCoder: aCoder];
+          [aCoder encodeObject: [self valueForKey: keys[i]]
+                        forKey: keys[i]];
         }
     }
 }
 
 - (id) copyWithZone: (NSZone *)zone
 {
-  id theCopy = [[self class] allocWithZone: zone];
+  /* -init and not just +allocWithZone:, or the copy is left without the
+     things -init sets up for it. */
+  id theCopy = [[[self class] allocWithZone: zone] init];
   if (!theCopy)
     return nil;
 
@@ -339,11 +342,12 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
 
 - (id) initWithCoder:(NSCoder *)aDecoder
 {
-  self = [self init];
+  self = [super initWithCoder: aDecoder];
   if (!self)
     return nil;
 
-  static NSString * keys[] = {@"additive", @"cumulative", @"valueFunction"};
+  static NSString * keys[] = {@"keyPath", @"additive", @"cumulative",
+    @"valueFunction"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       if ([aDecoder containsValueForKey: keys[i]])
@@ -358,12 +362,16 @@ NSString *const kCAAnimationDiscrete = @"CAAnimationDiscrete";
 
 - (void) encodeWithCoder: (NSCoder *)aCoder
 {
-  static NSString * keys[] = {@"additive", @"cumulative", @"valueFunction"};
+  [super encodeWithCoder: aCoder];
+
+  static NSString * keys[] = {@"keyPath", @"additive", @"cumulative",
+    @"valueFunction"};
   for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
     {
       if ([[self class] shouldArchiveValueForKey: keys[i]])
         {
-          [self encodeWithCoder: aCoder];
+          [aCoder encodeObject: [self valueForKey: keys[i]]
+                        forKey: keys[i]];
         }
     }
 }
@@ -612,6 +620,40 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize fromValue=_fromValue;
 @synthesize byValue=_byValue;
 @synthesize toValue=_toValue;
+
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [super initWithCoder: aDecoder];
+  if (!self)
+    return nil;
+
+  static NSString * keys[] = {@"fromValue", @"byValue", @"toValue"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      if ([aDecoder containsValueForKey: keys[i]])
+        {
+          [self setValue: [aDecoder decodeObjectForKey: keys[i]]
+                  forKey: keys[i]];
+        }
+    }
+
+  return self;
+}
+
+- (void) encodeWithCoder: (NSCoder *)aCoder
+{
+  [super encodeWithCoder: aCoder];
+
+  static NSString * keys[] = {@"fromValue", @"byValue", @"toValue"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      if ([[self class] shouldArchiveValueForKey: keys[i]])
+        {
+          [aCoder encodeObject: [self valueForKey: keys[i]]
+                        forKey: keys[i]];
+        }
+    }
+}
 
 - (id) copyWithZone: (NSZone *)zone
 {
@@ -1028,6 +1070,40 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
 
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [super initWithCoder: aDecoder];
+  if (!self)
+    return nil;
+
+  static NSString * keys[] = {@"calculationMode", @"values"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      if ([aDecoder containsValueForKey: keys[i]])
+        {
+          [self setValue: [aDecoder decodeObjectForKey: keys[i]]
+                  forKey: keys[i]];
+        }
+    }
+
+  return self;
+}
+
+- (void) encodeWithCoder: (NSCoder *)aCoder
+{
+  [super encodeWithCoder: aCoder];
+
+  static NSString * keys[] = {@"calculationMode", @"values"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      if ([[self class] shouldArchiveValueForKey: keys[i]])
+        {
+          [aCoder encodeObject: [self valueForKey: keys[i]]
+                        forKey: keys[i]];
+        }
+    }
+}
+
 - (id) copyWithZone: (NSZone *)zone
 {
   id theCopy = [super copyWithZone: zone];
@@ -1098,6 +1174,42 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
     }
 
   return self;
+}
+
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [super initWithCoder: aDecoder];
+  if (!self)
+    return nil;
+
+  static NSString * keys[] = {@"mass", @"stiffness", @"damping",
+    @"initialVelocity"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      if ([aDecoder containsValueForKey: keys[i]])
+        {
+          [self setValue: [aDecoder decodeObjectForKey: keys[i]]
+                  forKey: keys[i]];
+        }
+    }
+
+  return self;
+}
+
+- (void) encodeWithCoder: (NSCoder *)aCoder
+{
+  [super encodeWithCoder: aCoder];
+
+  static NSString * keys[] = {@"mass", @"stiffness", @"damping",
+    @"initialVelocity"};
+  for (int i = 0; i < sizeof(keys)/sizeof(keys[0]); i++)
+    {
+      if ([[self class] shouldArchiveValueForKey: keys[i]])
+        {
+          [aCoder encodeObject: [self valueForKey: keys[i]]
+                        forKey: keys[i]];
+        }
+    }
 }
 
 - (id) copyWithZone: (NSZone *)zone

--- a/Tests/quartzcore/CAAnimation/TestInfo
+++ b/Tests/quartzcore/CAAnimation/TestInfo
@@ -1,0 +1,3 @@
+# The layer bookkeeping this checks is internal to this implementation,
+# and Apple does not raise where it does.
+APPLE_SKIP_TESTS="copyinit.m"

--- a/Tests/quartzcore/CAAnimation/animation.m
+++ b/Tests/quartzcore/CAAnimation/animation.m
@@ -1,0 +1,170 @@
+/* The values each animation class starts with, what its setters keep, and
+   copying one.  Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CAMediaTimingFunction.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values an animation starts with")
+
+  CAAnimation *a = [CAAnimation animation];
+
+  PASS(a != nil, "an animation can be created");
+  PASS([a delegate] == nil, "it starts with no delegate");
+  PASS([a timingFunction] == nil, "it starts with no timing function");
+  PASS([a removedOnCompletion] == YES,
+       "it is removed when it completes");
+
+  END_SET("the values an animation starts with")
+
+  START_SET("the values a property animation starts with")
+
+  CAPropertyAnimation *p = [CAPropertyAnimation animation];
+
+  PASS([p keyPath] == nil, "it starts with no key path");
+  PASS([p isAdditive] == NO, "it is not additive");
+  PASS([p isCumulative] == NO, "it is not cumulative");
+  PASS([p valueFunction] == nil, "it starts with no value function");
+
+  CAPropertyAnimation *k =
+    [CAPropertyAnimation animationWithKeyPath: @"opacity"];
+
+  PASS([[k keyPath] isEqualToString: @"opacity"],
+       "animationWithKeyPath: keeps the key path it is given");
+  PASS([k isKindOfClass: [CAPropertyAnimation class]],
+       "animationWithKeyPath: answers a property animation");
+
+  END_SET("the values a property animation starts with")
+
+  START_SET("the values a basic animation starts with")
+
+  CABasicAnimation *b = [CABasicAnimation animation];
+
+  PASS([b fromValue] == nil, "it starts with no from value");
+  PASS([b toValue] == nil, "it starts with no to value");
+  PASS([b byValue] == nil, "it starts with no by value");
+  PASS([b keyPath] == nil, "it starts with no key path");
+
+  END_SET("the values a basic animation starts with")
+
+  START_SET("the values a keyframe animation starts with")
+
+  CAKeyframeAnimation *k = [CAKeyframeAnimation animation];
+
+  PASS([k values] == nil, "it starts with no values");
+
+  /* Apple names this "linear"; the constant for it arrives with #26. */
+  testHopeful = YES;
+  PASS([[k calculationMode] isEqualToString: @"linear"],
+       "it starts calculating linearly");
+  testHopeful = NO;
+
+  END_SET("the values a keyframe animation starts with")
+
+  START_SET("the values a spring animation starts with")
+
+  CASpringAnimation *s = [CASpringAnimation animation];
+
+  testHopeful = YES;
+  PASS([s mass] == 1.0, "a spring starts with a mass of 1");
+  PASS([s stiffness] == 100.0, "a spring starts with a stiffness of 100");
+  PASS([s damping] == 10.0, "a spring starts with a damping of 10");
+  PASS([s settlingDuration] > 0.0,
+       "a spring works out how long it takes to settle");
+  testHopeful = NO;
+
+  PASS([s initialVelocity] == 0.0, "a spring starts at rest");
+
+  END_SET("the values a spring animation starts with")
+
+  START_SET("what an animation's setters keep")
+
+  CABasicAnimation *b = [CABasicAnimation animation];
+  CAMediaTimingFunction *fn =
+    [CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionEaseIn];
+
+  [b setKeyPath: @"position"];
+  PASS([[b keyPath] isEqualToString: @"position"],
+       "the key path reads back as it was set");
+
+  [b setToValue: [NSNumber numberWithInt: 7]];
+  PASS([[b toValue] intValue] == 7, "the to value reads back as it was set");
+
+  [b setFromValue: [NSNumber numberWithInt: 3]];
+  PASS([[b fromValue] intValue] == 3,
+       "the from value reads back as it was set");
+
+  [b setTimingFunction: fn];
+  PASS([b timingFunction] == fn,
+       "the timing function reads back as it was set");
+
+  [b setRemovedOnCompletion: NO];
+  PASS([b removedOnCompletion] == NO,
+       "removed on completion reads back as it was set");
+
+  [b setAdditive: YES];
+  PASS([b isAdditive] == YES, "additive reads back as it was set");
+
+  [b setCumulative: YES];
+  PASS([b isCumulative] == YES, "cumulative reads back as it was set");
+
+  END_SET("what an animation's setters keep")
+
+  /* -delegate is an atomic property getter, so it answers something
+     autoreleased and reading it moves the count.  The two counted
+     assertions below therefore never call it. */
+  START_SET("an animation owns its delegate")
+
+  NSObject *named = [[[NSObject alloc] init] autorelease];
+  CAAnimation *reader = [CAAnimation animation];
+
+  [reader setDelegate: named];
+  PASS([reader delegate] == named, "the delegate reads back as it was set");
+
+  NSObject *d = [[NSObject alloc] init];
+  CAAnimation *a = [CAAnimation animation];
+  NSUInteger before = [d retainCount];
+
+  [a setDelegate: d];
+  PASS([d retainCount] == before + 1,
+       "an animation retains its delegate, unlike most delegates");
+
+  [a setDelegate: nil];
+  PASS([d retainCount] == before, "and lets go of it when it is replaced");
+  [d release];
+
+  END_SET("an animation owns its delegate")
+
+  START_SET("copying an animation")
+
+  CABasicAnimation *b = [CABasicAnimation animation];
+
+  [b setKeyPath: @"position"];
+  [b setDuration: 3.0];
+  [b setToValue: [NSNumber numberWithInt: 7]];
+  [b setRepeatCount: 2.0];
+
+  CABasicAnimation *c = [b copy];
+
+  PASS(c != b, "a copy is a distinct object");
+  PASS([c duration] == 3.0, "a copy keeps the duration");
+  PASS([c repeatCount] == 2.0, "a copy keeps the repeat count");
+
+  /* The properties a subclass adds are copied too, not just the ones
+     CAAnimation itself declares. */
+  testHopeful = YES;
+  PASS([[c keyPath] isEqualToString: @"position"], "a copy keeps the key path");
+  PASS([[c toValue] intValue] == 7, "a copy keeps the to value");
+  testHopeful = NO;
+  [c release];
+
+  END_SET("copying an animation")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAAnimation/archiving.m
+++ b/Tests/quartzcore/CAAnimation/archiving.m
@@ -1,0 +1,59 @@
+/* Archiving an animation, and the layer bookkeeping a copy carries.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("archiving a basic animation")
+
+  CABasicAnimation *b = [CABasicAnimation animation];
+  NSData *d;
+  CABasicAnimation *r;
+
+  [b setKeyPath: @"position"];
+  [b setDuration: 3.0];
+  [b setRepeatCount: 2.0];
+  [b setToValue: [NSNumber numberWithInt: 7]];
+
+  d = [NSKeyedArchiver archivedDataWithRootObject: b];
+  PASS(d != nil && [d length] > 0, "an animation can be archived");
+
+  r = [NSKeyedUnarchiver unarchiveObjectWithData: d];
+  PASS([r isKindOfClass: [CABasicAnimation class]],
+       "what comes back is a basic animation");
+  PASS([[r keyPath] isEqualToString: @"position"],
+       "the key path survives being archived");
+  PASS([r duration] == 3.0, "the duration survives being archived");
+  PASS([r repeatCount] == 2.0, "the repeat count survives being archived");
+  PASS([[r toValue] intValue] == 7, "the to value survives being archived");
+
+  END_SET("archiving a basic animation")
+
+  START_SET("archiving a keyframe animation")
+
+  CAKeyframeAnimation *k = [CAKeyframeAnimation animation];
+  NSArray *values = [NSArray arrayWithObjects:
+    [NSNumber numberWithInt: 1], [NSNumber numberWithInt: 2], nil];
+  CAKeyframeAnimation *r;
+
+  [k setKeyPath: @"opacity"];
+  [k setValues: values];
+
+  r = [NSKeyedUnarchiver unarchiveObjectWithData:
+    [NSKeyedArchiver archivedDataWithRootObject: k]];
+
+  PASS([[r keyPath] isEqualToString: @"opacity"],
+       "a keyframe animation keeps its key path");
+  PASS([[r values] count] == 2, "a keyframe animation keeps its values");
+
+  END_SET("archiving a keyframe animation")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAAnimation/copyinit.m
+++ b/Tests/quartzcore/CAAnimation/copyinit.m
@@ -1,0 +1,44 @@
+/* A copied animation carries the same bookkeeping a fresh one does.
+
+   This checks an internal guarantee of this implementation rather than
+   anything Apple promises: adding one animation to the same layer twice
+   raises here, and a copy that was never initialised would not notice.
+   Apple does not raise, so this file is not run against it. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a copied animation keeps its own bookkeeping")
+
+  CABasicAnimation *b = [CABasicAnimation animation];
+  CABasicAnimation *c;
+  CALayer *l = [CALayer layer];
+  BOOL raised = NO;
+
+  [b setKeyPath: @"opacity"];
+  c = [b copy];
+
+  [l addAnimation: c forKey: @"first"];
+  @try
+    {
+      [l addAnimation: c forKey: @"second"];
+    }
+  @catch (NSException *e)
+    {
+      raised = YES;
+    }
+
+  PASS(raised, "a copy still notices being added to one layer twice");
+  [c release];
+
+  END_SET("a copied animation keeps its own bookkeeping")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Archiving an animation crashes. Inside its own key loop, -[CAAnimation encodeWithCoder:] calls [self encodeWithCoder: aCoder] instead of encoding the value, so it recurses until the stack is exhausted; CAPropertyAnimation does the same. A test that archives a basic animation exits with a segmentation fault.

Three further faults are in the same area. CAPropertyAnimation's -initWithCoder: calls [self init] rather than [super initWithCoder:], so nothing the superclass wrote is read back, and its key list omits the key path. CABasicAnimation, CAKeyframeAnimation and CASpringAnimation have no coder methods, so what they add is not archived. And -[CAAnimation copyWithZone:] allocates without sending -init, so the copy has no layer list and does not detect being added to the same layer twice.

This encodes the value, chains both coder methods through super, adds the key path, adds coder methods to the three subclasses, and sends -init in the copy. The copy check is in its own file, named in APPLE_SKIP_TESTS, because the exception it relies on is specific to this implementation and Apple does not raise it.

The branch carries #31 and #32, whose test file this adds to.

From Tests/quartzcore:

    gnustep-tests CAAnimation

Before, archiving.m exits with a segmentation fault and reports a failed file. After, its 8 assertions pass, and with copyinit.m beside it the suite is 70 passed with 2 dashed hopes.
