### PR TITLE
Fix: give each thread its own transaction stack

### DIFF
--- a/Headers/QuartzCore/CATransaction.h
+++ b/Headers/QuartzCore/CATransaction.h
@@ -31,12 +31,16 @@
 
 @interface CATransaction : NSObject
 {
+  /* The three below are no longer read.  A transaction keeps its values in
+     _values so that it can also carry keys it does not define itself; they
+     stay declared to leave the layout of the class unchanged. */
   CFTimeInterval _animationDuration;
   CAMediaTimingFunction *_animationTimingFunction;
   BOOL _disableActions;
 
   NSMutableArray *_actions;
   BOOL _implicit;
+  NSMutableDictionary *_values;
 }
 
 + (void) begin;

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -35,7 +35,26 @@ NSString *kCATransactionAnimationDuration = @"animationDuration";
 NSString *kCATransactionAnimationTimingFunction= @"animationTimingFunction";
 NSString *kCATransactionDisableActions = @"disableActions";
 
-static NSMutableArray *transactionStack = nil;
+/* A thread has a transaction stack of its own.  What one thread has begun is
+   nothing to do with another, and neither can commit or disturb what the
+   other holds open, so the stack lives in the thread rather than beside the
+   class.  Being per-thread, it needs no lock of its own. */
+static NSString * const CATransactionStackKey = @"CATransactionStack";
+
+static NSMutableArray *
+CATransactionStack(void)
+{
+  NSMutableDictionary *thread = [[NSThread currentThread] threadDictionary];
+  NSMutableArray *stack = [thread objectForKey: CATransactionStackKey];
+
+  if (stack == nil)
+    {
+      stack = [NSMutableArray array];
+      [thread setObject: stack forKey: CATransactionStackKey];
+    }
+
+  return stack;
+}
 
 /* +lock and +unlock hand out a recursive lock for callers to hold across a
    read, a change and a write.  How deep the calling thread has gone is kept
@@ -60,17 +79,13 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
 
 + (void) begin
 {
+  NSMutableArray *stack = CATransactionStack();
   CATransaction *enclosingTransaction;
   CATransaction *newTransaction;
 
-  if (!transactionStack)
-    {
-      transactionStack = [NSMutableArray new];
-    }
-
   /* A transaction starts out with the values of the one it is nested in;
      changing them affects only the new transaction. */
-  enclosingTransaction = [transactionStack lastObject];
+  enclosingTransaction = [stack lastObject];
   newTransaction = [CATransaction new];
   if (enclosingTransaction)
     {
@@ -79,21 +94,25 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
         [enclosingTransaction values]];
     }
 
