### PR TITLE
Fix: answer the shadow path, not the shadow colour, for shadowPath

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -1213,7 +1213,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
     }
   if ([key isEqualToString: @"shadowPath"])
     {
-      return (id)[self shadowColor];
+      return (id)[self shadowPath];
     }
 
   return [super valueForUndefinedKey: key];

--- a/Tests/quartzcore/CALayer/cgkeys.m
+++ b/Tests/quartzcore/CALayer/cgkeys.m
@@ -1,0 +1,45 @@
+/* Reading the Core Graphics valued properties of a layer by key.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("reading a Core Graphics property by key")
+
+  CALayer *l = [CALayer layer];
+  CGMutablePathRef path = CGPathCreateMutable();
+  CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
+  CGFloat components[4] = {1.0, 0.0, 0.0, 1.0};
+  CGColorRef red = CGColorCreate(space, components);
+
+  CGPathAddRect(path, NULL, CGRectMake(0, 0, 10, 10));
+  [l setShadowPath: path];
+  [l setShadowColor: red];
+
+  PASS([l valueForKey: @"shadowColor"] == (id)[l shadowColor],
+       "the shadow colour key answers the shadow colour");
+  PASS([l valueForKey: @"backgroundColor"] == nil,
+       "the background colour key answers nothing when none is set");
+  PASS([l valueForKey: @"borderColor"] == (id)[l borderColor],
+       "the border colour key answers the border colour");
+
+  PASS([l valueForKey: @"shadowPath"] != nil,
+       "the shadow path key answers something once a path is set");
+  PASS([l valueForKey: @"shadowPath"] != (id)[l shadowColor],
+       "and what it answers is not the shadow colour");
+
+  CGPathRelease(path);
+  CGColorRelease(red);
+  CGColorSpaceRelease(space);
+
+  END_SET("reading a Core Graphics property by key")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Reading a layer's shadow path by key returns its shadow colour. In -valueForUndefinedKey:, the branch for shadowPath returns [self shadowColor], one line below the branch that returns the shadow colour for shadowColor. Anything reaching that property by key, which is how an animation reaches it, gets a CGColorRef where a CGPathRef belongs.

The fix is one word, and it comes with the test that catches it rather than in a separate pull request.

Tests/quartzcore/CALayer/cgkeys.m also pins the three neighbouring keys that were already correct. All four Core Graphics properties were read by key against Apple QuartzCore on a macOS runner, which returns the path, the shadow colour, the border colour, and nil for a background colour that was never set.

From Tests/quartzcore:

    gnustep-tests CALayer/cgkeys.m

1 of the 5 assertions fails before this change and none after, taking the suite from 31 to 32 passed.
