### PR TITLE
Fix: ask for layout when the sublayers or the bounds change

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -79,7 +79,6 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 @synthesize renderer=_renderer;
 @synthesize superlayer=_superlayer;
 @synthesize sublayers=_sublayers;
-@synthesize frame=_frame;
 @synthesize bounds=_bounds;
 @synthesize anchorPoint=_anchorPoint;
 @synthesize position=_position;
@@ -209,6 +208,10 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
   if ([key isEqualToString: @"shouldRasterize"])
     {
       return [NSNumber numberWithBool: NO];
+    }
+  if ([key isEqualToString: @"contentsScale"])
+    {
+      return [NSNumber numberWithDouble: 1.0];
     }
   if ([key isEqualToString: @"opacity"])
     {
@@ -479,8 +482,54 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
 #endif
 
+/* The rectangle the bounds size occupies around the anchor point, with the
+   layer transform applied.  Its origin is relative to the position. */
+- (CGRect) _transformedBoundsRect
+{
+  CGAffineTransform affine;
+  CGRect r;
+
+  affine = CGAffineTransformMake(_transform.m11, _transform.m12,
+                                 _transform.m21, _transform.m22,
+                                 _transform.m41, _transform.m42);
+  r = CGRectMake(-_anchorPoint.x * _bounds.size.width,
+                 -_anchorPoint.y * _bounds.size.height,
+                 _bounds.size.width, _bounds.size.height);
+  return CGRectApplyAffineTransform(r, affine);
+}
+
+- (CGRect) frame
+{
+  CGRect r = [self _transformedBoundsRect];
+
+  r.origin.x += _position.x;
+  r.origin.y += _position.y;
+  return r;
+}
+
+- (void) setFrame: (CGRect)frame
+{
+  CGAffineTransform affine;
+  CGRect bounds = _bounds;
+  CGRect r;
+
+  affine = CGAffineTransformMake(_transform.m11, _transform.m12,
+                                 _transform.m21, _transform.m22,
+                                 _transform.m41, _transform.m42);
+  frame = CGRectStandardize(frame);
+  bounds.size = CGSizeApplyAffineTransform(frame.size,
+                                           CGAffineTransformInvert(affine));
+  [self setBounds: bounds];
+
+  r = [self _transformedBoundsRect];
+  [self setPosition: CGPointMake(frame.origin.x - r.origin.x,
+                                 frame.origin.y - r.origin.y)];
+}
+
 - (void) setBounds: (CGRect)bounds
 {
+  bounds = CGRectStandardize(bounds);
+
   if (CGRectEqualToRect(bounds, _bounds))
     return;
 
@@ -842,6 +891,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 {
   NSMutableArray * mutableSublayers = (NSMutableArray*)_sublayers;
 
+  [layer removeFromSuperlayer];
   [mutableSublayers addObject: layer];
   [layer setSuperlayer: self];
 }
@@ -858,6 +908,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 {
   NSMutableArray * mutableSublayers = (NSMutableArray*)_sublayers;
 
+  [layer removeFromSuperlayer];
   [mutableSublayers insertObject: layer atIndex: index];
   [layer setSuperlayer: self];
 }
@@ -865,8 +916,10 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 - (void) insertSublayer: (CALayer *)layer below: (CALayer *)sibling;
 {
   NSMutableArray * mutableSublayers = (NSMutableArray*)_sublayers;
+  NSInteger siblingIndex;
 
-  NSInteger siblingIndex = [mutableSublayers indexOfObject: sibling];
+  [layer removeFromSuperlayer];
+  siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex];
   [layer setSuperlayer: self];
 }
@@ -874,8 +927,10 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 - (void) insertSublayer: (CALayer *)layer above: (CALayer *)sibling;
 {
   NSMutableArray * mutableSublayers = (NSMutableArray*)_sublayers;
+  NSInteger siblingIndex;
 
-  NSInteger siblingIndex = [mutableSublayers indexOfObject: sibling];
+  [layer removeFromSuperlayer];
+  siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex+1];
   [layer setSuperlayer: self];
 }

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -69,6 +69,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 @property (nonatomic, retain) NSMutableDictionary *dynamicPropertyValueDict;
 
 - (void)setModelLayer: (id)modelLayer;
