### PR TITLE
Fix: clear the display flag when a layer draws, and lay layers out

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -69,6 +69,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 @property (nonatomic, retain) NSMutableDictionary *dynamicPropertyValueDict;
 
 - (void)setModelLayer: (id)modelLayer;
+- (void)layoutTreeIfNeeded;
 @end
 
 @implementation CALayer
@@ -615,6 +616,9 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
       [self.backingStore refresh];
     }
+
+  /* Having drawn, the layer no longer wants drawing. */
+  _needsDisplay = NO;
 }
 
 - (void) displayIfNeeded
@@ -655,10 +659,52 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 /* MARK: - Layout methods */
 - (void) layoutIfNeeded
 {
+  CALayer * top = self;
+
+  /* Up through the superlayers for as long as they want laying out too, so
+     that the whole tree below the highest one is laid out at once. */
+  while ([top superlayer] && [[top superlayer] needsLayout])
+    {
+      top = [top superlayer];
+    }
+
+  [top layoutTreeIfNeeded];
+}
+
+- (void) layoutTreeIfNeeded
+{
+  CALayer * sublayer;
+
+  if (_needsLayout)
+    {
+      [self layoutSublayers];
+      _needsLayout = NO;
+    }
+
+  for (sublayer in _sublayers)
+    {
+      [sublayer layoutTreeIfNeeded];
+    }
 }
 
 - (void) layoutSublayers
 {
+  /* The delegate is asked first, and the layout manager only if the delegate
+     has nothing to say. */
+  if ([_delegate respondsToSelector: @selector(layoutSublayersOfLayer:)])
+    {
+      [_delegate layoutSublayersOfLayer: self];
+    }
+  else if ([_layoutManager respondsToSelector:
+             @selector(layoutSublayersOfLayer:)])
+    {
+      [_layoutManager layoutSublayersOfLayer: self];
+    }
+}
+
+- (BOOL) needsLayout
+{
+  return _needsLayout;
 }
 
 - (void) setNeedsLayout

