### PR TITLE
Feature: add CAScrollLayer

### DIFF
--- a/Headers/QuartzCore/AppleSupport.h
+++ b/Headers/QuartzCore/AppleSupport.h
@@ -126,6 +126,11 @@
 /* CAReplicatorLayer.h */
 
 /* CAScrollLayer.h */
+#define CAScrollLayer GSCAScrollLayer
+#define kCAScrollNone GSkCAScrollNone
+#define kCAScrollVertically GSkCAScrollVertically
+#define kCAScrollHorizontally GSkCAScrollHorizontally
+#define kCAScrollBoth GSkCAScrollBoth
 
 /* CAShapeLayer.h */
 

--- a/Headers/QuartzCore/AppleSupportRevert.h
+++ b/Headers/QuartzCore/AppleSupportRevert.h
@@ -103,6 +103,11 @@
 /* CAReplicatorLayer.h */
 
 /* CAScrollLayer.h */
+#undef CAScrollLayer
+#undef kCAScrollNone
+#undef kCAScrollVertically
+#undef kCAScrollHorizontally
+#undef kCAScrollBoth
 
 /* CAShapeLayer.h */
 

--- a/Headers/QuartzCore/CAScrollLayer.h
+++ b/Headers/QuartzCore/CAScrollLayer.h
@@ -22,3 +22,27 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <QuartzCore/CALayer.h>
+
+@interface CAScrollLayer : CALayer
+{
+  NSString *_scrollMode;
+}
+
+/* Which way this layer will scroll: one of the four names below. */
+@property (copy) NSString *scrollMode;
+
+/* Moves the origin of the bounds to the given point, as far as the scroll
+   mode allows. */
+- (void) scrollToPoint: (CGPoint)p;
+
+/* Scrolls the least amount that brings the rectangle into view. */
+- (void) scrollToRect: (CGRect)r;
+
+@end
+
+extern NSString *const kCAScrollNone;
+extern NSString *const kCAScrollVertically;
+extern NSString *const kCAScrollHorizontally;
+extern NSString *const kCAScrollBoth;

--- a/Source/CAScrollLayer.m
+++ b/Source/CAScrollLayer.m
@@ -1,8 +1,11 @@
 /* CAScrollLayer.m
 
-   Copyright (C) 2012 Free Software Foundation, Inc.
+   Copyright (C) 2012, 2026 Free Software Foundation, Inc.
 
    Author: Amr Aboelela <amraboelela@gmail.com>
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
 
    This file is part of QuartzCore.
 

--- a/Source/CAScrollLayer.m
+++ b/Source/CAScrollLayer.m
@@ -22,3 +22,84 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CAScrollLayer.h"
+
+NSString *const kCAScrollNone = @"none";
+NSString *const kCAScrollVertically = @"vertically";
+NSString *const kCAScrollHorizontally = @"horizontally";
+NSString *const kCAScrollBoth = @"both";
+
+@implementation CAScrollLayer
+
+@synthesize scrollMode = _scrollMode;
+
+- (id) init
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _scrollMode = [kCAScrollBoth copy];
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_scrollMode release];
+
+  [super dealloc];
+}
+
+- (void) scrollToPoint: (CGPoint)p
+{
+  CGRect bounds = [self bounds];
+  BOOL horizontally = [_scrollMode isEqualToString: kCAScrollHorizontally]
+                        || [_scrollMode isEqualToString: kCAScrollBoth];
+  BOOL vertically = [_scrollMode isEqualToString: kCAScrollVertically]
+                      || [_scrollMode isEqualToString: kCAScrollBoth];
+
+  if (horizontally)
+    {
+      bounds.origin.x = p.x;
+    }
+  if (vertically)
+    {
+      bounds.origin.y = p.y;
+    }
+
+  [self setBounds: bounds];
+}
+
+- (void) scrollToRect: (CGRect)r
+{
+  CGRect bounds = [self bounds];
+  CGPoint p = bounds.origin;
+
+  /* Move only as far as it takes to bring each edge inside. */
+  if (CGRectGetMaxX(r) > CGRectGetMaxX(bounds))
+    {
+      p.x = CGRectGetMaxX(r) - bounds.size.width;
+    }
+  if (CGRectGetMinX(r) < p.x)
+    {
+      p.x = CGRectGetMinX(r);
+    }
+
+  if (CGRectGetMaxY(r) > CGRectGetMaxY(bounds))
+    {
+      p.y = CGRectGetMaxY(r) - bounds.size.height;
+    }
+  if (CGRectGetMinY(r) < p.y)
+    {
+      p.y = CGRectGetMinY(r);
+    }
+
+  [self scrollToPoint: p];
+}
+
+@end

