### PR TITLE
Feature: be told once a transaction has been committed

### DIFF
--- a/Headers/QuartzCore/CATransaction.h
+++ b/Headers/QuartzCore/CATransaction.h
@@ -62,13 +62,24 @@
 + (BOOL) disableActions;
 + (void) setDisableActions: (BOOL)disableActions;
 
+/* Something to do once the transaction has been committed.  Each of these
+   adds to what will be run; setting one does not replace what was set
+   before.
+
+   The target and selector form is here so that a compiler without blocks can
+   still ask to be told, and so that this header can be read by one. */
++ (void) setCompletionTarget: (id)target selector: (SEL)selector;
+
+#if defined(__BLOCKS__)
++ (void (^)(void)) completionBlock;
++ (void) setCompletionBlock: (void (^)(void))block;
+#endif
+
 @end
 
 extern NSString *kCATransactionAnimationDuration;
 extern NSString *kCATransactionAnimationTimingFunction;
 extern NSString *kCATransactionDisableActions;
-
-// TODO: setValue:forKey: for constants:
-// - kCATransactionCompletionBlock
+extern NSString *kCATransactionCompletionBlock;
 
 /* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Headers/QuartzCore/CATransaction.h
+++ b/Headers/QuartzCore/CATransaction.h
@@ -31,12 +31,16 @@
 
 @interface CATransaction : NSObject
 {
+  /* The three below are no longer read.  A transaction keeps its values in
+     _values so that it can also carry keys it does not define itself; they
+     stay declared to leave the layout of the class unchanged. */
   CFTimeInterval _animationDuration;
   CAMediaTimingFunction *_animationTimingFunction;
   BOOL _disableActions;
 
   NSMutableArray *_actions;
   BOOL _implicit;
+  NSMutableDictionary *_values;
 }
 
 + (void) begin;

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -35,7 +35,26 @@ NSString *kCATransactionAnimationDuration = @"animationDuration";
 NSString *kCATransactionAnimationTimingFunction= @"animationTimingFunction";
 NSString *kCATransactionDisableActions = @"disableActions";
 
-static NSMutableArray *transactionStack = nil;
+/* A thread has a transaction stack of its own.  What one thread has begun is
+   nothing to do with another, and neither can commit or disturb what the
+   other holds open, so the stack lives in the thread rather than beside the
+   class.  Being per-thread, it needs no lock of its own. */
+static NSString * const CATransactionStackKey = @"CATransactionStack";
+
+static NSMutableArray *
+CATransactionStack(void)
+{
+  NSMutableDictionary *thread = [[NSThread currentThread] threadDictionary];
+  NSMutableArray *stack = [thread objectForKey: CATransactionStackKey];
+
+  if (stack == nil)
+    {
+      stack = [NSMutableArray array];
+      [thread setObject: stack forKey: CATransactionStackKey];
+    }
+
+  return stack;
+}
 
 /* +lock and +unlock hand out a recursive lock for callers to hold across a
    read, a change and a write.  How deep the calling thread has gone is kept
@@ -60,17 +79,13 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
 
 + (void) begin
 {
+  NSMutableArray *stack = CATransactionStack();
   CATransaction *enclosingTransaction;
   CATransaction *newTransaction;
 
-  if (!transactionStack)
-    {
-      transactionStack = [NSMutableArray new];
-    }
-
   /* A transaction starts out with the values of the one it is nested in;
      changing them affects only the new transaction. */
-  enclosingTransaction = [transactionStack lastObject];
+  enclosingTransaction = [stack lastObject];
   newTransaction = [CATransaction new];
   if (enclosingTransaction)
     {
@@ -79,21 +94,25 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
         [enclosingTransaction values]];
     }
 
