### PR TITLE
Feature: make the value functions Core Animation names

### DIFF
--- a/Headers/QuartzCore/AppleSupportRevert.h
+++ b/Headers/QuartzCore/AppleSupportRevert.h
@@ -126,6 +126,9 @@
 #undef CATransform3DConcat
 #undef CATransform3DInvert
 
+/* CAValueFunction.h */
+#undef CAValueFunction
+
 /* CoreAnimation.h */
 
 /* QuartzCore.h */

--- a/Headers/QuartzCore/CAValueFunction.h
+++ b/Headers/QuartzCore/CAValueFunction.h
@@ -25,7 +25,16 @@
 */
 
 #import <Foundation/Foundation.h>
-@interface CAValueFunction : NSObject
+@interface CAValueFunction : NSObject <NSCoding>
+{
+  NSString *_name;
+}
+
+/* Answers the function of that name, or nil when there is no function of
+   that name.  The same name always answers the same object. */
++ (id) functionWithName: (NSString *)name;
+
+- (NSString *) name;
 
 @end
 

--- a/Source/CAValueFunction.m
+++ b/Source/CAValueFunction.m
@@ -26,7 +26,83 @@
 
 #import "QuartzCore/CAValueFunction.h"
 
+/* The functions, built once and keyed by name.  Building all of them up
+   front leaves the table read-only afterwards, so a lookup needs no lock. */
+static NSDictionary *functionsByName = nil;
+
 @implementation CAValueFunction
+
++ (void) initialize
+{
+  if (self != [CAValueFunction class] || functionsByName != nil)
+    {
+      return;
+    }
+
+  NSArray *names = [NSArray arrayWithObjects:
+    kCAValueFunctionRotateX, kCAValueFunctionRotateY,
+    kCAValueFunctionRotateZ, kCAValueFunctionScale,
+    kCAValueFunctionScaleX, kCAValueFunctionScaleY,
+    kCAValueFunctionScaleZ, kCAValueFunctionTranslate,
+    kCAValueFunctionTranslateX, kCAValueFunctionTranslateY,
+    kCAValueFunctionTranslateZ, nil];
+  NSMutableDictionary *table;
+  NSEnumerator *e;
+  NSString *name;
+
+  table = [[NSMutableDictionary alloc] initWithCapacity: [names count]];
+  e = [names objectEnumerator];
+  while ((name = [e nextObject]) != nil)
+    {
+      CAValueFunction *function = [[CAValueFunction alloc] init];
+
+      function->_name = [name copy];
+      [table setObject: function forKey: name];
+      [function release];
+    }
+
+  functionsByName = [table copy];
+  [table release];
+}
+
++ (id) functionWithName: (NSString *)name
+{
+  if (name == nil)
+    {
+      return nil;
+    }
+
+  return [functionsByName objectForKey: name];
+}
+
+- (void) dealloc
+{
+  [_name release];
+  [super dealloc];
+}
+
+- (NSString *) name
+{
+  return _name;
+}
+
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _name = [[aDecoder decodeObjectForKey: @"name"] copy];
+
+  return self;
+}
+
+- (void) encodeWithCoder: (NSCoder *)aCoder
+{
+  [aCoder encodeObject: _name forKey: @"name"];
+}
 
 @end
 

