### PR TITLE
Fix: read media time from a monotonic clock

### DIFF
--- a/Source/CABase.m
+++ b/Source/CABase.m
@@ -29,20 +29,51 @@
 
 #if GNUSTEP
 #import <sys/time.h>
+#import <time.h>
 
+/* Media time is the time since the machine started and only moves forward.
+   The wall clock moves when the date is set and when NTP corrects it, and
+   animation begin times are derived from media time. */
 CFTimeInterval CACurrentMediaTime(void)
 {
-  struct timeval systemTime;
+#if defined(CLOCK_MONOTONIC)
+  struct timespec monotonicTime;
 
-  gettimeofday(&systemTime, NULL);
-  return (double)systemTime.tv_sec + ((double)systemTime.tv_usec)/(1000 * 1000.);
+  if (clock_gettime(CLOCK_MONOTONIC, &monotonicTime) == 0)
+    {
+      return (double)monotonicTime.tv_sec
+        + ((double)monotonicTime.tv_nsec)/(1000 * 1000 * 1000.);
+    }
+#endif
+
+  /* Nothing better to read from.  This moves with the wall clock. */
+  {
+    struct timeval systemTime;
+
+    gettimeofday(&systemTime, NULL);
+    return (double)systemTime.tv_sec + ((double)systemTime.tv_usec)/(1000 * 1000.);
+  }
 }
 #else
 #import <mach/mach_time.h>
 
+/* mach_absolute_time() counts in machine-dependent units, not nanoseconds.
+   mach_timebase_info() gives the ratio between the two: 1/1 on Intel and
+   125/3 on Apple silicon, where one tick is 41.67ns. */
 CFTimeInterval CACurrentMediaTime(void)
 {
-  return mach_absolute_time() / (1000 * 1000 * 1000.);
+  static double secondsPerTick = 0.0;
+
+  if (secondsPerTick == 0.0)
+    {
+      mach_timebase_info_data_t timebase;
+
+      mach_timebase_info(&timebase);
+      secondsPerTick = (double)timebase.numer
+        / ((double)timebase.denom * (1000 * 1000 * 1000.));
+    }
+
+  return (double)mach_absolute_time() * secondsPerTick;
 }
 
 #endif

--- a/Tests/quartzcore/CABase/mediatime.m
+++ b/Tests/quartzcore/CABase/mediatime.m
@@ -1,0 +1,89 @@
+/* What CACurrentMediaTime() measures, and how it moves.
+   Expected values checked against Apple QuartzCore, where media time reads
+   the same as NSProcessInfo's systemUptime and not the wall clock.
+
+   A test cannot set the system clock, so the check below is that media time
+   is a time since the machine started rather than seconds since 1970. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CABase.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what media time measures")
+
+  CFTimeInterval media = CACurrentMediaTime();
+  NSTimeInterval wall = [[NSDate date] timeIntervalSince1970];
+
+  PASS(media > 0, "media time is positive");
+  PASS(!isinf(media) && !isnan(media), "media time is a real number");
+
+  /* On Apple the two readings are 1.79e9 apart. */
+  testHopeful = YES;
+  PASS(wall - media > 365.0 * 24 * 60 * 60,
+       "media time is not the wall clock");
+  testHopeful = NO;
+
+  END_SET("what media time measures")
+
+  START_SET("how media time moves")
+
+  CFTimeInterval before, after;
+  int i, backwards = 0;
+
+  before = CACurrentMediaTime();
+  for (i = 0; i < 200000; i++)
+    {
+      after = CACurrentMediaTime();
+      if (after < before)
+        {
+          backwards++;
+        }
+      before = after;
+    }
+  PASS(backwards == 0, "media time never goes backwards");
+
+  before = CACurrentMediaTime();
+  [NSThread sleepForTimeInterval: 0.1];
+  after = CACurrentMediaTime();
+
+  PASS(after - before >= 0.09,
+       "media time counts a tenth of a second spent asleep");
+  PASS(after - before < 10.0,
+       "media time counts the sleep in seconds");
+
+  END_SET("how media time moves")
+
+  START_SET("how finely media time is measured")
+
+  CFTimeInterval smallest = 1.0;
+  int trial;
+
+  /* The smallest step over many trials; one trial can be interrupted by
+     the scheduler. */
+  for (trial = 0; trial < 200; trial++)
+    {
+      CFTimeInterval t0 = CACurrentMediaTime();
+      CFTimeInterval t1 = t0;
+
+      while (t1 == t0)
+        {
+          t1 = CACurrentMediaTime();
+        }
+      if (t1 - t0 < smallest)
+        {
+          smallest = t1 - t0;
+        }
+    }
+  PASS(smallest < 0.001,
+       "media time resolves a step shorter than a millisecond");
+
+  END_SET("how finely media time is measured")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`CACurrentMediaTime()` read the wall clock through `gettimeofday()`. Setting the date or an NTP correction moves the wall clock, and it can move backwards. Animation begin times, `convertTime:` results and the test in `-[CALayer nextFrameTime]` for an animation that has finished are all derived from media time.

It now reads `CLOCK_MONOTONIC`, the time since the machine started, which does not count time spent suspended and so matches `mach_absolute_time()` on Apple. Where `CLOCK_MONOTONIC` is not defined it falls back to `gettimeofday()`.

The Darwin path divided `mach_absolute_time()` by 1e9, which holds only where one tick is one nanosecond. The timebase is 125/3 on Apple silicon. Measured on an arm64 runner: that path gives 8.94 where `CACurrentMediaTime()` gives 372.66. It is now scaled by `mach_timebase_info()`.

A test cannot set the system clock, so `Tests/quartzcore/CABase/mediatime.m` checks that media time is a time since the machine started rather than seconds since 1970; on macOS the two readings are 1.79e9 apart and media time reads the same as `NSProcessInfo`'s `systemUptime`.

6 passed and 1 dashed hope before, 7 passed after. Whole suite 34 passed.