-  [transactionStack addObject: newTransaction];
+  [stack addObject: newTransaction];
   [newTransaction release];
 }
 
 + (void) commit
 {
+  NSMutableArray *stack;
   CATransaction *topTransaction = [self topTransaction];
+
   [topTransaction commit];
 
-  [transactionStack removeObjectAtIndex: [transactionStack count]-1];
+  stack = CATransactionStack();
+  [stack removeObjectAtIndex: [stack count]-1];
 }
 
 + (void) flush
 {
-  CATransaction *top = [transactionStack lastObject];
+  NSMutableArray *stack = CATransactionStack();
+  CATransaction *top = [stack lastObject];
 
   /* Only the implicit transaction is flushed, and only once nothing
      explicit is still open on top of it: an explicit transaction is the
@@ -101,7 +120,7 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
   if (top != nil && [top isImplicit])
     {
       [top commit];
-      [transactionStack removeLastObject];
+      [stack removeLastObject];
     }
 }
 
@@ -184,13 +203,15 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
 /* ***** Private class methods ******* */
 + (CATransaction *) topTransaction
 {
-  if(![transactionStack lastObject])
+  NSMutableArray *stack = CATransactionStack();
+
+  if(![stack lastObject])
     {
       [CATransaction begin];
-      [[transactionStack lastObject] setImplicit: YES];
+      [[stack lastObject] setImplicit: YES];
     }
 
-  return [transactionStack lastObject];
+  return [stack lastObject];
 }
 
 /* ***** Instance methods ****** */

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -34,6 +34,47 @@
 NSString *kCATransactionAnimationDuration = @"animationDuration";
 NSString *kCATransactionAnimationTimingFunction= @"animationTimingFunction";
 NSString *kCATransactionDisableActions = @"disableActions";
+NSString *kCATransactionCompletionBlock = @"completionBlock";
+
+#if defined(__BLOCKS__)
+/* Something invocable holding a block, so that everything waiting on a commit
+   can be scheduled the same way whether it came from a block or from a target
+   and a selector. */
+@interface CACompletionBlockHolder : NSObject
+{
+  void (^_block)(void);
+}
+- (id) initWithBlock: (void (^)(void))block;
+- (void) invoke;
+@end
+
+@implementation CACompletionBlockHolder
+
+- (id) initWithBlock: (void (^)(void))block
+{
+  if ((self = [super init]) != nil)
+    {
+      _block = [block copy];
+    }
+  return self;
+}
+
+- (void) invoke
+{
+  if (_block != NULL)
+    {
+      _block();
+    }
+}
+
+- (void) dealloc
+{
+  [_block release];
+  [super dealloc];
+}
+
+@end
+#endif
 
 /* A thread has a transaction stack of its own.  What one thread has begun is
    nothing to do with another, and neither can commit or disturb what the
@@ -69,12 +110,14 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
 
 @property (retain) NSMutableDictionary *values;
 @property (retain) NSMutableArray *actions;
+@property (retain) NSMutableArray *completions;
 @property (assign, getter=isImplicit) BOOL implicit;
 @end
 
 @implementation CATransaction
 @synthesize values=_values;
 @synthesize actions=_actions;
+@synthesize completions=_completions;
 @synthesize implicit=_implicit;
 
 + (void) begin
@@ -190,6 +233,49 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
           forKey: kCATransactionDisableActions];
 }
 
++ (void) setCompletionTarget: (id)target selector: (SEL)selector
+{
+  NSInvocation *invocation;
+
+  if (target == nil || selector == NULL)
+    {
+      return;
+    }
+
+  invocation = [NSInvocation invocationWithMethodSignature:
+                 [target methodSignatureForSelector: selector]];
+  [invocation setTarget: target];
+  [invocation setSelector: selector];
+  [invocation retainArguments];
+  [[[self topTransaction] completions] addObject: invocation];
+}
+
+#if defined(__BLOCKS__)
++ (void (^)(void)) completionBlock
+{
+  return [self valueForKey: kCATransactionCompletionBlock];
+}
+
++ (void) setCompletionBlock: (void (^)(void))block
+{
+  CATransaction *transaction = [self topTransaction];
+
+  /* Each block set adds to what will run; the one most recently set is also
+     what the getter answers, and a nil clears that without taking away what
+     was already asked for. */
+  if (block != NULL)
+    {
+      CACompletionBlockHolder *holder =
+        [[CACompletionBlockHolder alloc] initWithBlock: block];
+
+      [[transaction completions] addObject: holder];
+      [holder release];
+    }
+
+  [transaction setValue: block forKey: kCATransactionCompletionBlock];
+}
+#endif
+
 + (id) valueForKey: (NSString *)key
 {
   return [[self topTransaction] valueForKey: key];
@@ -224,6 +310,7 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
     return nil;
 
   _actions = [[NSMutableArray alloc] init];
+  _completions = [[NSMutableArray alloc] init];
 
   /* The values an outermost transaction starts with.  There is no timing
      function until one is set. */
@@ -240,6 +327,7 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
 {
   [_values release];
   [_actions release];
+  [_completions release];
 
   [super dealloc];
 }
@@ -297,6 +385,24 @@ static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
                     arguments: arguments];
     }
   [_actions removeAllObjects];
+
+  /* Whatever was asked to be told about the commit is told on a later turn
+     of this thread's run loop rather than here, so that a caller committing
+     is not made to wait on it. */
+  {
+    NSInvocation *completion;
+
+    for (completion in _completions)
+      {
+        [[NSRunLoop currentRunLoop] performSelector: @selector(invoke)
+                                             target: completion
+                                           argument: nil
+                                              order: 0
+                                              modes: [NSArray arrayWithObject:
+                                                       NSDefaultRunLoopMode]];
+      }
+    [_completions removeAllObjects];
+  }
 }
 
 - (void)registerAction: (NSObject<CAAction> *)action

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -41,28 +41,37 @@ static NSMutableArray *transactionStack = nil;
 
 - (void) commit;
 
