### PR TITLE
Fix: synthesise a dynamic property of any scalar type

### DIFF
--- a/Source/CALayer+DynamicProperties.m
+++ b/Source/CALayer+DynamicProperties.m
@@ -145,11 +145,29 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
-  if ([type hasPrefix: @"c"] || [type hasPrefix: @"C"])
+  if ([type hasPrefix: @"B"])
     {
-      /* BOOL */
+      /* _Bool, which is BOOL on some runtimes */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertyGetterForBooleans));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"c"])
+    {
+      /* signed characters */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForChars));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"C"])
+    {
+      /* unsigned characters, which is BOOL on other runtimes.  The
+         value is kept as given, so a BOOL reads back as 0 or 1 and a
+         character keeps its value */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedChars));
       return method_getImplementation(method);
     }
 
@@ -201,6 +219,38 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
+  if ([type hasPrefix: @"S"])
+    {
+      /* unsigned short integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedShortIntegers));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"L"])
+    {
+      /* unsigned long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedLongIntegers));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"q"])
+    {
+      /* long long integers, which is what a 64 bit long encodes as */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForLongLongIntegers));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"Q"])
+    {
+      /* unsigned long long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedLongLongIntegers));
+      return method_getImplementation(method);
+    }
+
   [NSException raise: NSGenericException
               format: @"%@ is not a supported data type for dynamic synthesis", type];
 
@@ -217,11 +267,29 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
-  if ([type hasPrefix: @"c"] || [type hasPrefix: @"C"])
+  if ([type hasPrefix: @"B"])
     {
-      /* BOOL */
+      /* _Bool, which is BOOL on some runtimes */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertySetterForBooleans:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"c"])
+    {
+      /* signed characters */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForChars:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"C"])
+    {
+      /* unsigned characters, which is BOOL on other runtimes.  The
+         value is kept as given, so a BOOL reads back as 0 or 1 and a
+         character keeps its value */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedChars:));
       return method_getImplementation(method);
     }
 