--- a/Tests/quartzcore/CAScrollLayer/scroll.m
+++ b/Tests/quartzcore/CAScrollLayer/scroll.m
@@ -1,0 +1,108 @@
+/* CAScrollLayer: the scroll mode it starts with, and where scrolling leaves
+   the bounds.  Expected values checked against Apple QuartzCore.
+
+   Scrolling moves the origin of the layer's own bounds.  The scrolling
+   methods CALayer gains from this header are not covered: they convert a
+   point from a sublayer's space, which this framework cannot do yet. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAScrollLayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what a scroll layer starts with")
+
+  CAScrollLayer *s = [CAScrollLayer layer];
+
+  PASS([s isKindOfClass: [CALayer class]], "a scroll layer is a layer");
+  PASS([[s scrollMode] isEqualToString: kCAScrollBoth],
+       "a scroll layer scrolls both ways");
+  PASS([s opacity] == 1.0, "a scroll layer keeps what a layer starts with");
+
+  END_SET("what a scroll layer starts with")
+
+  START_SET("the scroll mode names")
+
+  PASS([kCAScrollNone isEqualToString: @"none"],
+       "not scrolling is named none");
+  PASS([kCAScrollVertically isEqualToString: @"vertically"],
+       "scrolling up and down is named vertically");
+  PASS([kCAScrollHorizontally isEqualToString: @"horizontally"],
+       "scrolling side to side is named horizontally");
+  PASS([kCAScrollBoth isEqualToString: @"both"],
+       "scrolling either way is named both");
+
+  END_SET("the scroll mode names")
+
+  START_SET("scrolling to a point")
+
+  CAScrollLayer *s = [CAScrollLayer layer];
+
+  [s setBounds: CGRectMake(0, 0, 100, 100)];
+  [s scrollToPoint: CGPointMake(50, 60)];
+
+  PASS([s bounds].origin.x == 50 && [s bounds].origin.y == 60,
+       "scrolling moves the origin of the bounds");
+  PASS([s bounds].size.width == 100 && [s bounds].size.height == 100,
+       "scrolling leaves the size of the bounds alone");
+
+  END_SET("scrolling to a point")
+
+  START_SET("scrolling to a rectangle")
+
+  CAScrollLayer *s = [CAScrollLayer layer];
+
+  [s setBounds: CGRectMake(50, 60, 100, 100)];
+  [s scrollToRect: CGRectMake(200, 200, 10, 10)];
+
+  /* Far enough to bring the far edge in, and no further. */
+  PASS([s bounds].origin.x == 110 && [s bounds].origin.y == 110,
+       "scrolling to a rectangle moves as little as it can");
+
+  [s setBounds: CGRectMake(100, 100, 100, 100)];
+  [s scrollToRect: CGRectMake(120, 120, 10, 10)];
+  PASS([s bounds].origin.x == 100 && [s bounds].origin.y == 100,
+       "a rectangle already in view does not move anything");
+
+  [s setBounds: CGRectMake(100, 100, 100, 100)];
+  [s scrollToRect: CGRectMake(20, 20, 10, 10)];
+  PASS([s bounds].origin.x == 20 && [s bounds].origin.y == 20,
+       "a rectangle behind the view is scrolled back to");
+
+  [s setBounds: CGRectMake(0, 0, 100, 100)];
+  [s scrollToRect: CGRectMake(20, 20, 400, 400)];
+  PASS([s bounds].origin.x == 20 && [s bounds].origin.y == 20,
+       "a rectangle too big to fit is scrolled to its own origin");
+
+  END_SET("scrolling to a rectangle")
+
+  START_SET("a scroll mode that holds one way still")
+
+  CAScrollLayer *s = [CAScrollLayer layer];
+
+  [s setBounds: CGRectMake(0, 0, 100, 100)];
+  [s setScrollMode: kCAScrollVertically];
+  [s scrollToPoint: CGPointMake(70, 80)];
+  PASS([s bounds].origin.x == 0 && [s bounds].origin.y == 80,
+       "scrolling vertically leaves the horizontal origin alone");
+
+  [s setBounds: CGRectMake(0, 0, 100, 100)];
+  [s setScrollMode: kCAScrollHorizontally];
+  [s scrollToPoint: CGPointMake(70, 80)];
+  PASS([s bounds].origin.x == 70 && [s bounds].origin.y == 0,
+       "scrolling horizontally leaves the vertical origin alone");
+
+  [s setBounds: CGRectMake(0, 0, 100, 100)];
+  [s setScrollMode: kCAScrollNone];
+  [s scrollToPoint: CGPointMake(70, 80)];
+  PASS([s bounds].origin.x == 0 && [s bounds].origin.y == 0,
+       "a layer that does not scroll stays where it is");
+
+  END_SET("a scroll mode that holds one way still")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`Source/CAScrollLayer.m` and `Headers/QuartzCore/CAScrollLayer.h` held the copyright banner and nothing else. There was no class, so `[CAScrollLayer layer]` had nothing to message.

Adds `scrollMode`, `-scrollToPoint:` and `-scrollToRect:`, and the four scroll mode names `none`, `vertically`, `horizontally` and `both`.

A scroll layer starts scrolling both ways. Scrolling moves the origin of the bounds and leaves the size alone. `-scrollToRect:` moves as little as it takes to bring the rectangle into view: a rectangle already in view moves nothing, one behind the view is scrolled back to, and one too big to fit is scrolled to its own origin. A scroll mode of `vertically` or `horizontally` holds the other axis still, and `none` holds both. All of that is checked against Apple QuartzCore.

The scrolling methods CALayer gains from this header are not included. `-scrollPoint:` and `-scrollRectToVisible:` convert a point from the space of a sublayer, and this framework has no layer geometry conversion yet, so they are better added alongside it.

`AppleSupport.h` and `AppleSupportRevert.h` get the class and the four constants, which their `CAScrollLayer.h` sections were left empty for.

`Tests/quartzcore/CAScrollLayer/scroll.m` is 16 assertions. Whole suite 43.