--- a/Tests/quartzcore/CALayer/display.m
+++ b/Tests/quartzcore/CALayer/display.m
@@ -1,0 +1,60 @@
+/* When a layer decides it needs drawing again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants drawing")
+
+  CALayer *l = [CALayer layer];
+
+  [l setBounds: CGRectMake(0, 0, 50, 50)];
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "a layer that has drawn does not want drawing");
+
+  [l setNeedsDisplay];
+  PASS([l needsDisplay] == YES, "asking for drawing sets the flag");
+
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "drawing when needed clears it");
+
+  [l setNeedsDisplayInRect: CGRectMake(0, 0, 10, 10)];
+  PASS([l needsDisplay] == YES, "asking for part of it sets the flag too");
+
+  [l displayIfNeeded];
+
+  testHopeful = YES;
+  [l setNeedsDisplay];
+  [l display];
+  PASS([l needsDisplay] == NO, "drawing outright clears it as well");
+  testHopeful = NO;
+
+  END_SET("the flag that says a layer wants drawing")
+
+  START_SET("redrawing when the bounds change")
+
+  CALayer *off = [CALayer layer];
+
+  [off displayIfNeeded];
+  [off setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([off needsDisplay] == NO,
+       "a bounds change alone does not ask for drawing");
+
+  CALayer *on = [CALayer layer];
+
+  [on setNeedsDisplayOnBoundsChange: YES];
+  [on displayIfNeeded];
+  [on setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([on needsDisplay] == YES,
+       "a layer told to redraw on a bounds change asks for drawing");
+
+  END_SET("redrawing when the bounds change")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -1,0 +1,92 @@
+/* When a layer decides it needs laying out again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+@interface QCLayoutManager : NSObject
+{
+  int _count;
+}
+- (int) count;
+@end
+
+@implementation QCLayoutManager
+
+- (void) layoutSublayersOfLayer: (CALayer *)layer
+{
+  _count++;
+}
+
+- (int) count
+{
+  return _count;
+}
+
+@end
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants laying out")
+
+  CALayer *l = [CALayer layer];
+
+  PASS([l needsLayout] == NO, "a fresh layer does not want laying out");
+
+  [l setNeedsLayout];
+  PASS([l needsLayout] == YES, "asking for layout sets the flag");
+
+  [l layoutIfNeeded];
+  PASS([l needsLayout] == NO, "laying out when needed clears it");
+
+  [l setNeedsLayout];
+  [l layoutSublayers];
+  PASS([l needsLayout] == YES,
+       "laying the sublayers out does not clear it by itself");
+
+  END_SET("the flag that says a layer wants laying out")
+
+  START_SET("who is asked to do the laying out")
+
+  CALayer *l = [CALayer layer];
+  QCLayoutManager *m = [[[QCLayoutManager alloc] init] autorelease];
+
+  PASS([l layoutManager] == nil, "a layer starts with no layout manager");
+
+  [l setLayoutManager: m];
+  [l setNeedsLayout];
+  [l layoutIfNeeded];
+  PASS([m count] == 1, "the layout manager is asked to lay the sublayers out");
+
+  END_SET("who is asked to do the laying out")
+
+  START_SET("laying out a tree")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  QCLayoutManager *rootManager = [[[QCLayoutManager alloc] init] autorelease];
+  QCLayoutManager *childManager = [[[QCLayoutManager alloc] init] autorelease];
+
+  [root setLayoutManager: rootManager];
+  [child setLayoutManager: childManager];
+  [root addSublayer: child];
+
+  [root setNeedsLayout];
+  [child setNeedsLayout];
+
+  /* Asking the child lays out from the highest layer that wants it. */
+  [child layoutIfNeeded];
+
+  PASS([root needsLayout] == NO, "the layer above is laid out as well");
+  PASS([child needsLayout] == NO, "and so is the one asked");
+  PASS([rootManager count] == 1 && [childManager count] == 1,
+       "each of them lays its own sublayers out once");
+
+  END_SET("laying out a tree")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -1,0 +1,46 @@
+/* The values a transition starts with, and what its setters keep.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a transition starts with")
+
+  CATransition *t = [CATransition animation];
+
+  PASS(t != nil, "a transition can be created");
+  PASS([t isKindOfClass: [CAAnimation class]], "a transition is an animation");
+  PASS([t subtype] == nil, "it starts with no subtype");
+  PASS([t duration] == 0.0, "it starts with a duration of 0");
+
+  /* Apple names this "fade"; the constant for it arrives with #26. */
+  testHopeful = YES;
+  PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
+  testHopeful = NO;
+
+  END_SET("the values a transition starts with")
+
+  START_SET("what a transition's setters keep")
+
+  CATransition *t = [CATransition animation];
+
+  /* Spelled out rather than named, because kCATransitionMoveIn and the
+     subtype constants beside it are declared but defined nowhere until #25. */
+  [t setType: @"moveIn"];
+  PASS([[t type] isEqualToString: @"moveIn"],
+       "the type reads back as it was set");
+
+  [t setSubtype: @"fromLeft"];
+  PASS([[t subtype] isEqualToString: @"fromLeft"],
+       "the subtype reads back as it was set");
+
+  END_SET("what a transition's setters keep")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Three things about display and layout differ from Apple's. -display leaves needsDisplay set, because only -displayIfNeeded clears the flag. -needsLayout is declared in the header and not implemented. And -layoutIfNeeded and -layoutSublayers are both empty, so the layout manager is never called and the layout flag, once set, is never cleared.

This clears the flag at the end of -display and leaves -displayIfNeeded as it was. It adds -needsLayout. -layoutSublayers now calls the delegate, and the layout manager only if the delegate does not implement -layoutSublayersOfLayer:, which is the order Apple documents. -layoutIfNeeded walks up through the superlayers while they also need layout and then lays out that whole tree, clearing each flag as it goes, which is what Apple documents.

The layout tests come with the fix rather than ahead of it, because -needsLayout could not be called before.

Two divergences are left. A new CATransition has no type where Apple uses kCATransitionFade, which needs the constant #26 adds. And adding a sublayer does not set the layout flag as Apple does, which would mean touching the four methods #19 is already rewriting.

From Tests/quartzcore:

    gnustep-tests

40 passed with 8 failed and 2 dashed hopes before this change, and 49 passed with 1 dashed hope after.
