### PR TITLE
Feature: add the layer properties that describe how it looks

### DIFF
--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -126,6 +126,14 @@ extern NSString *const kCATransition;
      - ...more?
      Creating framebuffers is more expensive than reusing them.
      */
+
+  NSString * _name;
+  CGFloat _borderWidth;
+  CGFloat _cornerRadius;
+  CGFloat _rasterizationScale;
+  BOOL _doubleSided;
+  NSString * _minificationFilter;
+  NSString * _magnificationFilter;
 }
 
 + (id) layer;
@@ -161,6 +169,13 @@ extern NSString *const kCATransition;
 @property (copy)                     NSString *contentsGravity;
 @property (assign)                   BOOL needsDisplayOnBoundsChange;
 @property (assign)                   CGFloat zPosition;
+@property (copy)                     NSString *name;
+@property (assign)                   CGFloat borderWidth;
+@property (assign)                   CGFloat cornerRadius;
+@property (assign)                   CGFloat rasterizationScale;
+@property (assign,getter=isDoubleSided) BOOL doubleSided;
+@property (copy)                     NSString *minificationFilter;
+@property (copy)                     NSString *magnificationFilter;
 @property (copy)                     NSDictionary *actions;
 /* TODO: Style property is unimplemented */
 @property (copy)                     NSDictionary *style;
@@ -185,6 +200,7 @@ extern NSString *const kCATransition;
 - (void) insertSublayer: (CALayer *)layer atIndex: (unsigned)index;
 - (void) insertSublayer: (CALayer *)layer below: (CALayer *)sibling;
 - (void) insertSublayer: (CALayer *)layer above: (CALayer *)sibling;
+- (void) replaceSublayer: (CALayer *)layer with: (CALayer *)layer2;
 
 - (CGPoint) convertPoint: (CGPoint)pt fromLayer: (CALayer *)layer;
 - (CGPoint) convertPoint: (CGPoint)pt toLayer: (CALayer *)layer;

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -100,6 +100,13 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 @synthesize style=_style;
 @synthesize borderColor=_borderColor;
 @synthesize contentsScale=_contentsScale;
+@synthesize name=_name;
+@synthesize borderWidth=_borderWidth;
+@synthesize cornerRadius=_cornerRadius;
+@synthesize rasterizationScale=_rasterizationScale;
+@synthesize doubleSided=_doubleSided;
+@synthesize minificationFilter=_minificationFilter;
+@synthesize magnificationFilter=_magnificationFilter;
 
 @synthesize shadowColor=_shadowColor;
 @synthesize shadowOffset=_shadowOffset;
@@ -250,6 +257,19 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
          just like Opal's Objective-C class instances */
       return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
     }