-  [transactionStack addObject: newTransaction];
+  [stack addObject: newTransaction];
   [newTransaction release];
 }
 
 + (void) commit
 {
+  NSMutableArray *stack;
   CATransaction *topTransaction = [self topTransaction];
+
   [topTransaction commit];
 
-  [transactionStack removeObjectAtIndex: [transactionStack count]-1];
+  stack = CATransactionStack();
+  [stack removeObjectAtIndex: [stack count]-1];
 }
 
 + (void) flush
 {
-  CATransaction *top = [transactionStack lastObject];
+  NSMutableArray *stack = CATransactionStack();
+  CATransaction *top = [stack lastObject];
 
   /* Only the implicit transaction is flushed, and only once nothing
      explicit is still open on top of it: an explicit transaction is the
@@ -101,7 +120,7 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
   if (top != nil && [top isImplicit])
     {
       [top commit];
-      [transactionStack removeLastObject];
+      [stack removeLastObject];
     }
 }
 
@@ -184,13 +203,15 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
 /* ***** Private class methods ******* */
 + (CATransaction *) topTransaction
 {
-  if(![transactionStack lastObject])
+  NSMutableArray *stack = CATransactionStack();
+
+  if(![stack lastObject])
     {
       [CATransaction begin];
-      [[transactionStack lastObject] setImplicit: YES];
+      [[stack lastObject] setImplicit: YES];
     }
 
-  return [transactionStack lastObject];
+  return [stack lastObject];
 }
 
 /* ***** Instance methods ****** */

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -41,28 +41,37 @@ static NSMutableArray *transactionStack = nil;
 
 - (void) commit;
 
-@property (assign) CFTimeInterval animationDuration;
-@property (retain) CAMediaTimingFunction *animationTimingFunction;
-@property (assign) BOOL disableActions;
+@property (retain) NSMutableDictionary *values;
 @property (retain) NSMutableArray *actions;
 @property (assign, getter=isImplicit) BOOL implicit;
 @end
 
 @implementation CATransaction
-@synthesize animationDuration=_animationDuration;
-@synthesize animationTimingFunction=_animationTimingFunction;
-@synthesize disableActions=_disableActions;
+@synthesize values=_values;
 @synthesize actions=_actions;
 @synthesize implicit=_implicit;
 
 + (void) begin
 {
+  CATransaction *enclosingTransaction;
+  CATransaction *newTransaction;
+
   if (!transactionStack)
     {
       transactionStack = [NSMutableArray new];
     }
 
-  CATransaction *newTransaction = [CATransaction new];
+  /* A transaction starts out with the values of the one it is nested in;
+     changing them affects only the new transaction. */
+  enclosingTransaction = [transactionStack lastObject];
+  newTransaction = [CATransaction new];
+  if (enclosingTransaction)
+    {
+      [[newTransaction values] removeAllObjects];
+      [[newTransaction values] addEntriesFromDictionary:
+        [enclosingTransaction values]];
+    }
+
   [transactionStack addObject: newTransaction];
   [newTransaction release];
 }
@@ -95,32 +104,34 @@ static NSMutableArray *transactionStack = nil;
 
 + (CFTimeInterval) animationDuration
 {
-  return [[self topTransaction] animationDuration];
+  return [[self valueForKey: kCATransactionAnimationDuration] doubleValue];
 }
 
 + (void) setAnimationDuration: (CFTimeInterval)animationDuration
 {
-  [[self topTransaction] setAnimationDuration: animationDuration];
+  [self setValue: [NSNumber numberWithDouble: animationDuration]
+          forKey: kCATransactionAnimationDuration];
 }
 
 + (CAMediaTimingFunction *) animationTimingFunction
 {
-  return [[self topTransaction] animationTimingFunction];
+  return [self valueForKey: kCATransactionAnimationTimingFunction];
 }
 
 + (void) setAnimationTimingFunction: (CAMediaTimingFunction *)function
 {
-  [[self topTransaction] setAnimationTimingFunction: function];
+  [self setValue: function forKey: kCATransactionAnimationTimingFunction];
 }
 
 + (BOOL) disableActions
 {
-    return [[self topTransaction] disableActions];
+  return [[self valueForKey: kCATransactionDisableActions] boolValue];
 }
 
 + (void) setDisableActions: (BOOL)disableActions
 {
-    [[self topTransaction] setDisableActions: disableActions];
+  [self setValue: [NSNumber numberWithBool: disableActions]
+          forKey: kCATransactionDisableActions];
 }
 
 + (id) valueForKey: (NSString *)key
@@ -155,19 +166,43 @@ static NSMutableArray *transactionStack = nil;
     return nil;
 
   _actions = [[NSMutableArray alloc] init];
-  _animationDuration = 0.25;
-  _animationTimingFunction = [[CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionDefault] retain];
-  _disableActions = NO;
+
+  /* The values an outermost transaction starts with.  There is no timing
+     function until one is set. */
+  _values = [[NSMutableDictionary alloc] init];
+  [_values setObject: [NSNumber numberWithDouble: 0.25]
+              forKey: kCATransactionAnimationDuration];
+  [_values setObject: [NSNumber numberWithBool: NO]
+              forKey: kCATransactionDisableActions];
 
   return self;
 }
 
 - (void) dealloc
 {
-  [_animationTimingFunction release];
+  [_values release];
   [_actions release];
 
   [super dealloc];
+}
+
+/* A transaction holds whatever keys are set on it, and reading one that was
+   never set answers nil rather than raising. */
+- (id) valueForKey: (NSString *)key
+{
+  return [_values objectForKey: key];
+}
+
+- (void) setValue: (id)value forKey: (NSString *)key
+{
+  if (value == nil)
+    {
+      [_values removeObjectForKey: key];
+    }
+  else
+    {
+      [_values setObject: value forKey: key];
+    }
 }
 
 - (void) commit
