### PR TITLE
Fix: answer nothing for the sublayers of a layer that has none

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -250,6 +250,15 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
          just like Opal's Objective-C class instances */
       return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
     }
+  if ([key isEqualToString: @"borderColor"])
+    {
+      /* opaque black, as for the shadow colour above */
+      return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
+    }
+  if ([key isEqualToString: @"contentsGravity"])
+    {
+      return kCAGravityResize;
+    }
   if ([key isEqualToString: @"shadowOffset"])
     {
       CGSize offset = CGSizeMake(0.0, -3.0);
@@ -301,6 +310,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
         @"anchorPoint", @"transform", @"sublayerTransform",
         @"opacity", @"delegate", @"contentsRect", @"shouldRasterize",
         @"backgroundColor", @"borderColor", @"contentsScale",
+        @"contentsGravity",
 
         @"beginTime", @"duration", @"speed", @"autoreverses",
         @"repeatCount",
@@ -690,7 +700,34 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
 - (id) modelLayer
 {
-  return _modelLayer;
+  /* A layer that is not standing in for another one is its own model.
+     -isPresentationLayer reads the ivar directly, so it is unaffected. */
+  return _modelLayer ? _modelLayer : self;
+}
+
+- (void) setSublayers: (NSArray *)sublayers
+{
+  NSArray *oldSublayers = _sublayers;
+  CALayer *layer;
+
+  if (sublayers == _sublayers)
+    return;
+
+  /* The layers on their way out lose their superlayer, and the ones coming
+     in take this layer as theirs. */
+  for (layer in oldSublayers)
+    {
+      if (![sublayers containsObject: layer])
+        [layer setSuperlayer: nil];
+    }
+
+  _sublayers = [sublayers mutableCopy];
+  [oldSublayers release];
+
+  for (layer in _sublayers)
+    {
+      [layer setSuperlayer: self];
+    }
 }
 
 - (void) setModelLayer: (id)modelLayer

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -721,7 +721,10 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
         [layer setSuperlayer: nil];
     }
 
-  _sublayers = [sublayers mutableCopy];
+  /* Kept as a real array even when handed nothing, so that a layer given no
+     sublayers can still be given some later. */
+  _sublayers = sublayers != nil
+    ? [sublayers mutableCopy] : [[NSMutableArray alloc] init];
   [oldSublayers release];
 
   for (layer in _sublayers)
@@ -754,9 +757,11 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
 - (NSArray *) sublayers
 {
+  /* A layer with none answers nothing at all rather than an empty array.
+     The array itself is kept either way, so sublayers can still be added. */
   if (![self isPresentationLayer])
     {
-      return _sublayers;
+      return [_sublayers count] > 0 ? _sublayers : nil;
     }
   else
     {
@@ -765,7 +770,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
         {
           [presentationSublayers addObject: [modelSublayer presentationLayer]];
         }
-      return presentationSublayers;
+      return [presentationSublayers count] > 0 ? presentationSublayers : nil;
     }
 }
 