--- a/Tests/quartzcore/CAValueFunction/valuefunction.m
+++ b/Tests/quartzcore/CAValueFunction/valuefunction.m
@@ -1,0 +1,109 @@
+/* CAValueFunction: what each name answers, what an unknown name answers,
+   and that a function survives being archived.
+   Expected values checked against Apple QuartzCore.
+
+   The names are read through the constants rather than written out, so this
+   checks the lookup and not the value of any constant. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAValueFunction.h>
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  NSArray *names = [NSArray arrayWithObjects:
+    kCAValueFunctionRotateX, kCAValueFunctionRotateY,
+    kCAValueFunctionRotateZ, kCAValueFunctionScale,
+    kCAValueFunctionScaleX, kCAValueFunctionScaleY,
+    kCAValueFunctionScaleZ, kCAValueFunctionTranslate,
+    kCAValueFunctionTranslateX, kCAValueFunctionTranslateY,
+    kCAValueFunctionTranslateZ, nil];
+
+  START_SET("the function of each name")
+
+  NSEnumerator *e = [names objectEnumerator];
+  NSString *name;
+  unsigned found = 0;
+  unsigned named = 0;
+
+  while ((name = [e nextObject]) != nil)
+    {
+      CAValueFunction *f = [CAValueFunction functionWithName: name];
+
+      if (f != nil)
+        {
+          found++;
+          if ([[f name] isEqualToString: name])
+            {
+              named++;
+            }
+        }
+    }
+
+  PASS([names count] == 11, "there are eleven value function names");
+  PASS(found == 11, "every name answers a function");
+  PASS(named == 11, "every function answers the name it was asked for");
+
+  END_SET("the function of each name")
+
+  START_SET("a name with no function")
+
+  PASS([CAValueFunction functionWithName: @"notAValueFunction"] == nil,
+       "a name that is not a function answers nothing");
+  PASS([CAValueFunction functionWithName: @""] == nil,
+       "an empty name answers nothing");
+
+  END_SET("a name with no function")
+
+  START_SET("the same name answers the same function")
+
+  CAValueFunction *first = [CAValueFunction functionWithName:
+                              kCAValueFunctionRotateX];
+  CAValueFunction *second = [CAValueFunction functionWithName:
+                               kCAValueFunctionRotateX];
+  CAValueFunction *other = [CAValueFunction functionWithName:
+                              kCAValueFunctionRotateY];
+
+  PASS(first == second, "asking twice answers the same object");
+  PASS(first != other, "two names answer two objects");
+
+  END_SET("the same name answers the same function")
+
+  START_SET("archiving a function")
+
+  CAValueFunction *f = [CAValueFunction functionWithName:
+                          kCAValueFunctionScale];
+
+  PASS([f conformsToProtocol: @protocol(NSCoding)],
+       "a value function can be archived");
+
+  NSData *d = [NSKeyedArchiver archivedDataWithRootObject: f];
+  CAValueFunction *back = [NSKeyedUnarchiver unarchiveObjectWithData: d];
+
+  PASS([d length] > 0, "archiving a value function writes something");
+  PASS([[back name] isEqualToString: kCAValueFunctionScale],
+       "an unarchived function keeps its name");
+
+  END_SET("archiving a function")
+
+  START_SET("a function on an animation")
+
+  CABasicAnimation *anim = [CABasicAnimation animationWithKeyPath:
+                              @"transform"];
+
+  PASS([anim valueFunction] == nil,
+       "an animation starts with no value function");
+  [anim setValueFunction: [CAValueFunction functionWithName:
+                             kCAValueFunctionRotateZ]];
+  PASS([[[anim valueFunction] name] isEqualToString:
+          kCAValueFunctionRotateZ],
+       "an animation keeps the value function it is given");
+
+  END_SET("a function on an animation")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`CAValueFunction` was an empty `@implementation` with no methods at all, while `CAPropertyAnimation` declares a `valueFunction` property of that type. Nothing could produce one.

Adds `+functionWithName:` and `-name`, and conformance to `NSCoding`.

The eleven functions are built once in `+initialize` and held in a dictionary keyed by name, so `+functionWithName:` is a read-only lookup and needs no lock. A name that is not one of the eleven answers nil, as does nil itself. Asking twice for the same name answers the same object.

`AppleSupportRevert.h` had no `#undef CAValueFunction` to match the `#define` in `AppleSupport.h`. Added.

`Tests/quartzcore/CAValueFunction/valuefunction.m` is 12 assertions, covering the function each name answers, a name with no function, the sharing, archiving, and setting one on an animation. The names are read through the constants rather than written out, so the file checks the lookup and not the value of any constant.

Before the change the class does not recognise `functionWithName:`: 4 failed sets and 2 failed tests. After it, 12 pass and the whole suite is 39.

Expected values checked against Apple QuartzCore.