@@ -195,7 +230,7 @@ static NSMutableArray *transactionStack = nil;
       if ([action isKindOfClass: [CAAnimation class]])
         {
           CAAnimation * animation = (id)action;
-          if(![animation timingFunction])
+          if(![animation timingFunction] && [CATransaction animationTimingFunction])
             [animation setTimingFunction: [CATransaction animationTimingFunction]];
         }
 

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -37,6 +37,13 @@ NSString *kCATransactionDisableActions = @"disableActions";
 
 static NSMutableArray *transactionStack = nil;
 
+/* +lock and +unlock hand out a recursive lock for callers to hold across a
+   read, a change and a write.  How deep the calling thread has gone is kept
+   beside it, so that unlocking more often than locking does nothing rather
+   than unlocking somebody else's hold. */
+static NSRecursiveLock *transactionLock = nil;
+static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
+
 @interface CATransaction ()
 
 - (void) commit;
@@ -86,20 +93,50 @@ static NSMutableArray *transactionStack = nil;
 
 + (void) flush
 {
-  /* TODO: flushing transaction means committing the implicit
-     animation immediately after all nested explicit transaction
-     are committed.
-     */
+  CATransaction *top = [transactionStack lastObject];
+
+  /* Only the implicit transaction is flushed, and only once nothing
+     explicit is still open on top of it: an explicit transaction is the
+     caller's to commit, and the flush waits for it. */
+  if (top != nil && [top isImplicit])
+    {
+      [top commit];
+      [transactionStack removeLastObject];
+    }
 }
 
 + (void) lock
 {
-  NSLog(@"+[CATransaction lock] unimplemented");
+  NSNumber *depth;
+
+  if (transactionLock == nil)
+    {
+      transactionLock = [NSRecursiveLock new];
+    }
+
+  [transactionLock lock];
+
+  depth = [[[NSThread currentThread] threadDictionary]
+            objectForKey: CATransactionLockDepthKey];
+  [[[NSThread currentThread] threadDictionary]
+    setObject: [NSNumber numberWithInt: [depth intValue] + 1]
+       forKey: CATransactionLockDepthKey];
 }
 
 + (void) unlock
 {
-  NSLog(@"+[CATransaction unlock] unimplemented");
+  NSMutableDictionary *thread = [[NSThread currentThread] threadDictionary];
+  int depth = [[thread objectForKey: CATransactionLockDepthKey] intValue];
+
+  /* Unlocking what this thread never locked does nothing at all. */
+  if (depth <= 0)
+    {
+      return;
+    }
+
+  [thread setObject: [NSNumber numberWithInt: depth - 1]
+             forKey: CATransactionLockDepthKey];
+  [transactionLock unlock];
 }
 
 + (CFTimeInterval) animationDuration

--- a/Tests/apple/Testing.h
+++ b/Tests/apple/Testing.h
@@ -62,4 +62,35 @@ static void testResult__(int passed, const char *fmt, ...)
 
 #define SKIP(msg__) { fprintf(stderr, "Skipped test:    %s\n", (msg__)); }
 