+- (void)layoutTreeIfNeeded;
 @end
 
 @implementation CALayer
@@ -615,6 +616,9 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
       [self.backingStore refresh];
     }
+
+  /* Having drawn, the layer no longer wants drawing. */
+  _needsDisplay = NO;
 }
 
 - (void) displayIfNeeded
@@ -655,10 +659,52 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 /* MARK: - Layout methods */
 - (void) layoutIfNeeded
 {
+  CALayer * top = self;
+
+  /* Up through the superlayers for as long as they want laying out too, so
+     that the whole tree below the highest one is laid out at once. */
+  while ([top superlayer] && [[top superlayer] needsLayout])
+    {
+      top = [top superlayer];
+    }
+
+  [top layoutTreeIfNeeded];
+}
+
+- (void) layoutTreeIfNeeded
+{
+  CALayer * sublayer;
+
+  if (_needsLayout)
+    {
+      [self layoutSublayers];
+      _needsLayout = NO;
+    }
+
+  for (sublayer in _sublayers)
+    {
+      [sublayer layoutTreeIfNeeded];
+    }
 }
 
 - (void) layoutSublayers
 {
+  /* The delegate is asked first, and the layout manager only if the delegate
+     has nothing to say. */
+  if ([_delegate respondsToSelector: @selector(layoutSublayersOfLayer:)])
+    {
+      [_delegate layoutSublayersOfLayer: self];
+    }
+  else if ([_layoutManager respondsToSelector:
+             @selector(layoutSublayersOfLayer:)])
+    {
+      [_layoutManager layoutSublayersOfLayer: self];
+    }
+}
+
+- (BOOL) needsLayout
+{
+  return _needsLayout;
 }
 
 - (void) setNeedsLayout

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -570,6 +570,9 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
     {
       [self setNeedsDisplay];
     }
+
+  /* Whatever it holds has a different amount of room now. */
+  [self setNeedsLayout];
 }
 
 - (void)setBackgroundColor: (CGColorRef)backgroundColor
@@ -963,14 +966,20 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   [layer removeFromSuperlayer];
   [mutableSublayers addObject: layer];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (void)removeFromSuperlayer
 {
-  NSMutableArray * mutableSublayersOfSuperlayer = (NSMutableArray*)[[self superlayer] sublayers];
+  CALayer * above = [self superlayer];
+  NSMutableArray * mutableSublayersOfSuperlayer
+    = (NSMutableArray*)[above sublayers];
 
   [mutableSublayersOfSuperlayer removeObject: self];
   [self setSuperlayer: nil];
+
+  /* The layer it has left has one fewer to arrange. */
+  [above setNeedsLayout];
 }
 
 - (void) insertSublayer: (CALayer *)layer atIndex: (unsigned)index
@@ -980,6 +989,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   [layer removeFromSuperlayer];
   [mutableSublayers insertObject: layer atIndex: index];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (void) insertSublayer: (CALayer *)layer below: (CALayer *)sibling;
@@ -991,6 +1001,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (void) insertSublayer: (CALayer *)layer above: (CALayer *)sibling;
@@ -1002,6 +1013,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex+1];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (CALayer *) rootLayer