+  if ([key isEqualToString: @"doubleSided"])
+    {
+      return [NSNumber numberWithBool: YES];
+    }
+  if ([key isEqualToString: @"rasterizationScale"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+  if ([key isEqualToString: @"minificationFilter"]
+      || [key isEqualToString: @"magnificationFilter"])
+    {
+      return kCAFilterLinear;
+    }
   if ([key isEqualToString: @"shadowOffset"])
     {
       CGSize offset = CGSizeMake(0.0, -3.0);
@@ -301,6 +321,8 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
         @"anchorPoint", @"transform", @"sublayerTransform",
         @"opacity", @"delegate", @"contentsRect", @"shouldRasterize",
         @"backgroundColor", @"borderColor", @"contentsScale",
+        @"doubleSided", @"rasterizationScale",
+        @"minificationFilter", @"magnificationFilter",
 
         @"beginTime", @"duration", @"speed", @"autoreverses",
         @"repeatCount",
@@ -451,6 +473,9 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
   CGColorRelease(_backgroundColor);
   CGColorRelease(_borderColor);
   [_contentsGravity release];
+  [_name release];
+  [_minificationFilter release];
+  [_magnificationFilter release];
   [_fillMode release];
 
   [_backingStore release];
@@ -901,6 +926,24 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   NSInteger siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex+1];
   [layer setSuperlayer: self];
+}
+
+- (void) replaceSublayer: (CALayer *)layer with: (CALayer *)layer2
+{
+  NSMutableArray * mutableSublayers = (NSMutableArray*)_sublayers;
+  NSUInteger index = [mutableSublayers indexOfObject: layer];
+
+  if (index == NSNotFound)
+    {
+      return;
+    }
+
+  [layer2 retain];
+  [layer2 removeFromSuperlayer];
+  [mutableSublayers replaceObjectAtIndex: index withObject: layer2];
+  [layer setSuperlayer: nil];
+  [layer2 setSuperlayer: self];
+  [layer2 release];
 }
 
 - (CALayer *) rootLayer

--- a/Tests/quartzcore/CALayer/properties.m
+++ b/Tests/quartzcore/CALayer/properties.m
@@ -1,0 +1,85 @@
+/* The layer properties that describe how it looks, and replacing a sublayer.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+/* The whole framework rather than CALayer.h alone, because the filter names
+   are declared in a header of their own here and alongside the layer on
+   Apple. */
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what these properties start as")
+
+  CALayer *l = [CALayer layer];
+
+  PASS([l name] == nil, "a layer starts with no name");
+  PASS([l borderWidth] == 0.0, "its border starts with no width");
+  PASS([l cornerRadius] == 0.0, "its corners start square");
+  PASS([l rasterizationScale] == 1.0, "it rasterises at a scale of 1");
+  PASS([l isDoubleSided] == YES, "it starts double sided");
+  PASS([[l minificationFilter] isEqualToString: kCAFilterLinear],
+       "it shrinks with the linear filter");
+  PASS([[l magnificationFilter] isEqualToString: kCAFilterLinear],
+       "and grows with it too");
+
+  END_SET("what these properties start as")
+
+  START_SET("what their setters keep")
+
+  CALayer *l = [CALayer layer];
+
+  [l setName: @"a layer"];
+  PASS([[l name] isEqualToString: @"a layer"],
+       "the name reads back as it was set");
+
+  [l setBorderWidth: 2.5];
+  PASS([l borderWidth] == 2.5, "the border width reads back as it was set");
+
+  [l setCornerRadius: 4.0];
+  PASS([l cornerRadius] == 4.0, "the corner radius reads back as it was set");
+
+  [l setRasterizationScale: 2.0];
+  PASS([l rasterizationScale] == 2.0,
+       "the rasterization scale reads back as it was set");
+
+  [l setDoubleSided: NO];
+  PASS([l isDoubleSided] == NO, "double sided reads back as it was set");
+
+  [l setMinificationFilter: kCAFilterNearest];
+  PASS([[l minificationFilter] isEqualToString: kCAFilterNearest],
+       "the minification filter reads back as it was set");
+
+  [l setMagnificationFilter: kCAFilterNearest];
+  PASS([[l magnificationFilter] isEqualToString: kCAFilterNearest],
+       "the magnification filter reads back as it was set");
+
+  END_SET("what their setters keep")
+
+  START_SET("replacing one sublayer with another")
+
+  CALayer *root = [CALayer layer];
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+  CALayer *c = [CALayer layer];
+
+  [root addSublayer: a];
+  [root addSublayer: b];
+  [root replaceSublayer: b with: c];
+
+  PASS([[root sublayers] count] == 2, "the count does not change");
+  PASS([[root sublayers] objectAtIndex: 1] == c,
+       "the new layer takes the place of the old one");
+  PASS([c superlayer] == root, "and its superlayer is the one it went into");
+  PASS([b superlayer] == nil, "while the old one has no superlayer left");
+  PASS([[root sublayers] objectAtIndex: 0] == a,
+       "the layers around it are left alone");
+
+  END_SET("replacing one sublayer with another")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Seven CALayer properties are absent, along with -replaceSublayer:with:: name, borderWidth, cornerRadius, rasterizationScale, doubleSided, minificationFilter and magnificationFilter.

This adds them, with tests, since none could be tested before they existed. The four with a non-zero default match Apple: doubleSided is YES, rasterizationScale is 1, and both minificationFilter and magnificationFilter are kCAFilterLinear. The other three start at 0 or nil, as they do on Apple. -replaceSublayer:with: puts the new layer at the index the old one held, sets its superlayer and clears the old one's, and leaves the surrounding layers in place.

The two filter properties are compared against the constants rather than their string values, so these tests do not depend on #24.

The new ivars go at the end of the ivar block, so nothing already there moves.

From Tests/quartzcore:

    gnustep-tests CALayer/properties.m

19 assertions, none of which could run before, all passing after. The suite is 46 passed.