@@ -270,6 +338,38 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       /* long integers */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertySetterForLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"S"])
+    {
+      /* unsigned short integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedShortIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"L"])
+    {
+      /* unsigned long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"q"])
+    {
+      /* long long integers, which is what a 64 bit long encodes as */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForLongLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"Q"])
+    {
+      /* unsigned long long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedLongLongIntegers:));
       return method_getImplementation(method);
     }
 
@@ -357,5 +457,64 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
 - (void) _dynamicPropertySetterForLongIntegers: (long int)number
 {
   [_dynamicPropertyValueDict setValue: [NSNumber numberWithLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+- (char) _dynamicPropertyGetterForChars
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] charValue];
+}
+
+- (void) _dynamicPropertySetterForChars: (char)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithChar: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned char) _dynamicPropertyGetterForUnsignedChars
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedCharValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedChars: (unsigned char)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedChar: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned short int) _dynamicPropertyGetterForUnsignedShortIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedShortValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedShortIntegers: (unsigned short int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedShort: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned long int) _dynamicPropertyGetterForUnsignedLongIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedLongValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedLongIntegers: (unsigned long int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (long long int) _dynamicPropertyGetterForLongLongIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] longLongValue];
+}
+
+- (void) _dynamicPropertySetterForLongLongIntegers: (long long int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithLongLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned long long int) _dynamicPropertyGetterForUnsignedLongLongIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedLongLongValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedLongLongIntegers: (unsigned long long int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedLongLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
 }
 @end

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -456,6 +456,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
   [_backingStore release];
   [_animations release];
   [_animationKeys release];
+  [_dynamicPropertyValueDict release];
 
   [super dealloc];
 }

--- a/Tests/quartzcore/CALayer/dynamic.m
+++ b/Tests/quartzcore/CALayer/dynamic.m
@@ -1,0 +1,156 @@
+/* The properties a CALayer subclass declares @dynamic: which types can be
+   synthesised, what a fresh layer reads, and what the accessors keep.
+   Expected values checked against Apple QuartzCore, which synthesises every
+   type below.
+
+   Each type gets its own subclass so that one type failing does not stop
+   the rest from being checked.  The accessors are created the first time
+   the class is messaged, so a type that cannot be synthesised raises there
+   rather than at the set. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+#define DYNAMIC_LAYER(name, type) \
+@interface name : CALayer \
+@property (nonatomic, assign) type p; \
+@end \
+@implementation name \
+@dynamic p; \
+@end
+
+DYNAMIC_LAYER(DynBoolLayer, BOOL)
+DYNAMIC_LAYER(DynCharLayer, char)
+DYNAMIC_LAYER(DynUCharLayer, unsigned char)
+DYNAMIC_LAYER(DynIntLayer, int)
+DYNAMIC_LAYER(DynUIntLayer, unsigned int)
+DYNAMIC_LAYER(DynShortLayer, short)
+DYNAMIC_LAYER(DynUShortLayer, unsigned short)
+DYNAMIC_LAYER(DynIntegerLayer, NSInteger)
+DYNAMIC_LAYER(DynUIntegerLayer, NSUInteger)
+DYNAMIC_LAYER(DynLongLongLayer, long long)
+DYNAMIC_LAYER(DynFloatLayer, float)
+DYNAMIC_LAYER(DynDoubleLayer, double)
+DYNAMIC_LAYER(DynPointLayer, CGPoint)
+
+@interface DynObjectLayer : CALayer
+@property (nonatomic, retain) NSString *p;
+@end
+@implementation DynObjectLayer
+@dynamic p;
+@end
+
+/* Reads the fresh value and the value the setter kept.  A type that cannot
+   be synthesised raises on the first message to the class, so both are
+   reported as failures rather than stopping the file. */
+#define ROUNDTRIP(cls, value, what) \
+  @try \
+    { \
+      cls *l = [cls layer]; \
+      PASS([l p] == 0, "a fresh " what " dynamic property is 0"); \
+      [l setP: value]; \
+      PASS([l p] == value, "a " what " dynamic property keeps what it is set to"); \
+    } \
+  @catch (NSException *e) \
+    { \
+      PASS(NO, "a fresh " what " dynamic property is 0"); \
+      PASS(NO, "a " what " dynamic property keeps what it is set to"); \
+    }
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the types a dynamic property can have")
+
+  ROUNDTRIP(DynBoolLayer, YES, "BOOL")
+  ROUNDTRIP(DynIntLayer, -42, "int")
+  ROUNDTRIP(DynUIntLayer, 42u, "unsigned int")
+  ROUNDTRIP(DynShortLayer, 7, "short")
+  ROUNDTRIP(DynFloatLayer, 1.5f, "float")
+  ROUNDTRIP(DynDoubleLayer, 2.25, "double")
+
+  /* BOOL and unsigned char share an encoding where BOOL is a character
+     type, so a character property has to keep its value rather than be
+     reduced to 0 or 1. */
+  testHopeful = YES;
+  ROUNDTRIP(DynCharLayer, 'a', "char")
+  ROUNDTRIP(DynUCharLayer, 200, "unsigned char")
+  ROUNDTRIP(DynUShortLayer, 7u, "unsigned short")
+  ROUNDTRIP(DynIntegerLayer, -1234567890123LL, "NSInteger")
+  ROUNDTRIP(DynUIntegerLayer, 1234567890123ULL, "NSUInteger")
+  ROUNDTRIP(DynLongLongLayer, -9007199254740993LL, "long long")
+  testHopeful = NO;
+
+  END_SET("the types a dynamic property can have")
+
+  START_SET("a dynamic property holding an object")
+
+  @try
+    {
+      DynObjectLayer *l = [DynObjectLayer layer];
+
+      PASS([l p] == nil, "a fresh object dynamic property is nil");
+      [l setP: @"hello"];
+      PASS([[l p] isEqualToString: @"hello"],
+           "an object dynamic property keeps what it is set to");
+      [l setP: nil];
+      PASS([l p] == nil, "an object dynamic property can be set back to nil");
+    }
+  @catch (NSException *e)
+    {
+      PASS(NO, "a fresh object dynamic property is nil");
+      PASS(NO, "an object dynamic property keeps what it is set to");
+      PASS(NO, "an object dynamic property can be set back to nil");
+    }
+
+  END_SET("a dynamic property holding an object")
+
+  START_SET("dynamic properties through key-value coding")
+
+  DynIntLayer *l = [DynIntLayer layer];
+
+  [l setP: -42];
+  PASS([[l valueForKey: @"p"] intValue] == -42,
+       "valueForKey: reads a dynamic property");
+  [l setValue: [NSNumber numberWithInt: 99] forKey: @"p"];
+  PASS([l p] == 99, "setValue:forKey: writes a dynamic property");
+
+  END_SET("dynamic properties through key-value coding")
+
+  START_SET("dynamic properties belong to the layer")
+
+  DynIntLayer *first = [DynIntLayer layer];
+  DynIntLayer *second = [DynIntLayer layer];
+
+  [first setP: 11];
+  PASS([second p] == 0, "a second layer starts with its own value");
+  [second setP: 22];
+  PASS([first p] == 11, "setting one layer leaves the other alone");
+
+  END_SET("dynamic properties belong to the layer")
+
+  START_SET("a dynamic property holding a structure")
+
+  /* Apple synthesises these too. */
+  testHopeful = YES;
+  @try
+    {
+      DynPointLayer *l = [DynPointLayer layer];
+
+      [l setP: CGPointMake(3, 4)];
+      PASS([l p].x == 3 && [l p].y == 4,
+           "a CGPoint dynamic property keeps what it is set to");
+    }
+  @catch (NSException *e)
+    {
+      PASS(NO, "a CGPoint dynamic property keeps what it is set to");
+    }
+  testHopeful = NO;
+
+  END_SET("a dynamic property holding a structure")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Stacked on #52, which adds the test file.

`+[CALayer initialize]` adds an accessor for every property a subclass declares `@dynamic`, choosing it from the property's type encoding. Several encodings had no branch and two more were treated as `BOOL`.

On a 64 bit target `long` and `NSInteger` encode as `q`, `unsigned long` and `NSUInteger` as `Q`, `unsigned short` as `S`, and `_Bool` as `B`. None of them had a branch, so `+initialize` raised `NSGenericException` and a subclass declaring any of them could not be created at all.

`c` and `C` both answered the boolean accessor, which stores `numberWithBool:`, so a `char` property set to `'a'` read back as 1. `C` is what `BOOL` encodes as here and `c` is a signed character, so each now keeps the value it is given; a `BOOL` set to `YES` still reads 1.

`-[CALayer dealloc]` did not release `_dynamicPropertyValueDict`, which `-init` allocates for every layer. The suite does not cover that, since the dictionary is private to `CALayer.m`.

Structures are still not synthesised. Apple synthesises `CGPoint`, `CGSize` and `CGRect`; that needs a different mechanism and stays a dashed hope.

dynamic.m: 21 passed and 11 dashed hopes before, 31 passed and 1 dashed hope after. Whole suite 58 passed.