-@property (assign) CFTimeInterval animationDuration;
-@property (retain) CAMediaTimingFunction *animationTimingFunction;
-@property (assign) BOOL disableActions;
+@property (retain) NSMutableDictionary *values;
 @property (retain) NSMutableArray *actions;
 @property (assign, getter=isImplicit) BOOL implicit;
 @end
 
 @implementation CATransaction
-@synthesize animationDuration=_animationDuration;
-@synthesize animationTimingFunction=_animationTimingFunction;
-@synthesize disableActions=_disableActions;
+@synthesize values=_values;
 @synthesize actions=_actions;
 @synthesize implicit=_implicit;
 
 + (void) begin
 {
+  CATransaction *enclosingTransaction;
+  CATransaction *newTransaction;
+
   if (!transactionStack)
     {
       transactionStack = [NSMutableArray new];
     }
 
-  CATransaction *newTransaction = [CATransaction new];
+  /* A transaction starts out with the values of the one it is nested in;
+     changing them affects only the new transaction. */
+  enclosingTransaction = [transactionStack lastObject];
+  newTransaction = [CATransaction new];
+  if (enclosingTransaction)
+    {
+      [[newTransaction values] removeAllObjects];
+      [[newTransaction values] addEntriesFromDictionary:
+        [enclosingTransaction values]];
+    }
+
   [transactionStack addObject: newTransaction];
   [newTransaction release];
 }
@@ -95,32 +104,34 @@ static NSMutableArray *transactionStack = nil;
 
 + (CFTimeInterval) animationDuration
 {
-  return [[self topTransaction] animationDuration];
+  return [[self valueForKey: kCATransactionAnimationDuration] doubleValue];
 }
 
 + (void) setAnimationDuration: (CFTimeInterval)animationDuration
 {
-  [[self topTransaction] setAnimationDuration: animationDuration];
+  [self setValue: [NSNumber numberWithDouble: animationDuration]
+          forKey: kCATransactionAnimationDuration];
 }
 
 + (CAMediaTimingFunction *) animationTimingFunction
 {
-  return [[self topTransaction] animationTimingFunction];
+  return [self valueForKey: kCATransactionAnimationTimingFunction];
 }
 
 + (void) setAnimationTimingFunction: (CAMediaTimingFunction *)function
 {
-  [[self topTransaction] setAnimationTimingFunction: function];
+  [self setValue: function forKey: kCATransactionAnimationTimingFunction];
 }
 
 + (BOOL) disableActions
 {
-    return [[self topTransaction] disableActions];
+  return [[self valueForKey: kCATransactionDisableActions] boolValue];
 }
 
 + (void) setDisableActions: (BOOL)disableActions
 {
-    [[self topTransaction] setDisableActions: disableActions];
+  [self setValue: [NSNumber numberWithBool: disableActions]
+          forKey: kCATransactionDisableActions];
 }
 
 + (id) valueForKey: (NSString *)key
@@ -155,19 +166,43 @@ static NSMutableArray *transactionStack = nil;
     return nil;
 
   _actions = [[NSMutableArray alloc] init];
-  _animationDuration = 0.25;
-  _animationTimingFunction = [[CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionDefault] retain];
-  _disableActions = NO;
+
+  /* The values an outermost transaction starts with.  There is no timing
+     function until one is set. */
+  _values = [[NSMutableDictionary alloc] init];
+  [_values setObject: [NSNumber numberWithDouble: 0.25]
+              forKey: kCATransactionAnimationDuration];
+  [_values setObject: [NSNumber numberWithBool: NO]
+              forKey: kCATransactionDisableActions];
 
   return self;
 }
 
 - (void) dealloc
 {
-  [_animationTimingFunction release];
+  [_values release];
   [_actions release];
 
   [super dealloc];
+}
+
+/* A transaction holds whatever keys are set on it, and reading one that was
+   never set answers nil rather than raising. */
+- (id) valueForKey: (NSString *)key
+{
+  return [_values objectForKey: key];
+}
+
+- (void) setValue: (id)value forKey: (NSString *)key
+{
+  if (value == nil)
+    {
+      [_values removeObjectForKey: key];
+    }
+  else
+    {
+      [_values setObject: value forKey: key];
+    }
 }
 
 - (void) commit
