### PR TITLE
Feature: add CAGradientLayer

### DIFF
--- a/Headers/QuartzCore/AppleSupport.h
+++ b/Headers/QuartzCore/AppleSupport.h
@@ -79,6 +79,10 @@
 /* CAEAGLLayer.h */
 
 /* CAGradientLayer.h */
+#define CAGradientLayer GSCAGradientLayer
+#define kCAGradientLayerAxial GSkCAGradientLayerAxial
+#define kCAGradientLayerRadial GSkCAGradientLayerRadial
+#define kCAGradientLayerConic GSkCAGradientLayerConic
 
 /* CAImplicitAnimationObserver.h */
 #define CAImplicitAnimationObserver GSCAImplicitAnimationObserver

--- a/Headers/QuartzCore/AppleSupportRevert.h
+++ b/Headers/QuartzCore/AppleSupportRevert.h
@@ -56,6 +56,10 @@
 /* CAEAGLLayer.h */
 
 /* CAGradientLayer.h */
+#undef CAGradientLayer
+#undef kCAGradientLayerAxial
+#undef kCAGradientLayerRadial
+#undef kCAGradientLayerConic
 
 /* CAImplicitAnimationObserver.h */
 #undef CAImplicitAnimationObserver

--- a/Headers/QuartzCore/CAGradientLayer.h
+++ b/Headers/QuartzCore/CAGradientLayer.h
@@ -22,3 +22,31 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <QuartzCore/CALayer.h>
+
+@interface CAGradientLayer : CALayer
+{
+  NSArray *_colors;
+  NSArray *_locations;
+  CGPoint _startPoint;
+  CGPoint _endPoint;
+  NSString *_type;
+}
+
+/* An array of CGColorRef, drawn in order along the gradient. */
+@property (copy)   NSArray *colors;
+
+/* Where each colour sits along the gradient, as numbers between 0 and 1.
+   Nil spreads the colours evenly. */
+@property (copy)   NSArray *locations;
+
+@property (assign) CGPoint startPoint;
+@property (assign) CGPoint endPoint;
+@property (copy)   NSString *type;
+
+@end
+
+extern NSString *const kCAGradientLayerAxial;
+extern NSString *const kCAGradientLayerRadial;
+extern NSString *const kCAGradientLayerConic;

--- a/Source/CAGradientLayer.m
+++ b/Source/CAGradientLayer.m
@@ -62,4 +62,9 @@ NSString *const kCAGradientLayerConic = @"conic";
   [super dealloc];
 }
 
+/* TODO: draw the gradient.  The properties above are held and read back,
+   but nothing fills the backing store, so a gradient layer draws as a plain
+   layer does.  The colours and the locations map onto a CGGradient drawn
+   between startPoint and endPoint. */
+
 @end

--- a/Source/CAGradientLayer.m
+++ b/Source/CAGradientLayer.m
@@ -22,3 +22,44 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CAGradientLayer.h"
+
+NSString *const kCAGradientLayerAxial = @"axial";
+NSString *const kCAGradientLayerRadial = @"radial";
+NSString *const kCAGradientLayerConic = @"conic";
+
+@implementation CAGradientLayer
+
+@synthesize colors = _colors;
+@synthesize locations = _locations;
+@synthesize startPoint = _startPoint;
+@synthesize endPoint = _endPoint;
+@synthesize type = _type;
+
+- (id) init
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _startPoint = CGPointMake(0.5, 0.0);
+  _endPoint = CGPointMake(0.5, 1.0);
+  _type = [kCAGradientLayerAxial copy];
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_colors release];
+  [_locations release];
+  [_type release];
+
+  [super dealloc];
+}
+
+@end