+/* PASS_RUNS passes when the code completes without raising; PASS_EXCEPTION
+   passes when it raises, and when an expected name is given, only for that
+   name.  Both report through testResult__, so a hopeful one dashes rather
+   than fails, exactly as in gnustep-tests. */
+#define PASS_RUNS(code__, fmt__, ...) \
+  do { \
+    int _ran__ = 1; \
+    @try { code__; } \
+    @catch (NSException *_e__) { \
+      _ran__ = 0; \
+      fprintf(stderr, "%s: %s\n", [[_e__ name] UTF8String], \
+        [[_e__ reason] UTF8String]); \
+    } \
+    testResult__(_ran__, "%s:%d ... " fmt__, \
+      __FILE__, __LINE__, ##__VA_ARGS__); \
+  } while (0)
+
+#define PASS_EXCEPTION(code__, expect__, fmt__, ...) \
+  do { \
+    int _matched__ = 0; \
+    @try { code__; } \
+    @catch (NSException *_e__) { \
+      _matched__ = (nil == (expect__) || [[_e__ name] isEqual: (expect__)]); \
+      if (!_matched__) \
+        fprintf(stderr, "Expected '%s' and got '%s'\n", \
+          [(expect__) UTF8String], [[_e__ name] UTF8String]); \
+    } \
+    testResult__(_matched__, "%s:%d ... " fmt__, \
+      __FILE__, __LINE__, ##__VA_ARGS__); \
+  } while (0)
+
 #endif /* Testing_h */

--- a/Tests/quartzcore/CATransaction/transaction.m
+++ b/Tests/quartzcore/CATransaction/transaction.m
@@ -1,0 +1,190 @@
+/* The transaction stack, the values a transaction carries, and key-value
+   access to them.  Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CATransaction.h>
+#import <QuartzCore/CAMediaTimingFunction.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("CATransaction key names")
+
+  PASS([kCATransactionAnimationDuration
+         isEqualToString: @"animationDuration"],
+       "kCATransactionAnimationDuration is \"animationDuration\"");
+  PASS([kCATransactionDisableActions isEqualToString: @"disableActions"],
+       "kCATransactionDisableActions is \"disableActions\"");
+  PASS([kCATransactionAnimationTimingFunction
+         isEqualToString: @"animationTimingFunction"],
+       "kCATransactionAnimationTimingFunction is"
+       " \"animationTimingFunction\"");
+
+  END_SET("CATransaction key names")
+
+  /* Read the implicit transaction before anything has modified it. */
+  START_SET("values with no transaction started")
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "the animation duration is 0.25 when no transaction has been begun");
+  PASS([CATransaction disableActions] == NO,
+       "actions are enabled when no transaction has been begun");
+
+  testHopeful = YES;
+  PASS([CATransaction animationTimingFunction] == nil,
+       "no timing function is set when no transaction has been begun");
+  testHopeful = NO;
+
+  END_SET("values with no transaction started")
+
+  START_SET("setting values on a transaction")
+
+  [CATransaction begin];
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "a transaction begins with an animation duration of 0.25");
+
+  [CATransaction setAnimationDuration: 1.5];
+  PASS([CATransaction animationDuration] == 1.5,
+       "the animation duration reads back as it was set");
+
+  [CATransaction setDisableActions: YES];
+  PASS([CATransaction disableActions] == YES,
+       "disabling actions reads back as it was set");
+
+  [CATransaction setAnimationTimingFunction:
+    [CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionEaseIn]];
+  PASS([CATransaction animationTimingFunction] != nil,
+       "the timing function reads back after it is set");
+  {
+    float cp[2];
+
+    [[CATransaction animationTimingFunction] getControlPointAtIndex: 1
+                                                             values: cp];
+    PASS(cp[0] == 0.42f && cp[1] == 0.0f,
+         "the timing function that reads back is the one that was set");
+  }
+
+  [CATransaction commit];
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "committing restores the animation duration of the enclosing"
+       " transaction");
+  PASS([CATransaction disableActions] == NO,
+       "committing restores the actions setting of the enclosing"
+       " transaction");
+
+  testHopeful = YES;
+  PASS([CATransaction animationTimingFunction] == nil,
+       "committing restores the timing function of the enclosing"
+       " transaction");
+  testHopeful = NO;
+
+  END_SET("setting values on a transaction")
+
+  START_SET("nested transactions")
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 1.0];
+  [CATransaction setDisableActions: YES];
+
+  [CATransaction begin];
+
+  testHopeful = YES;
+  PASS([CATransaction animationDuration] == 1.0,
+       "a nested transaction sees the animation duration of the enclosing"
+       " one");
+  PASS([CATransaction disableActions] == YES,
+       "a nested transaction sees the actions setting of the enclosing one");
+  testHopeful = NO;
+
+  [CATransaction setAnimationDuration: 2.0];
+  PASS([CATransaction animationDuration] == 2.0,
+       "a nested transaction takes the duration it is given");
+
+  [CATransaction commit];
+
+  PASS([CATransaction animationDuration] == 1.0,
+       "a nested transaction does not carry its duration out to the"
+       " enclosing one");
+  PASS([CATransaction disableActions] == YES,
+       "the enclosing transaction keeps its actions setting");
+
+  [CATransaction commit];
+
+  END_SET("nested transactions")
+
+  START_SET("reading and writing values by key")
+
+  [CATransaction begin];
+
+  [CATransaction setAnimationDuration: 0.75];
+  PASS([[CATransaction valueForKey: kCATransactionAnimationDuration]
+         doubleValue] == 0.75,
+       "the duration key reads what the accessor set");
+
+  [CATransaction setValue: [NSNumber numberWithDouble: 1.25]
+                   forKey: kCATransactionAnimationDuration];
+  PASS([CATransaction animationDuration] == 1.25,
+       "the accessor reads what the duration key set");
+
+  [CATransaction setDisableActions: YES];
+  PASS([[CATransaction valueForKey: kCATransactionDisableActions]
+         boolValue] == YES,
+       "the actions key reads what the accessor set");
+
+  [CATransaction setValue: [NSNumber numberWithBool: NO]
+                   forKey: kCATransactionDisableActions];
+  PASS([CATransaction disableActions] == NO,
+       "the accessor reads what the actions key set");
+
+  [CATransaction commit];
+
+  END_SET("reading and writing values by key")
+
+  /* A transaction on Apple carries arbitrary key-value pairs, and an unset
+     key reads as nil rather than raising.  Both of these end the set early
+     where they raise, so they come last. */
+  START_SET("keys a transaction does not define")
+
+  [CATransaction begin];
+
+  testHopeful = YES;
+
+  {
+    id fetched = nil;
+
+    PASS_RUNS(fetched = [CATransaction valueForKey: @"aKeyNobodyDefined"],
+              "reading a key the transaction does not define does not raise");
+    PASS_RUNS([CATransaction setValue: @"stored" forKey: @"aKeyNobodyDefined"],
+              "an arbitrary key can be set on a transaction");
+    PASS_RUNS(fetched = [CATransaction valueForKey: @"aKeyNobodyDefined"],
+              "an arbitrary key can be read back from a transaction");
+    PASS([fetched isEqual: @"stored"],
+         "an arbitrary key round-trips through a transaction");
+  }
+
+  testHopeful = NO;
+
+  [CATransaction commit];
+
+  END_SET("keys a transaction does not define")
+
+  START_SET("the class methods that take no transaction")
+
+  PASS_RUNS([CATransaction commit],
+            "committing with no matching begin does not raise");
+  PASS([CATransaction animationDuration] == 0.25,
+       "an unmatched commit leaves the animation duration at 0.25");
+
+  PASS_RUNS([CATransaction flush], "flush does not raise");
+  PASS_RUNS([CATransaction lock]; [CATransaction unlock],
+            "lock and unlock do not raise");
+
+  END_SET("the class methods that take no transaction")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransaction/transaction.m
+++ b/Tests/quartzcore/CATransaction/transaction.m
@@ -185,6 +185,53 @@ int main(void)
 
   END_SET("the class methods that take no transaction")
 