@@ -195,7 +230,7 @@ static NSMutableArray *transactionStack = nil;
       if ([action isKindOfClass: [CAAnimation class]])
         {
           CAAnimation * animation = (id)action;
-          if(![animation timingFunction])
+          if(![animation timingFunction] && [CATransaction animationTimingFunction])
             [animation setTimingFunction: [CATransaction animationTimingFunction]];
         }
 

--- a/Source/CATransaction.m
+++ b/Source/CATransaction.m
@@ -37,6 +37,13 @@ NSString *kCATransactionDisableActions = @"disableActions";
 
 static NSMutableArray *transactionStack = nil;
 
+/* +lock and +unlock hand out a recursive lock for callers to hold across a
+   read, a change and a write.  How deep the calling thread has gone is kept
+   beside it, so that unlocking more often than locking does nothing rather
+   than unlocking somebody else's hold. */
+static NSRecursiveLock *transactionLock = nil;
+static NSString * const CATransactionLockDepthKey = @"CATransactionLockDepth";
+
 @interface CATransaction ()
 
 - (void) commit;
@@ -86,20 +93,50 @@ static NSMutableArray *transactionStack = nil;
 
 + (void) flush
 {
-  /* TODO: flushing transaction means committing the implicit
-     animation immediately after all nested explicit transaction
-     are committed.
-     */
+  CATransaction *top = [transactionStack lastObject];
+
+  /* Only the implicit transaction is flushed, and only once nothing
+     explicit is still open on top of it: an explicit transaction is the
+     caller's to commit, and the flush waits for it. */
+  if (top != nil && [top isImplicit])
+    {
+      [top commit];
+      [transactionStack removeLastObject];
+    }
 }
 
 + (void) lock
 {
-  NSLog(@"+[CATransaction lock] unimplemented");
+  NSNumber *depth;
+
+  if (transactionLock == nil)
+    {
+      transactionLock = [NSRecursiveLock new];
+    }
+
+  [transactionLock lock];
+
+  depth = [[[NSThread currentThread] threadDictionary]
+            objectForKey: CATransactionLockDepthKey];
+  [[[NSThread currentThread] threadDictionary]
+    setObject: [NSNumber numberWithInt: [depth intValue] + 1]
+       forKey: CATransactionLockDepthKey];
 }
 
 + (void) unlock
 {
-  NSLog(@"+[CATransaction unlock] unimplemented");
+  NSMutableDictionary *thread = [[NSThread currentThread] threadDictionary];
+  int depth = [[thread objectForKey: CATransactionLockDepthKey] intValue];
+
+  /* Unlocking what this thread never locked does nothing at all. */
+  if (depth <= 0)
+    {
+      return;
+    }
+
+  [thread setObject: [NSNumber numberWithInt: depth - 1]
+             forKey: CATransactionLockDepthKey];
+  [transactionLock unlock];
 }
 
 + (CFTimeInterval) animationDuration

--- a/Tests/apple/Testing.h
+++ b/Tests/apple/Testing.h
@@ -62,4 +62,35 @@ static void testResult__(int passed, const char *fmt, ...)
 
 #define SKIP(msg__) { fprintf(stderr, "Skipped test:    %s\n", (msg__)); }
 