--- a/Tests/quartzcore/CAGradientLayer/gradient.m
+++ b/Tests/quartzcore/CAGradientLayer/gradient.m
@@ -1,0 +1,83 @@
+/* CAGradientLayer: what a fresh gradient layer holds, and what its setters
+   keep.  Expected values checked against Apple QuartzCore.
+
+   This covers the properties only.  A gradient layer does not draw itself
+   here yet. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAGradientLayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what a gradient layer starts with")
+
+  CAGradientLayer *g = [CAGradientLayer layer];
+
+  PASS([g isKindOfClass: [CALayer class]], "a gradient layer is a layer");
+  PASS([g colors] == nil, "a gradient layer starts with no colours");
+  PASS([g locations] == nil, "a gradient layer starts with no locations");
+  PASS([g startPoint].x == 0.5 && [g startPoint].y == 0.0,
+       "a gradient starts at the middle of the top edge");
+  PASS([g endPoint].x == 0.5 && [g endPoint].y == 1.0,
+       "a gradient ends at the middle of the bottom edge");
+  PASS([[g type] isEqualToString: kCAGradientLayerAxial],
+       "a gradient layer is axial");
+  PASS([g opacity] == 1.0, "a gradient layer keeps what a layer starts with");
+
+  END_SET("what a gradient layer starts with")
+
+  START_SET("the gradient type names")
+
+  PASS([kCAGradientLayerAxial isEqualToString: @"axial"],
+       "the axial gradient is named axial");
+  PASS([kCAGradientLayerRadial isEqualToString: @"radial"],
+       "the radial gradient is named radial");
+  PASS([kCAGradientLayerConic isEqualToString: @"conic"],
+       "the conic gradient is named conic");
+
+  END_SET("the gradient type names")
+
+  START_SET("what the setters keep")
+
+  CAGradientLayer *g = [CAGradientLayer layer];
+  NSArray *locations = [NSArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.0],
+    [NSNumber numberWithFloat: 0.5],
+    [NSNumber numberWithFloat: 1.0], nil];
+
+  [g setLocations: locations];
+  PASS([[g locations] count] == 3, "the locations read back");
+  PASS([[[g locations] objectAtIndex: 1] floatValue] == 0.5,
+       "a location reads back as it was set");
+
+  [g setStartPoint: CGPointMake(0.25, 0.75)];
+  PASS([g startPoint].x == 0.25 && [g startPoint].y == 0.75,
+       "the start point reads back as it was set");
+
+  [g setEndPoint: CGPointMake(1.0, 1.0)];
+  PASS([g endPoint].x == 1.0 && [g endPoint].y == 1.0,
+       "the end point reads back as it was set");
+
+  [g setType: kCAGradientLayerRadial];
+  PASS([[g type] isEqualToString: kCAGradientLayerRadial],
+       "the type reads back as it was set");
+
+  /* Apple does not check the name against the three it knows. */
+  [g setType: @"notAGradientType"];
+  PASS([[g type] isEqualToString: @"notAGradientType"],
+       "a type that is not a gradient is kept as it was given");
+
+  [g setLocations: nil];
+  PASS([g locations] == nil, "the locations can be taken away again");
+
+  END_SET("what the setters keep")
+
+  /* Apple answers NO from +needsDisplayForKey: for colors, locations and
+     startPoint.  CALayer has no such method here, so it is not checked. */
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`Source/CAGradientLayer.m` and `Headers/QuartzCore/CAGradientLayer.h` held the copyright banner and nothing else. There was no class, so `[CAGradientLayer layer]` had nothing to message.

Adds the class with `colors`, `locations`, `startPoint`, `endPoint` and `type`, and the three gradient type names.

The values a fresh gradient layer holds are Apple's: no colours, no locations, a start point of 0.5,0 and an end point of 0.5,1, and a type of `axial`. The type names are `axial`, `radial` and `conic`. A type that is not one of the three is kept as it was given, which is also what Apple does.

`AppleSupport.h` and `AppleSupportRevert.h` get the class and the three constants, which their `CAGradientLayer.h` sections were left empty for.

This covers the properties. A gradient layer does not draw itself yet, which needs the layer display path rather than anything in this diff.

`Tests/quartzcore/CAGradientLayer/gradient.m` is 17 assertions. Whole suite 44.

Apple answers NO from `+needsDisplayForKey:` for `colors`, `locations` and `startPoint`. CALayer has no `+needsDisplayForKey:` here at all, so that is not checked and is left for whoever adds it.