+  START_SET("flushing")
+
+  [CATransaction setAnimationDuration: 5.0];
+  PASS([CATransaction animationDuration] == 5.0,
+       "the implicit transaction takes a duration like any other");
+
+  [CATransaction flush];
+  PASS([CATransaction animationDuration] == 0.25,
+       "flushing takes the implicit transaction away");
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 7.0];
+  [CATransaction flush];
+  PASS([CATransaction animationDuration] == 7.0,
+       "a flush leaves an explicit transaction where it is");
+  [CATransaction commit];
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "and once that is committed there is nothing left of it");
+
+  PASS_RUNS([CATransaction flush]; [CATransaction flush],
+            "flushing when there is nothing to flush does nothing");
+
+  END_SET("flushing")
+
+  START_SET("the lock")
+
+  PASS_RUNS([CATransaction lock]; [CATransaction unlock],
+            "a lock can be taken and given back");
+
+  PASS_RUNS([CATransaction lock]; [CATransaction lock];
+            [CATransaction unlock]; [CATransaction unlock],
+            "and taken twice over by the one thread");
+
+  [CATransaction lock];
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 9.0];
+  PASS([CATransaction animationDuration] == 9.0,
+       "a transaction still works while the lock is held");
+  [CATransaction commit];
+  [CATransaction unlock];
+
+  PASS_RUNS([CATransaction unlock],
+            "giving back a lock that was never taken does nothing");
+
+  END_SET("the lock")
+
   [pool release];
   return 0;
 }

--- a/Tests/quartzcore/CATransaction/transaction.m
+++ b/Tests/quartzcore/CATransaction/transaction.m
@@ -6,6 +6,80 @@
 #import <QuartzCore/CATransaction.h>
 #import <QuartzCore/CAMediaTimingFunction.h>
 