+/* PASS_RUNS passes when the code completes without raising; PASS_EXCEPTION
+   passes when it raises, and when an expected name is given, only for that
+   name.  Both report through testResult__, so a hopeful one dashes rather
+   than fails, exactly as in gnustep-tests. */
+#define PASS_RUNS(code__, fmt__, ...) \
+  do { \
+    int _ran__ = 1; \
+    @try { code__; } \
+    @catch (NSException *_e__) { \
+      _ran__ = 0; \
+      fprintf(stderr, "%s: %s\n", [[_e__ name] UTF8String], \
+        [[_e__ reason] UTF8String]); \
+    } \
+    testResult__(_ran__, "%s:%d ... " fmt__, \
+      __FILE__, __LINE__, ##__VA_ARGS__); \
+  } while (0)
+
+#define PASS_EXCEPTION(code__, expect__, fmt__, ...) \
+  do { \
+    int _matched__ = 0; \
+    @try { code__; } \
+    @catch (NSException *_e__) { \
+      _matched__ = (nil == (expect__) || [[_e__ name] isEqual: (expect__)]); \
+      if (!_matched__) \
+        fprintf(stderr, "Expected '%s' and got '%s'\n", \
+          [(expect__) UTF8String], [[_e__ name] UTF8String]); \
+    } \
+    testResult__(_matched__, "%s:%d ... " fmt__, \
+      __FILE__, __LINE__, ##__VA_ARGS__); \
+  } while (0)
+
 #endif /* Testing_h */

--- a/Tests/quartzcore/CATransaction/TestInfo
+++ b/Tests/quartzcore/CATransaction/TestInfo
@@ -1,0 +1,3 @@
+# Apple has no completion target and selector method, so that file is not
+# run against it.
+APPLE_SKIP_TESTS="completiontarget.m"

--- a/Tests/quartzcore/CATransaction/completion.m
+++ b/Tests/quartzcore/CATransaction/completion.m
@@ -1,0 +1,119 @@
+/* Being told once a transaction has been committed.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CATransaction.h>
+
+static void turn(void)
+{
+  [[NSRunLoop currentRunLoop] runUntilDate:
+    [NSDate dateWithTimeIntervalSinceNow: 0.3]];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+#if defined(__BLOCKS__)
+  __block int ran = 0;
+
+  START_SET("what the completion block reads as")
+
+  [CATransaction begin];
+  PASS([CATransaction completionBlock] == nil,
+       "a transaction starts with nothing to be told");
+
+  [CATransaction setCompletionBlock: ^{ ran++; }];
+  PASS([CATransaction completionBlock] != nil,
+       "and answers what it was given");
+
+  [CATransaction commit];
+  turn();
+  PASS([CATransaction completionBlock] == nil,
+       "which is gone once that transaction has been committed");
+
+  END_SET("what the completion block reads as")
+
+  START_SET("when it runs")
+
+  ran = 0;
+  [CATransaction begin];
+  [CATransaction setCompletionBlock: ^{ ran++; }];
+  [CATransaction commit];
+  PASS(ran == 0, "committing does not run it there and then");
+
+  turn();
+  PASS(ran == 1, "a turn of the run loop does");
+
+  turn();
+  PASS(ran == 1, "and it runs the once");
+
+  END_SET("when it runs")
+
+  START_SET("a transaction left open")
+
+  ran = 0;
+  [CATransaction begin];
+  [CATransaction setCompletionBlock: ^{ ran++; }];
+  turn();
+  PASS(ran == 0, "a transaction still open does not run it");
+
+  [CATransaction commit];
+  turn();
+  PASS(ran == 1, "committing it does");
+
+  END_SET("a transaction left open")
+
+  START_SET("more than one")
+
+  __block int first = 0;
+  __block int second = 0;
+
+  [CATransaction begin];
+  [CATransaction setCompletionBlock: ^{ first++; }];
+  [CATransaction setCompletionBlock: ^{ second++; }];
+  [CATransaction commit];
+  turn();
+  PASS(first == 1 && second == 1,
+       "setting a second adds to the first rather than replacing it");
+
+  END_SET("more than one")
+
+  START_SET("clearing one")
+
+  ran = 0;
+  [CATransaction begin];
+  [CATransaction setCompletionBlock: ^{ ran++; }];
+  [CATransaction setCompletionBlock: nil];
+  PASS([CATransaction completionBlock] == nil,
+       "clearing it leaves nothing to read");
+  [CATransaction commit];
+  turn();
+  PASS(ran == 1, "but what was already asked for still runs");
+
+  END_SET("clearing one")
+
+  START_SET("a nested transaction")
+
+  ran = 0;
+  [CATransaction begin];
+  [CATransaction setCompletionBlock: ^{ ran++; }];
+
+  [CATransaction begin];
+  PASS([CATransaction completionBlock] != nil,
+       "a nested transaction reads the one it is nested in");
+  [CATransaction commit];
+  turn();
+  PASS(ran == 0, "committing the nested one does not run it");
+
+  [CATransaction commit];
+  turn();
+  PASS(ran == 1, "committing the one that was given it does");
+
+  END_SET("a nested transaction")
+#endif
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransaction/completiontarget.m
+++ b/Tests/quartzcore/CATransaction/completiontarget.m
@@ -1,0 +1,75 @@
+/* Asking to be told about a commit without a block, so that a compiler
+   without them can still be told.  Apple has no such method, so this file is
+   not run against it. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CATransaction.h>
+
+static int told = 0;
+static int toldAgain = 0;
+
+@interface QCTellMe : NSObject
++ (void) tell;
++ (void) tellAgain;
+@end
+
+@implementation QCTellMe
++ (void) tell { told++; }
++ (void) tellAgain { toldAgain++; }
+@end
+
+static void turn(void)
+{
+  [[NSRunLoop currentRunLoop] runUntilDate:
+    [NSDate dateWithTimeIntervalSinceNow: 0.3]];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("being told by target and selector")
+
+  told = 0;
+  [CATransaction begin];
+  [CATransaction setCompletionTarget: [QCTellMe class]
+                            selector: @selector(tell)];
+  [CATransaction commit];
+  PASS(told == 0, "committing does not tell it there and then");
+
+  turn();
+  PASS(told == 1, "a turn of the run loop does");
+
+  turn();
+  PASS(told == 1, "and it is told the once");
+
+  END_SET("being told by target and selector")
+
+  START_SET("more than one to tell")
+
+  told = 0;
+  toldAgain = 0;
+  [CATransaction begin];
+  [CATransaction setCompletionTarget: [QCTellMe class]
+                            selector: @selector(tell)];
+  [CATransaction setCompletionTarget: [QCTellMe class]
+                            selector: @selector(tellAgain)];
+  [CATransaction commit];
+  turn();
+  PASS(told == 1 && toldAgain == 1, "both are told");
+
+  END_SET("more than one to tell")
+
+  START_SET("nothing to tell")
+
+  PASS_RUNS([CATransaction begin];
+            [CATransaction setCompletionTarget: nil selector: NULL];
+            [CATransaction commit],
+            "being given nothing to tell does nothing");
+
+  END_SET("nothing to tell")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransaction/transaction.m
+++ b/Tests/quartzcore/CATransaction/transaction.m
@@ -1,0 +1,190 @@
+/* The transaction stack, the values a transaction carries, and key-value
+   access to them.  Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CATransaction.h>
+#import <QuartzCore/CAMediaTimingFunction.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("CATransaction key names")
+
+  PASS([kCATransactionAnimationDuration
+         isEqualToString: @"animationDuration"],
+       "kCATransactionAnimationDuration is \"animationDuration\"");
+  PASS([kCATransactionDisableActions isEqualToString: @"disableActions"],
+       "kCATransactionDisableActions is \"disableActions\"");
+  PASS([kCATransactionAnimationTimingFunction
+         isEqualToString: @"animationTimingFunction"],
+       "kCATransactionAnimationTimingFunction is"
+       " \"animationTimingFunction\"");
+
+  END_SET("CATransaction key names")
+
+  /* Read the implicit transaction before anything has modified it. */
+  START_SET("values with no transaction started")
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "the animation duration is 0.25 when no transaction has been begun");
+  PASS([CATransaction disableActions] == NO,
+       "actions are enabled when no transaction has been begun");
+
+  testHopeful = YES;
+  PASS([CATransaction animationTimingFunction] == nil,
+       "no timing function is set when no transaction has been begun");
+  testHopeful = NO;
+
+  END_SET("values with no transaction started")
+
+  START_SET("setting values on a transaction")
+
+  [CATransaction begin];
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "a transaction begins with an animation duration of 0.25");
+
+  [CATransaction setAnimationDuration: 1.5];
+  PASS([CATransaction animationDuration] == 1.5,
+       "the animation duration reads back as it was set");
+
+  [CATransaction setDisableActions: YES];
+  PASS([CATransaction disableActions] == YES,
+       "disabling actions reads back as it was set");
+
+  [CATransaction setAnimationTimingFunction:
+    [CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionEaseIn]];
+  PASS([CATransaction animationTimingFunction] != nil,
+       "the timing function reads back after it is set");
+  {
+    float cp[2];
+
+    [[CATransaction animationTimingFunction] getControlPointAtIndex: 1
+                                                             values: cp];
+    PASS(cp[0] == 0.42f && cp[1] == 0.0f,
+         "the timing function that reads back is the one that was set");
+  }
+
+  [CATransaction commit];
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "committing restores the animation duration of the enclosing"
+       " transaction");
+  PASS([CATransaction disableActions] == NO,
+       "committing restores the actions setting of the enclosing"
+       " transaction");
+
+  testHopeful = YES;
+  PASS([CATransaction animationTimingFunction] == nil,
+       "committing restores the timing function of the enclosing"
+       " transaction");
+  testHopeful = NO;
+
+  END_SET("setting values on a transaction")
+
+  START_SET("nested transactions")
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 1.0];
+  [CATransaction setDisableActions: YES];
+
+  [CATransaction begin];
+
+  testHopeful = YES;
+  PASS([CATransaction animationDuration] == 1.0,
+       "a nested transaction sees the animation duration of the enclosing"
+       " one");
+  PASS([CATransaction disableActions] == YES,
+       "a nested transaction sees the actions setting of the enclosing one");
+  testHopeful = NO;
+
+  [CATransaction setAnimationDuration: 2.0];
+  PASS([CATransaction animationDuration] == 2.0,
+       "a nested transaction takes the duration it is given");
+
+  [CATransaction commit];
+
+  PASS([CATransaction animationDuration] == 1.0,
+       "a nested transaction does not carry its duration out to the"
+       " enclosing one");
+  PASS([CATransaction disableActions] == YES,
+       "the enclosing transaction keeps its actions setting");
+
+  [CATransaction commit];
+
+  END_SET("nested transactions")
+
+  START_SET("reading and writing values by key")
+
+  [CATransaction begin];
+
+  [CATransaction setAnimationDuration: 0.75];
+  PASS([[CATransaction valueForKey: kCATransactionAnimationDuration]
+         doubleValue] == 0.75,
+       "the duration key reads what the accessor set");
+
+  [CATransaction setValue: [NSNumber numberWithDouble: 1.25]
+                   forKey: kCATransactionAnimationDuration];
+  PASS([CATransaction animationDuration] == 1.25,
+       "the accessor reads what the duration key set");
+
+  [CATransaction setDisableActions: YES];
+  PASS([[CATransaction valueForKey: kCATransactionDisableActions]
+         boolValue] == YES,
+       "the actions key reads what the accessor set");
+
+  [CATransaction setValue: [NSNumber numberWithBool: NO]
+                   forKey: kCATransactionDisableActions];
+  PASS([CATransaction disableActions] == NO,
+       "the accessor reads what the actions key set");
+
+  [CATransaction commit];
+
+  END_SET("reading and writing values by key")
+
+  /* A transaction on Apple carries arbitrary key-value pairs, and an unset
+     key reads as nil rather than raising.  Both of these end the set early
+     where they raise, so they come last. */
+  START_SET("keys a transaction does not define")
+
+  [CATransaction begin];
+
+  testHopeful = YES;
+
+  {
+    id fetched = nil;
+
+    PASS_RUNS(fetched = [CATransaction valueForKey: @"aKeyNobodyDefined"],
+              "reading a key the transaction does not define does not raise");
+    PASS_RUNS([CATransaction setValue: @"stored" forKey: @"aKeyNobodyDefined"],
+              "an arbitrary key can be set on a transaction");
+    PASS_RUNS(fetched = [CATransaction valueForKey: @"aKeyNobodyDefined"],
+              "an arbitrary key can be read back from a transaction");
+    PASS([fetched isEqual: @"stored"],
+         "an arbitrary key round-trips through a transaction");
+  }
+
+  testHopeful = NO;
+
+  [CATransaction commit];
+
+  END_SET("keys a transaction does not define")
+
+  START_SET("the class methods that take no transaction")
+
+  PASS_RUNS([CATransaction commit],
+            "committing with no matching begin does not raise");
+  PASS([CATransaction animationDuration] == 0.25,
+       "an unmatched commit leaves the animation duration at 0.25");
+
+  PASS_RUNS([CATransaction flush], "flush does not raise");
+  PASS_RUNS([CATransaction lock]; [CATransaction unlock],
+            "lock and unlock do not raise");
+
+  END_SET("the class methods that take no transaction")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransaction/transaction.m
+++ b/Tests/quartzcore/CATransaction/transaction.m
@@ -185,6 +185,53 @@ int main(void)
 
   END_SET("the class methods that take no transaction")
 
