### PR TITLE
tests: add CALayer display flag and CATransition tests

### DIFF
--- a/Tests/quartzcore/CALayer/display.m
+++ b/Tests/quartzcore/CALayer/display.m
@@ -1,0 +1,60 @@
+/* When a layer decides it needs drawing again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants drawing")
+
+  CALayer *l = [CALayer layer];
+
+  [l setBounds: CGRectMake(0, 0, 50, 50)];
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "a layer that has drawn does not want drawing");
+
+  [l setNeedsDisplay];
+  PASS([l needsDisplay] == YES, "asking for drawing sets the flag");
+
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "drawing when needed clears it");
+
+  [l setNeedsDisplayInRect: CGRectMake(0, 0, 10, 10)];
+  PASS([l needsDisplay] == YES, "asking for part of it sets the flag too");
+
+  [l displayIfNeeded];
+
+  testHopeful = YES;
+  [l setNeedsDisplay];
+  [l display];
+  PASS([l needsDisplay] == NO, "drawing outright clears it as well");
+  testHopeful = NO;
+
+  END_SET("the flag that says a layer wants drawing")
+
+  START_SET("redrawing when the bounds change")
+
+  CALayer *off = [CALayer layer];
+
+  [off displayIfNeeded];
+  [off setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([off needsDisplay] == NO,
+       "a bounds change alone does not ask for drawing");
+
+  CALayer *on = [CALayer layer];
+
+  [on setNeedsDisplayOnBoundsChange: YES];
+  [on displayIfNeeded];
+  [on setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([on needsDisplay] == YES,
+       "a layer told to redraw on a bounds change asks for drawing");
+
+  END_SET("redrawing when the bounds change")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -1,0 +1,46 @@
+/* The values a transition starts with, and what its setters keep.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a transition starts with")
+
+  CATransition *t = [CATransition animation];
+
+  PASS(t != nil, "a transition can be created");
+  PASS([t isKindOfClass: [CAAnimation class]], "a transition is an animation");
+  PASS([t subtype] == nil, "it starts with no subtype");
+  PASS([t duration] == 0.0, "it starts with a duration of 0");
+
+  /* Apple names this "fade"; the constant for it arrives with #26. */
+  testHopeful = YES;
+  PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
+  testHopeful = NO;
+
+  END_SET("the values a transition starts with")
+
+  START_SET("what a transition's setters keep")
+
+  CATransition *t = [CATransition animation];
+
+  /* Spelled out rather than named, because kCATransitionMoveIn and the
+     subtype constants beside it are declared but defined nowhere until #25. */
+  [t setType: @"moveIn"];
+  PASS([[t type] isEqualToString: @"moveIn"],
+       "the type reads back as it was set");
+
+  [t setSubtype: @"fromLeft"];
+  PASS([[t subtype] isEqualToString: @"fromLeft"],
+       "the subtype reads back as it was set");
+
+  END_SET("what a transition's setters keep")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
There are no tests for the needsDisplay flag or for CATransition.

This adds Tests/quartzcore/CALayer/display.m and Tests/quartzcore/CATransition/transition.m, covering -setNeedsDisplay and -setNeedsDisplayInRect:, -displayIfNeeded and -display, whether a bounds change sets the flag on its own and once -setNeedsDisplayOnBoundsChange: is set, and the values a new CATransition has and what its setters store. Expected values were checked against Apple QuartzCore on a macOS runner.

Two assertions are hopeful. -display leaves needsDisplay set, where Apple clears it as -displayIfNeeded does; only the latter clears it here. And a new CATransition has no type, where Apple uses kCATransitionFade.

The transition type and subtype are written as string literals rather than named in the setter test, because kCATransitionMoveIn and the subtype constants beside it are declared and defined nowhere until #25 lands.

From Tests/quartzcore:

    gnustep-tests CALayer/display.m
    gnustep-tests CATransition

7 and 7 assertions, 12 passed and 2 dashed hopes between them, no failures. A fix follows separately.