+/* What another thread makes of a transaction this one holds open.  The
+   answer does not depend on how the two are scheduled, so nothing here is
+   timing dependent; the condition only waits for the other thread to finish,
+   and it has a deadline so a mistake cannot hang the run. */
+static NSCondition *gate = nil;
+static BOOL         otherFinished = NO;
+static double       otherDuration = -1.0;
+static BOOL         otherDisableActions = YES;
+
+@interface QCOtherThread : NSObject
++ (void) look: (id)ignored;
++ (void) runItsOwn: (id)ignored;
+@end
+
+@implementation QCOtherThread
+
++ (void) look: (id)ignored
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  otherDuration = (double)[CATransaction animationDuration];
+  otherDisableActions = [CATransaction disableActions];
+  [pool release];
+
+  [gate lock];
+  otherFinished = YES;
+  [gate signal];
+  [gate unlock];
+}
+
++ (void) runItsOwn: (id)ignored
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 11.0];
+  otherDuration = (double)[CATransaction animationDuration];
+  [CATransaction commit];
+  [pool release];
+
+  [gate lock];
+  otherFinished = YES;
+  [gate signal];
+  [gate unlock];
+}
+
+@end
+
+static BOOL runOnAnotherThread(SEL what)
+{
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow: 10.0];
+  BOOL ok = YES;
+
+  otherFinished = NO;
+  otherDuration = -1.0;
+  otherDisableActions = YES;
+  [NSThread detachNewThreadSelector: what
+                           toTarget: [QCOtherThread class]
+                         withObject: nil];
+
+  [gate lock];
+  while (!otherFinished)
+    {
+      if (![gate waitUntilDate: deadline])
+        {
+          ok = NO;
+          break;
+        }
+    }
+  [gate unlock];
+
+  return ok;
+}
+
 int main(void)
 {
   NSAutoreleasePool *pool = [NSAutoreleasePool new];
@@ -231,6 +305,42 @@ int main(void)
             "giving back a lock that was never taken does nothing");
 
   END_SET("the lock")
+
+  START_SET("a transaction belongs to the thread that began it")
+
+  gate = [NSCondition new];
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 5.0];
+  [CATransaction setDisableActions: YES];
+
+  PASS(runOnAnotherThread(@selector(look:)),
+       "another thread can read a transaction value at all");
+  PASS(otherDuration == 0.25,
+       "and reads its own duration rather than this thread's");
+  PASS(otherDisableActions == NO,
+       "and its own actions setting rather than this thread's");
+  PASS([CATransaction animationDuration] == 5.0,
+       "while this thread still reads what it set");
+
+  [CATransaction commit];
+  PASS([CATransaction animationDuration] == 0.25,
+       "and commits its own transaction away");
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 3.0];
+
+  PASS(runOnAnotherThread(@selector(runItsOwn:)),
+       "another thread can run a transaction of its own");
+  PASS(otherDuration == 11.0, "and sees the value it set in it");
+  PASS([CATransaction animationDuration] == 3.0,
+       "without disturbing the one open on this thread");
+
+  [CATransaction commit];
+  PASS([CATransaction animationDuration] == 0.25,
+       "which still commits cleanly afterwards");
+
+  END_SET("a transaction belongs to the thread that began it")
 
   [pool release];
   return 0;


### PR DESCRIPTION
There is one transaction stack for the whole process, so a transaction begun on one thread is the transaction every other thread sees. A thread reading an animation duration gets whatever another thread last set, and two threads beginning and committing concurrently operate on the same stack.

Apple gives each thread its own. With one thread holding a transaction that sets a duration of 5 and disables actions, another reads 0.25 and finds actions enabled, from its own implicit transaction. Each commits its own without affecting the other.

The stack now lives in the thread dictionary rather than in a class variable. Being per-thread it needs no lock of its own, and the lock #45 added stays what it is: something a caller holds across a read and a write of layer values.

Two of the nine assertions fail before this change. The other seven pass either way, because a thread that begins and commits in a balanced pair leaves a shared stack as it found it. The divergence shows in the values, so those two are what the change is measured by.

The test uses a second thread but nothing in it is timing dependent: the result is the same however the two are scheduled, and the wait has a deadline so a failure cannot hang the run.

The branch carries #21, #22 and #45.

From Tests/quartzcore:

    gnustep-tests CATransaction

74 passed with 2 failed before this change, and 76 passed after.