+  START_SET("flushing")
+
+  [CATransaction setAnimationDuration: 5.0];
+  PASS([CATransaction animationDuration] == 5.0,
+       "the implicit transaction takes a duration like any other");
+
+  [CATransaction flush];
+  PASS([CATransaction animationDuration] == 0.25,
+       "flushing takes the implicit transaction away");
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 7.0];
+  [CATransaction flush];
+  PASS([CATransaction animationDuration] == 7.0,
+       "a flush leaves an explicit transaction where it is");
+  [CATransaction commit];
+
+  PASS([CATransaction animationDuration] == 0.25,
+       "and once that is committed there is nothing left of it");
+
+  PASS_RUNS([CATransaction flush]; [CATransaction flush],
+            "flushing when there is nothing to flush does nothing");
+
+  END_SET("flushing")
+
+  START_SET("the lock")
+
+  PASS_RUNS([CATransaction lock]; [CATransaction unlock],
+            "a lock can be taken and given back");
+
+  PASS_RUNS([CATransaction lock]; [CATransaction lock];
+            [CATransaction unlock]; [CATransaction unlock],
+            "and taken twice over by the one thread");
+
+  [CATransaction lock];
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 9.0];
+  PASS([CATransaction animationDuration] == 9.0,
+       "a transaction still works while the lock is held");
+  [CATransaction commit];
+  [CATransaction unlock];
+
+  PASS_RUNS([CATransaction unlock],
+            "giving back a lock that was never taken does nothing");
+
+  END_SET("the lock")
+
   [pool release];
   return 0;
 }

