### PR TITLE
Fix: evaluate a timing function at the ends of its curve

### DIFF
--- a/Source/CAMediaTimingFunction.m
+++ b/Source/CAMediaTimingFunction.m
@@ -35,6 +35,8 @@
 #import "QuartzCore/CAMediaTimingFunction.h"
 #import "CAMediaTimingFunction+FrameworkPrivate.h"
 
+#include <math.h>
+
 NSString *const kCAMediaTimingFunctionDefault = @"kCAMediaTimingFunctionDefault";
 NSString *const kCAMediaTimingFunctionEaseInEaseOut = @"kCAMediaTimingFunctionEaseInEaseOut";
 NSString *const kCAMediaTimingFunctionEaseIn = @"kCAMediaTimingFunctionEaseIn";
@@ -166,23 +168,73 @@ static inline CGFloat evaluateDerivationAtParameterWithCoefficients(CGFloat t, C
   return coefficients[1] + 2*t*coefficients[2] + 3*t*t*coefficients[3];
 }
 
-static inline CGFloat calcParameterViaNewtonRaphsonUsingXAndCoefficientsForX(CGFloat x, CGFloat coefficientsX[])
+static const CGFloat _epsilon = 0.00001;
+
+/* The slope of x(t) is zero at t=0 when the first control point sits on the
+   y axis, and at t=1 when the second sits on the line x=1.  Both hold for
+   the named functions: linear at each end, ease in at t=1, ease out at t=0.
+   Dividing by that slope is what this has to avoid. */
+static inline CGFloat calcParameterViaNewtonRaphsonUsingXAndCoefficientsForX(CGFloat x, CGFloat coefficientsX[], BOOL *solved)
 {
   // see http://en.wikipedia.org/wiki/Newton's_method
 
   // start with X being the correct value
   CGFloat t = x;
+  int i;
+
+  *solved = NO;
 
   // iterate several times
-  const CGFloat epsilon = 0.00001;
-  for(int i = 0; i < 10; i++)
+  for(i = 0; i < 10; i++)
     {
       CGFloat x2 = evaluateAtParameterWithCoefficients(t, coefficientsX) - x;
-      CGFloat d = evaluateDerivationAtParameterWithCoefficients(t, coefficientsX);
+      CGFloat d;
 
-      CGFloat dt = x2/d;
+      if (fabs(x2) < _epsilon)
+        {
+          *solved = YES;
+          return t;
+        }
 
-      t = t - dt;
+      d = evaluateDerivationAtParameterWithCoefficients(t, coefficientsX);
+      if (fabs(d) < 1e-6)
+        {
+          break;
+        }
+
+      t = t - x2/d;
+    }
+
+  return t;
+}
+
+/* Halving the interval always converges, where Newton's method needs a
+   slope to work with. */
+static inline CGFloat calcParameterViaBisectionUsingXAndCoefficientsForX(CGFloat x, CGFloat coefficientsX[])
+{
+  CGFloat lower = 0.0;
+  CGFloat upper = 1.0;
+  CGFloat t = x;
+  int i;
+
+  for (i = 0; i < 60; i++)
+    {
+      CGFloat x2 = evaluateAtParameterWithCoefficients(t, coefficientsX);
+
+      if (fabs(x2 - x) < _epsilon)
+        {
+          return t;
+        }
+
+      if (x > x2)
+        {
+          lower = t;
+        }
+      else
+        {
+          upper = t;
+        }
+      t = (upper - lower) * 0.5 + lower;
     }
 
   return t;
@@ -190,21 +242,33 @@ static inline CGFloat calcParameterViaNewtonRaphsonUsingXAndCoefficientsForX(CGF
 
 static inline CGFloat calcParameterUsingXAndCoefficientsForX (CGFloat x, CGFloat coefficientsX[])
 {
-  // for the time being, we'll guess Newton-Raphson always
-  // returns the correct value.
+  BOOL solved;
+  CGFloat t = calcParameterViaNewtonRaphsonUsingXAndCoefficientsForX(x, coefficientsX, &solved);
 
-  // if we find it doesn't find the solution often enough,
-  // we can add additional calculation methods.
+  if (solved)
+    {
+      return t;
+    }
 
-  CGFloat t = calcParameterViaNewtonRaphsonUsingXAndCoefficientsForX(x, coefficientsX);
-
-  return t;
+  return calcParameterViaBisectionUsingXAndCoefficientsForX(x, coefficientsX);
 }
 
 - (CGFloat) evaluateYAtX: (CGFloat)x
 {
-  CGFloat t = calcParameterUsingXAndCoefficientsForX(x, _coefficientsX);
-  CGFloat y = evaluateAtParameterWithCoefficients(t, _coefficientsY);
+  CGFloat t, y;
+
+  /* The curve is only defined between its first and last control point. */
+  if (x <= 0.0)
+    {
+      return 0.0;
+    }
+  if (x >= 1.0)
+    {
+      return 1.0;
+    }
+
+  t = calcParameterUsingXAndCoefficientsForX(x, _coefficientsX);
+  y = evaluateAtParameterWithCoefficients(t, _coefficientsY);
 
   return y;
 }

--- a/Tests/quartzcore/CAMediaTimingFunction/evaluation.m
+++ b/Tests/quartzcore/CAMediaTimingFunction/evaluation.m
@@ -1,0 +1,127 @@
+/* What a timing function evaluates to along its curve, and at the two ends
+   of it.  Expected values checked against Apple QuartzCore.
+
+   The slope of x(t) is zero at t=0 when the first control point sits on the
+   y axis, and at t=1 when the second sits on the line x=1, which is where a
+   solver that divides by that slope comes apart.  Linear has both, ease in
+   has the second and ease out the first. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CAMediaTimingFunction.h>
+
+/* Private on Apple, and implemented here so both can be asked the same
+   question. */
+@interface CAMediaTimingFunction (Solve)
+- (float) _solveForInput: (float)x;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the ends of the curve")
+
+  NSArray *names = [NSArray arrayWithObjects:
+    kCAMediaTimingFunctionLinear, kCAMediaTimingFunctionEaseIn,
+    kCAMediaTimingFunctionEaseOut, kCAMediaTimingFunctionEaseInEaseOut,
+    kCAMediaTimingFunctionDefault, nil];
+  NSEnumerator *e = [names objectEnumerator];
+  NSString *name;
+  unsigned atZero = 0;
+  unsigned atOne = 0;
+
+  while ((name = [e nextObject]) != nil)
+    {
+      CAMediaTimingFunction *f = [CAMediaTimingFunction functionWithName: name];
+
+      if (CLOSE([f _solveForInput: 0.0], 0.0))
+        {
+          atZero++;
+        }
+      if (CLOSE([f _solveForInput: 1.0], 1.0))
+        {
+          atOne++;
+        }
+    }
+
+  PASS(atZero == 5, "every named function is 0 where the input is 0");
+  PASS(atOne == 5, "every named function is 1 where the input is 1");
+
+  END_SET("the ends of the curve")
+
+  START_SET("a straight line")
+
+  CAMediaTimingFunction *f = [CAMediaTimingFunction functionWithName:
+                                kCAMediaTimingFunctionLinear];
+
+  PASS(CLOSE([f _solveForInput: 0.25], 0.25), "linear is 0.25 at 0.25");
+  PASS(CLOSE([f _solveForInput: 0.5], 0.5), "linear is 0.5 at 0.5");
+  PASS(CLOSE([f _solveForInput: 0.75], 0.75), "linear is 0.75 at 0.75");
+
+  END_SET("a straight line")
+
+  START_SET("along the eased curves")
+
+  CAMediaTimingFunction *in = [CAMediaTimingFunction functionWithName:
+                                 kCAMediaTimingFunctionEaseIn];
+  CAMediaTimingFunction *out = [CAMediaTimingFunction functionWithName:
+                                  kCAMediaTimingFunctionEaseOut];
+  CAMediaTimingFunction *both = [CAMediaTimingFunction functionWithName:
+                                   kCAMediaTimingFunctionEaseInEaseOut];
+
+  PASS(CLOSE([in _solveForInput: 0.25], 0.093465), "ease in at 0.25");
+  PASS(CLOSE([in _solveForInput: 0.5], 0.315357), "ease in at 0.5");
+  PASS(CLOSE([in _solveForInput: 0.75], 0.621861), "ease in at 0.75");
+
+  PASS(CLOSE([out _solveForInput: 0.25], 0.378140), "ease out at 0.25");
+  PASS(CLOSE([out _solveForInput: 0.5], 0.684643), "ease out at 0.5");
+  PASS(CLOSE([out _solveForInput: 0.75], 0.906535), "ease out at 0.75");
+
+  PASS(CLOSE([both _solveForInput: 0.25], 0.129162), "ease in ease out at 0.25");
+  PASS(CLOSE([both _solveForInput: 0.5], 0.5), "ease in ease out at 0.5");
+  PASS(CLOSE([both _solveForInput: 0.75], 0.870838), "ease in ease out at 0.75");
+
+  END_SET("along the eased curves")
+
+  START_SET("a curve given its control points")
+
+  CAMediaTimingFunction *straight = [CAMediaTimingFunction
+    functionWithControlPoints: 0.0: 0.0: 1.0: 1.0];
+  CAMediaTimingFunction *steep = [CAMediaTimingFunction
+    functionWithControlPoints: 0.5: 0.0: 0.5: 1.0];
+
+  PASS(CLOSE([straight _solveForInput: 0.0], 0.0),
+       "control points along the diagonal are 0 at 0");
+  PASS(CLOSE([straight _solveForInput: 0.5], 0.5),
+       "control points along the diagonal are 0.5 at 0.5");
+  PASS(CLOSE([straight _solveForInput: 1.0], 1.0),
+       "control points along the diagonal are 1 at 1");
+
+  PASS(CLOSE([steep _solveForInput: 0.25], 0.105889),
+       "a curve of 0.5,0,0.5,1 at 0.25");
+  PASS(CLOSE([steep _solveForInput: 0.5], 0.5),
+       "a curve of 0.5,0,0.5,1 at 0.5");
+  PASS(CLOSE([steep _solveForInput: 0.75], 0.894111),
+       "a curve of 0.5,0,0.5,1 at 0.75");
+
+  END_SET("a curve given its control points")
+
+  START_SET("outside the curve")
+
+  CAMediaTimingFunction *line = [CAMediaTimingFunction functionWithName:
+                                   kCAMediaTimingFunctionLinear];
+
+  PASS(CLOSE([line _solveForInput: -0.5], 0.0),
+       "an input below 0 is held at 0");
+  PASS(CLOSE([line _solveForInput: 1.5], 1.0),
+       "an input above 1 is held at 1");
+
+  END_SET("outside the curve")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`-_solveForInput:` answered NaN at both ends of the linear curve, at the end of ease in and at the start of ease out.

The solver divides by the slope of x(t). That slope is zero at t=0 when the first control point sits on the y axis, and at t=1 when the second sits on the line x=1. Linear has both, ease in has the second and ease out the first, so the division is 0/0 there. An epsilon was declared in the loop and never used, so nothing stopped the iteration before the division.

`-[CABasicAnimation calculatedAnimationValueAtTime:]` passes `theTime / _duration` to the timing function. That is 0 on the first frame and 1 on the last, so an animation with a linear timing function interpolated to NaN at both ends.

The loop now returns once it is within epsilon of the answer, stops when the slope is too small to divide by, and falls back to halving the interval. Values away from the ends are unchanged: ease in at 0.5 reads 0.315357 before and after.

Apple holds the curve at its ends, answering 0 below 0 and 1 above 1. This did neither, and linear answered 1.0629 at -0.5. `-evaluateYAtX:` now holds it.

`Tests/quartzcore/CAMediaTimingFunction/evaluation.m` is 22 assertions: 16 passed and 6 failed before, 22 passed after. Whole suite 49.

It adds `Tests/quartzcore/CAMediaTimingFunction/`, which #14 also adds.

Expected values checked against Apple QuartzCore.