--- a/Tests/quartzcore/CALayer/state.m
+++ b/Tests/quartzcore/CALayer/state.m
@@ -1,0 +1,118 @@
+/* The values a layer starts with, and the shape of its sublayer tree.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a layer starts with")
+
+  CALayer *l = [CALayer layer];
+
+  PASS([l opacity] == 1.0, "a layer starts fully opaque");
+  PASS([l isHidden] == NO, "a layer starts visible");
+  PASS([l masksToBounds] == NO, "a layer does not mask to its bounds");
+  PASS([l isGeometryFlipped] == NO, "a layer's geometry is not flipped");
+  PASS([l zPosition] == 0.0, "a layer sits at a z position of 0");
+  PASS([l shadowOpacity] == 0.0, "a layer's shadow starts fully transparent");
+  PASS([l shadowRadius] == 3.0, "a layer's shadow radius starts at 3");
+  PASS([l shadowOffset].width == 0.0 && [l shadowOffset].height == -3.0,
+       "a layer's shadow is offset up by 3");
+  PASS(CGRectEqualToRect([l contentsRect], CGRectMake(0, 0, 1, 1)),
+       "a layer's contents rect is the unit rect");
+  PASS([l needsDisplayOnBoundsChange] == NO,
+       "a layer does not redraw when its bounds change");
+  PASS([l shouldRasterize] == NO, "a layer does not rasterise");
+  PASS([l superlayer] == nil, "a layer starts with no superlayer");
+  PASS([l actions] == nil, "a layer starts with no actions");
+  PASS([l style] == nil, "a layer starts with no style");
+  PASS([l contents] == nil, "a layer starts with no contents");
+  PASS([l backgroundColor] == NULL, "a layer starts with no background");
+
+  testHopeful = YES;
+  PASS([l modelLayer] == l, "a layer is its own model layer");
+  PASS([l sublayers] == nil, "a layer starts with no sublayers at all");
+  PASS([[l contentsGravity] isEqualToString: kCAGravityResize],
+       "a layer's contents gravity is resize");
+  PASS([l borderColor] != NULL, "a layer starts with a border colour");
+  testHopeful = NO;
+
+  END_SET("the values a layer starts with")
+
+  START_SET("the sublayer tree")
+
+  CALayer *root = [CALayer layer];
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+  CALayer *c = [CALayer layer];
+
+  [root addSublayer: a];
+  PASS([[root sublayers] count] == 1, "adding a sublayer leaves one behind");
+  PASS([a superlayer] == root, "and its superlayer is the one it went into");
+
+  [root addSublayer: b];
+  [root addSublayer: c];
+  PASS([[root sublayers] objectAtIndex: 0] == a
+       && [[root sublayers] objectAtIndex: 1] == b
+       && [[root sublayers] objectAtIndex: 2] == c,
+       "sublayers are kept in the order they were added");
+
+  [b removeFromSuperlayer];
+  PASS([[root sublayers] count] == 2, "removing one leaves the rest");
+  PASS([b superlayer] == nil, "and the one removed has no superlayer");
+
+  CALayer *d = [CALayer layer];
+
+  [root insertSublayer: d atIndex: 0];
+  PASS([[root sublayers] objectAtIndex: 0] == d,
+       "inserting at an index puts it there");
+
+  CALayer *e = [CALayer layer];
+
+  [root insertSublayer: e below: a];
+  PASS([[root sublayers] indexOfObject: e] == 1,
+       "inserting below a layer puts it just under that one");
+
+  CALayer *f = [CALayer layer];
+
+  [root insertSublayer: f above: a];
+  PASS([[root sublayers] indexOfObject: f] == 3,
+       "inserting above a layer puts it just over that one");
+
+  CALayer *other = [CALayer layer];
+
+  [other addSublayer: a];
+  PASS([a superlayer] == other, "and its superlayer is where it went");
+
+  /* #19 is what takes a layer out of the tree it was already in. */
+  testHopeful = YES;
+  PASS([[root sublayers] count] == 4,
+       "adding a layer elsewhere takes it out of where it was");
+  testHopeful = NO;
+
+  END_SET("the sublayer tree")
+
+  START_SET("setting the sublayers wholesale")
+
+  CALayer *root = [CALayer layer];
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [root setSublayers: [NSArray arrayWithObjects: a, b, nil]];
+  PASS([[root sublayers] count] == 2, "the layers given are the sublayers");
+
+  testHopeful = YES;
+  PASS([a superlayer] == root && [b superlayer] == root,
+       "and each one's superlayer is the layer they went into");
+  testHopeful = NO;
+
+  END_SET("setting the sublayers wholesale")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/state.m
+++ b/Tests/quartzcore/CALayer/state.m
@@ -34,15 +34,49 @@ int main(void)
   PASS([l contents] == nil, "a layer starts with no contents");
   PASS([l backgroundColor] == NULL, "a layer starts with no background");
 
+  PASS([l sublayers] == nil, "a layer starts with no sublayers at all");
+
   testHopeful = YES;
   PASS([l modelLayer] == l, "a layer is its own model layer");
-  PASS([l sublayers] == nil, "a layer starts with no sublayers at all");
   PASS([[l contentsGravity] isEqualToString: kCAGravityResize],
        "a layer's contents gravity is resize");
   PASS([l borderColor] != NULL, "a layer starts with a border colour");
   testHopeful = NO;
 
   END_SET("the values a layer starts with")
+
+  START_SET("a layer that has lost its sublayers")
+
+  CALayer *l = [CALayer layer];
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [l addSublayer: a];
+  PASS([l sublayers] != nil, "having one, it answers an array");
+
+  [a removeFromSuperlayer];
+  PASS([l sublayers] == nil, "having lost the only one, it answers nothing");
+
+  [l addSublayer: a];
+  [l addSublayer: b];
+  [a removeFromSuperlayer];
+  PASS([[l sublayers] count] == 1, "losing one of two leaves the other");
+  [b removeFromSuperlayer];
+  PASS([l sublayers] == nil, "and losing that one leaves nothing again");
+
+  [l setSublayers: [NSArray arrayWithObject: a]];
+  [l setSublayers: [NSArray array]];
+  PASS([l sublayers] == nil, "being given an empty array is the same thing");
+
+  [l setSublayers: [NSArray arrayWithObject: a]];
+  [l setSublayers: nil];
+  PASS([l sublayers] == nil, "and so is being given nothing");
+
+  /* Being given nothing must not stop it taking sublayers later. */
+  [l addSublayer: a];
+  PASS([[l sublayers] count] == 1, "a layer given nothing can still be given one");
+
+  END_SET("a layer that has lost its sublayers")
 
   START_SET("the sublayer tree")
 


### PR DESCRIPTION
-sublayers returns an empty array where Apple returns nil. #35 left this because what Apple returns once the last sublayer is removed had not been established. It has now, and the result is the same by every route: a layer that never had a sublayer, one whose only sublayer has been removed, one that has lost the last of two, one passed an empty array and one passed nil all return nil.

The getter now returns nil when the array is empty, on the presentation side as well as the model side. The array itself is kept either way, so a layer can still be given sublayers afterwards, and -setSublayers: keeps one even when passed nil. Without that a layer passed nil could never take a sublayer again, since everything that adds one goes to the array directly.

Seven assertions in state.m cover the routes, and the assertion already there stops being hopeful.

The branch carries #34 and #35, whose test file and -setSublayers: this builds on.

From Tests/quartzcore:

    gnustep-tests CALayer/state.m

60 passed with 5 failed before this change, and 65 passed after, with the one remaining dashed hope being the reparenting #19 deals with.
