### PR TITLE
Fix: let the action search say that nobody offered an action

### DIFF
--- a/Source/CAImplicitAnimationObserver.m
+++ b/Source/CAImplicitAnimationObserver.m
@@ -29,6 +29,7 @@
 #import "CAImplicitAnimationObserver.h"
 #import "CALayer+FrameworkPrivate.h"
 #import "CATransaction+FrameworkPrivate.h"
+#import "QuartzCore/CAAnimation.h"
 #import "QuartzCore/CATransaction.h"
 
 static CAImplicitAnimationObserver * sharedObserver;
@@ -80,8 +81,25 @@ static CAImplicitAnimationObserver * sharedObserver;
     return;
 
   NSObject<CAAction>* action = (id)[object actionForKey: keyPath];
-  if (!action || [action isKindOfClass: [NSNull class]])
+  if ([action isKindOfClass: [NSNull class]])
     return;
+
+  if (!action)
+    {
+      /* Nothing offered an action for this change, so animate it the way a
+         layer animates by default.  -actionForKey: used to build this and
+         answer it, which left it unable to say that nobody wanted one. */
+      CABasicAnimation * animation =
+        [CABasicAnimation animationWithKeyPath: keyPath];
+
+      if ([object isPresentationLayer])
+        [animation setFromValue: [object valueForKeyPath: keyPath]];
+      else
+        [animation setFromValue:
+          [[object presentationLayer] valueForKeyPath: keyPath]];
+
+      action = animation;
+    }
   [[CATransaction topTransaction] registerAction: action
                                         onObject: object
                                          keyPath: keyPath];

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -1181,18 +1181,11 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
       /* Return the value */
       return action;
     }
-  /* It's nil? That's it. Now we can only generate our own animation. */
-
-  /***********************/
-
-  /* construct new animation */
-  CABasicAnimation * animation = [CABasicAnimation animationWithKeyPath: key];
-  if ([self isPresentationLayer])
-    [animation setFromValue: [self valueForKeyPath: key]];
-  else
-    [animation setFromValue: [[self presentationLayer] valueForKeyPath: key]];
-  return animation;
-
+  /* It's nil? That's it: nothing here offers an action.  Saying so is the
+     answer.  What a change with no action of its own should do is for the
+     caller to decide, and CAImplicitAnimationObserver is the caller that
+     decides, by building an animation of its own. */
+  return nil;
 }
 
 - (id)valueForUndefinedKey: (NSString *)key


### PR DESCRIPTION
When no source provides an action for a key, -actionForKey: builds a CABasicAnimation and returns it, where Apple returns nil. A caller cannot distinguish "no action for this key" from an action, and asking for an unknown key returns an animation.

The fallback cannot simply be removed, because CAImplicitAnimationObserver relies on it: it treats a nil action as "do not animate this change", so removing the fallback on its own would stop implicit animation. The fallback moves there instead. -actionForKey: now returns nil once the delegate, the actions dictionary, the style and the class have all returned nothing, and the observer builds the animation itself when it receives nil, taking the from value as before. It is the only caller of -actionForKey: in the framework.

Implicit animation was measured either side of the change: setting a position inside a transaction leaves animationKeys as (position) both before and after.

With the tests from #36 applied, from Tests/quartzcore:

    gnustep-tests CALayer/actions.m

3 of those 15 assertions are dashed hopes before this change and none after, taking the suite from 39 to 42 passed.