--- a/Tests/quartzcore/CATransaction/transaction.m
+++ b/Tests/quartzcore/CATransaction/transaction.m
@@ -6,6 +6,80 @@
 #import <QuartzCore/CATransaction.h>
 #import <QuartzCore/CAMediaTimingFunction.h>
 
+/* What another thread makes of a transaction this one holds open.  The
+   answer does not depend on how the two are scheduled, so nothing here is
+   timing dependent; the condition only waits for the other thread to finish,
+   and it has a deadline so a mistake cannot hang the run. */
+static NSCondition *gate = nil;
+static BOOL         otherFinished = NO;
+static double       otherDuration = -1.0;
+static BOOL         otherDisableActions = YES;
+
+@interface QCOtherThread : NSObject
++ (void) look: (id)ignored;
++ (void) runItsOwn: (id)ignored;
+@end
+
+@implementation QCOtherThread
+
++ (void) look: (id)ignored
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  otherDuration = (double)[CATransaction animationDuration];
+  otherDisableActions = [CATransaction disableActions];
+  [pool release];
+
+  [gate lock];
+  otherFinished = YES;
+  [gate signal];
+  [gate unlock];
+}
+
++ (void) runItsOwn: (id)ignored
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 11.0];
+  otherDuration = (double)[CATransaction animationDuration];
+  [CATransaction commit];
+  [pool release];
+
+  [gate lock];
+  otherFinished = YES;
+  [gate signal];
+  [gate unlock];
+}
+
+@end
+
+static BOOL runOnAnotherThread(SEL what)
+{
+  NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow: 10.0];
+  BOOL ok = YES;
+
+  otherFinished = NO;
+  otherDuration = -1.0;
+  otherDisableActions = YES;
+  [NSThread detachNewThreadSelector: what
+                           toTarget: [QCOtherThread class]
+                         withObject: nil];
+
+  [gate lock];
+  while (!otherFinished)
+    {
+      if (![gate waitUntilDate: deadline])
+        {
+          ok = NO;
+          break;
+        }
+    }
+  [gate unlock];
+
+  return ok;
+}
+
 int main(void)
 {
   NSAutoreleasePool *pool = [NSAutoreleasePool new];
@@ -231,6 +305,42 @@ int main(void)
             "giving back a lock that was never taken does nothing");
 
   END_SET("the lock")