--- a/Tests/quartzcore/CALayer/display.m
+++ b/Tests/quartzcore/CALayer/display.m
@@ -1,0 +1,60 @@
+/* When a layer decides it needs drawing again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants drawing")
+
+  CALayer *l = [CALayer layer];
+
+  [l setBounds: CGRectMake(0, 0, 50, 50)];
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "a layer that has drawn does not want drawing");
+
+  [l setNeedsDisplay];
+  PASS([l needsDisplay] == YES, "asking for drawing sets the flag");
+
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "drawing when needed clears it");
+
+  [l setNeedsDisplayInRect: CGRectMake(0, 0, 10, 10)];
+  PASS([l needsDisplay] == YES, "asking for part of it sets the flag too");
+
+  [l displayIfNeeded];
+
+  testHopeful = YES;
+  [l setNeedsDisplay];
+  [l display];
+  PASS([l needsDisplay] == NO, "drawing outright clears it as well");
+  testHopeful = NO;
+
+  END_SET("the flag that says a layer wants drawing")
+
+  START_SET("redrawing when the bounds change")
+
+  CALayer *off = [CALayer layer];
+
+  [off displayIfNeeded];
+  [off setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([off needsDisplay] == NO,
+       "a bounds change alone does not ask for drawing");
+
+  CALayer *on = [CALayer layer];
+
+  [on setNeedsDisplayOnBoundsChange: YES];
+  [on displayIfNeeded];
+  [on setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([on needsDisplay] == YES,
+       "a layer told to redraw on a bounds change asks for drawing");
+
+  END_SET("redrawing when the bounds change")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -87,6 +87,50 @@ int main(void)
 
   END_SET("laying out a tree")
 
+  /* A layer whose sublayers have changed has them to arrange again. */
+  START_SET("what makes a layer want laying out")
+
+  CALayer *root = [CALayer layer];
+  CALayer *first = [CALayer layer];
+
+  [root setBounds: CGRectMake(0, 0, 100, 100)];
+  [root addSublayer: first];
+  [root layoutIfNeeded];
+  PASS([root needsLayout] == NO, "a layer just laid out is settled");
+
+  [root addSublayer: [CALayer layer]];
+  PASS([root needsLayout] == YES, "adding a sublayer unsettles it");
+
+  [root layoutIfNeeded];
+  [root insertSublayer: [CALayer layer] atIndex: 0];
+  PASS([root needsLayout] == YES, "so does inserting one at an index");
+
+  [root layoutIfNeeded];
+  [root insertSublayer: [CALayer layer] below: first];
+  PASS([root needsLayout] == YES, "and inserting one below another");
+
+  [root layoutIfNeeded];
+  [root insertSublayer: [CALayer layer] above: first];
+  PASS([root needsLayout] == YES, "and inserting one above another");
+
+  [root layoutIfNeeded];
+  [first removeFromSuperlayer];
+  PASS([root needsLayout] == YES,
+       "a sublayer taking itself away unsettles the layer it leaves");
+
+  [root layoutIfNeeded];
+  [root setBounds: CGRectMake(0, 0, 200, 200)];
+  PASS([root needsLayout] == YES, "and so does its own bounds changing");
+
+  CALayer *newcomer = [CALayer layer];
+
+  [newcomer layoutIfNeeded];
+  [root addSublayer: newcomer];
+  PASS([newcomer needsLayout] == NO,
+       "though the layer that was added is not itself unsettled");
+
+  END_SET("what makes a layer want laying out")
+
   [pool release];
   return 0;
 }

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -1,0 +1,92 @@
+/* When a layer decides it needs laying out again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+@interface QCLayoutManager : NSObject
+{
+  int _count;
+}
+- (int) count;
+@end
+
+@implementation QCLayoutManager
+
+- (void) layoutSublayersOfLayer: (CALayer *)layer
+{
+  _count++;
+}
+
+- (int) count
+{
+  return _count;
+}
+
+@end
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants laying out")
+
+  CALayer *l = [CALayer layer];
+
+  PASS([l needsLayout] == NO, "a fresh layer does not want laying out");
+
+  [l setNeedsLayout];
+  PASS([l needsLayout] == YES, "asking for layout sets the flag");
+
+  [l layoutIfNeeded];
+  PASS([l needsLayout] == NO, "laying out when needed clears it");
+
+  [l setNeedsLayout];
+  [l layoutSublayers];
+  PASS([l needsLayout] == YES,
+       "laying the sublayers out does not clear it by itself");
+
+  END_SET("the flag that says a layer wants laying out")
+
+  START_SET("who is asked to do the laying out")
+
+  CALayer *l = [CALayer layer];
+  QCLayoutManager *m = [[[QCLayoutManager alloc] init] autorelease];
+
+  PASS([l layoutManager] == nil, "a layer starts with no layout manager");
+
+  [l setLayoutManager: m];
+  [l setNeedsLayout];
+  [l layoutIfNeeded];
+  PASS([m count] == 1, "the layout manager is asked to lay the sublayers out");
+
+  END_SET("who is asked to do the laying out")
+
+  START_SET("laying out a tree")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  QCLayoutManager *rootManager = [[[QCLayoutManager alloc] init] autorelease];
+  QCLayoutManager *childManager = [[[QCLayoutManager alloc] init] autorelease];
+
+  [root setLayoutManager: rootManager];
+  [child setLayoutManager: childManager];
+  [root addSublayer: child];
+
+  [root setNeedsLayout];
+  [child setNeedsLayout];
+
+  /* Asking the child lays out from the highest layer that wants it. */
+  [child layoutIfNeeded];
+
+  PASS([root needsLayout] == NO, "the layer above is laid out as well");
+  PASS([child needsLayout] == NO, "and so is the one asked");
+  PASS([rootManager count] == 1 && [childManager count] == 1,
+       "each of them lays its own sublayers out once");
+
+  END_SET("laying out a tree")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -1,0 +1,46 @@
+/* The values a transition starts with, and what its setters keep.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a transition starts with")
+
+  CATransition *t = [CATransition animation];
+
+  PASS(t != nil, "a transition can be created");
+  PASS([t isKindOfClass: [CAAnimation class]], "a transition is an animation");
+  PASS([t subtype] == nil, "it starts with no subtype");
+  PASS([t duration] == 0.0, "it starts with a duration of 0");
+
+  /* Apple names this "fade"; the constant for it arrives with #26. */
+  testHopeful = YES;
+  PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
+  testHopeful = NO;
+
+  END_SET("the values a transition starts with")
+
+  START_SET("what a transition's setters keep")
+
+  CATransition *t = [CATransition animation];
+
+  /* Spelled out rather than named, because kCATransitionMoveIn and the
+     subtype constants beside it are declared but defined nowhere until #25. */
+  [t setType: @"moveIn"];
+  PASS([[t type] isEqualToString: @"moveIn"],
+       "the type reads back as it was set");
+
+  [t setSubtype: @"fromLeft"];
+  PASS([[t subtype] isEqualToString: @"fromLeft"],
+       "the subtype reads back as it was set");
+
+  END_SET("what a transition's setters keep")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
A layer does not set its layout flag when its sublayers change, so the layout manager is called once and never again.

Apple sets it after every one of these, which was measured rather than assumed: adding a sublayer, inserting one at an index, inserting below another, inserting above another, a sublayer removing itself, replacing one, and setting the sublayers wholesale. A change to the layer's own bounds sets it as well. The layer being added does not have its own flag set.

This calls -setNeedsLayout from the four methods that add or insert, from -removeFromSuperlayer for the layer being left, and from -setBounds:.

Two of the seven are left to the pull requests that own the methods: -replaceSublayer:with: arrives with #42 and an implemented -setSublayers: with #35, and both need the same line.

The branch carries #39 and #40, for the layout flag this reads, and #19, which rewrote the four methods this touches.

From Tests/quartzcore:

    gnustep-tests CALayer/layout.m

51 passed with 6 failed before this change, and 57 passed after, the one dashed hope throughout being the transition type that waits on #26.
