### PR TITLE
Fix: let a transaction turn implicit animation off

### DIFF
--- a/Source/CAImplicitAnimationObserver.m
+++ b/Source/CAImplicitAnimationObserver.m
@@ -65,6 +65,13 @@ static CAImplicitAnimationObserver * sharedObserver;
       return;
     }
 
+  /* The property still takes its new value; only the animation that would
+     have carried it there is dropped. */
+  if ([CATransaction disableActions])
+    {
+      return;
+    }
+
   id from = [change valueForKey: NSKeyValueChangeOldKey];
   id to = [change valueForKey: NSKeyValueChangeNewKey];
 

--- a/Tests/quartzcore/CALayer/TestInfo
+++ b/Tests/quartzcore/CALayer/TestInfo
@@ -1,0 +1,3 @@
+# A standalone layer answers nil from -animationKeys throughout on Apple, so
+# the implicit animation this file checks cannot be observed there.
+APPLE_SKIP_TESTS="implicit.m"

--- a/Tests/quartzcore/CALayer/implicit.m
+++ b/Tests/quartzcore/CALayer/implicit.m
@@ -1,0 +1,92 @@
+/* Implicit animation: a property change inside a transaction animates, and
+   disabling actions for that transaction stops it.
+
+   Apple documents setDisableActions: as suppressing the actions triggered by
+   property changes made within the transaction group.  A standalone layer
+   answers nil from -animationKeys throughout on Apple, so what is checked
+   here cannot be checked against it, and this file is not run there. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CATransaction.h>
+
+static BOOL
+animatesPosition(CALayer *layer)
+{
+  return [layer animationForKey: @"position"] != nil;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a property change inside a transaction")
+
+  CALayer *l = [CALayer layer];
+
+  PASS(!animatesPosition(l), "a fresh layer is not animating");
+
+  [CATransaction begin];
+  [l setPosition: CGPointMake(20, 20)];
+  [CATransaction commit];
+
+  PASS(animatesPosition(l), "changing the position animates it");
+  PASS([l position].x == 20, "the position is the one it was set to");
+
+  END_SET("a property change inside a transaction")
+
+  START_SET("a transaction with its actions disabled")
+
+  CALayer *l = [CALayer layer];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+  PASS([CATransaction disableActions], "the transaction says actions are off");
+  [l setPosition: CGPointMake(30, 30)];
+  [CATransaction commit];
+
+  PASS(!animatesPosition(l), "with actions off the change does not animate");
+  PASS([l position].x == 30, "with actions off the position still changes");
+
+  END_SET("a transaction with its actions disabled")
+
+  START_SET("actions are disabled for one transaction only")
+
+  CALayer *l = [CALayer layer];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+  [l setPosition: CGPointMake(40, 40)];
+  [CATransaction commit];
+
+  PASS(!animatesPosition(l), "the first change does not animate");
+
+  [CATransaction begin];
+  [l setPosition: CGPointMake(50, 50)];
+  [CATransaction commit];
+
+  PASS(animatesPosition(l), "a later transaction animates again");
+
+  END_SET("actions are disabled for one transaction only")
+
+  START_SET("setting a property to the value it already has")
+
+  CALayer *l = [CALayer layer];
+
+  [CATransaction begin];
+  [l setPosition: CGPointMake(60, 60)];
+  [CATransaction commit];
+  [l removeAnimationForKey: @"position"];
+
+  [CATransaction begin];
+  [l setPosition: CGPointMake(60, 60)];
+  [CATransaction commit];
+
+  PASS(!animatesPosition(l), "setting the same value again does not animate");
+
+  END_SET("setting a property to the value it already has")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`[CATransaction setDisableActions: YES]` did not suppress anything. The flag is stored on the transaction and read back by `+disableActions`, but nothing in the framework consulted it, so a property change inside such a transaction still took an implicit animation.

Apple documents `setDisableActions:` as suppressing the actions triggered by property changes made within the transaction group.

`CAImplicitAnimationObserver` is what turns a property change into an animation, so the check belongs there, and it now returns before looking for an action. The property still takes its new value; only the animation is dropped. The lookup in `-actionForKey:` is left alone, which is what Apple does: asking a layer for an action answers the same thing whether or not actions are disabled.

`Tests/quartzcore/CALayer/implicit.m` is 9 assertions: a change inside a transaction animates, one with actions disabled does not and still changes the value, the flag applies to its own transaction and not the next, and setting a property to the value it already has does not animate.

The file is named in `APPLE_SKIP_TESTS`. A standalone layer answers nil from `-animationKeys` on Apple in every case measured, including after a commit, so none of this is observable there.

7 passed and 2 failed before, 9 passed after. Whole suite 36.

#37 changes the same method, lower down; the two do not overlap.