+
+  START_SET("a transaction belongs to the thread that began it")
+
+  gate = [NSCondition new];
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 5.0];
+  [CATransaction setDisableActions: YES];
+
+  PASS(runOnAnotherThread(@selector(look:)),
+       "another thread can read a transaction value at all");
+  PASS(otherDuration == 0.25,
+       "and reads its own duration rather than this thread's");
+  PASS(otherDisableActions == NO,
+       "and its own actions setting rather than this thread's");
+  PASS([CATransaction animationDuration] == 5.0,
+       "while this thread still reads what it set");
+
+  [CATransaction commit];
+  PASS([CATransaction animationDuration] == 0.25,
+       "and commits its own transaction away");
+
+  [CATransaction begin];
+  [CATransaction setAnimationDuration: 3.0];
+
+  PASS(runOnAnotherThread(@selector(runItsOwn:)),
+       "another thread can run a transaction of its own");
+  PASS(otherDuration == 11.0, "and sees the value it set in it");
+  PASS([CATransaction animationDuration] == 3.0,
+       "without disturbing the one open on this thread");
+
+  [CATransaction commit];
+  PASS([CATransaction animationDuration] == 0.25,
+       "which still commits cleanly afterwards");
+
+  END_SET("a transaction belongs to the thread that began it")
 
   [pool release];
   return 0;


### PR DESCRIPTION
There is no way to be notified that a transaction has been committed. The header has carried a comment about kCATransactionCompletionBlock for years and the constant does not exist.

This adds it, with tests, since none of it could be tested before it existed.

Apple's method takes a block. A block type in a public header would stop a compiler without blocks from reading that header at all, so the block form is behind a `#if defined(__BLOCKS__)` guard and a target-and-selector form sits beside it unconditionally. A compiler with blocks gets both and matches Apple; one without still gets commit notification. CATransaction.m compiles with -fno-blocks with no diagnostics. Foundation.h itself cannot be read that way on a gnustep-base configured with GS_HAVE_NSURLSESSION, since NSURLSession.h declares block types; that is outside this repository.

The behaviour was measured rather than assumed, and three parts of it are not obvious. Setting a second block adds to the first rather than replacing it, and both run. Setting nil clears what the getter returns but does not remove what was already registered. A nested transaction reads the block of the enclosing transaction, but committing the nested one does not run it; committing the transaction it was set on does. Beyond that: it runs once, after the commit, on a later turn of the run loop rather than during the commit, and a transaction that is never committed never runs it.

The completion target file is named in APPLE_SKIP_TESTS, since Apple has no such method. The block file is guarded, so a compiler without blocks builds it empty rather than failing.

The branch carries #21, #22, #45 and #46.

From Tests/quartzcore:

    gnustep-tests CATransaction

19 assertions, none of which could run before, all passing after. The suite is 95 passed.
