### PR TITLE
Fix: give a layer the state Apple gives it

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -250,6 +250,15 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
          just like Opal's Objective-C class instances */
       return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
     }
+  if ([key isEqualToString: @"borderColor"])
+    {
+      /* opaque black, as for the shadow colour above */
+      return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
+    }
+  if ([key isEqualToString: @"contentsGravity"])
+    {
+      return kCAGravityResize;
+    }
   if ([key isEqualToString: @"shadowOffset"])
     {
       CGSize offset = CGSizeMake(0.0, -3.0);
@@ -301,6 +310,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
         @"anchorPoint", @"transform", @"sublayerTransform",
         @"opacity", @"delegate", @"contentsRect", @"shouldRasterize",
         @"backgroundColor", @"borderColor", @"contentsScale",
+        @"contentsGravity",
 
         @"beginTime", @"duration", @"speed", @"autoreverses",
         @"repeatCount",
@@ -690,7 +700,34 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
 - (id) modelLayer
 {
-  return _modelLayer;
+  /* A layer that is not standing in for another one is its own model.
+     -isPresentationLayer reads the ivar directly, so it is unaffected. */
+  return _modelLayer ? _modelLayer : self;
+}
+
+- (void) setSublayers: (NSArray *)sublayers
+{
+  NSArray *oldSublayers = _sublayers;
+  CALayer *layer;
+
+  if (sublayers == _sublayers)
+    return;
+
+  /* The layers on their way out lose their superlayer, and the ones coming
+     in take this layer as theirs. */
+  for (layer in oldSublayers)
+    {
+      if (![sublayers containsObject: layer])
+        [layer setSuperlayer: nil];
+    }
+
+  _sublayers = [sublayers mutableCopy];
+  [oldSublayers release];
+
+  for (layer in _sublayers)
+    {
+      [layer setSuperlayer: self];
+    }
 }
 
 - (void) setModelLayer: (id)modelLayer


### PR DESCRIPTION
Four of a layer's values differ from Apple's. -modelLayer returns nil where Apple returns the layer itself for anything that is not a presentation layer. A new layer has no contents gravity where Apple has kCAGravityResize, and no border colour where Apple has opaque black. And -setSublayers: leaves every layer in the array without a superlayer, which the source already has a comment asking for.

This returns self from -modelLayer when no other layer is the model, which does not affect -isPresentationLayer because that reads the ivar directly; sets the two defaults; and writes -setSublayers: so the layers being removed lose their superlayer and the ones being added take this layer as theirs.

Two of the hopeful assertions in #34 stay dashed. A layer added to a second superlayer is not removed from the first, which is #19's. And a new layer has an empty sublayers array where Apple returns nil; what Apple returns once the last sublayer is removed has not been measured, so the getter is left as it is.

With the tests from #34 applied, from Tests/quartzcore:

    gnustep-tests CALayer/state.m

6 of those 32 assertions are dashed hopes before this change and 2 after, taking the suite from 53 to 57 passed.
