### PR TITLE
Feature: add CATextLayer

### DIFF
--- a/Headers/QuartzCore/AppleSupport.h
+++ b/Headers/QuartzCore/AppleSupport.h
@@ -130,6 +130,16 @@
 /* CAShapeLayer.h */
 
 /* CATextLayer.h */
+#define CATextLayer GSCATextLayer
+#define kCAAlignmentNatural GSkCAAlignmentNatural
+#define kCAAlignmentLeft GSkCAAlignmentLeft
+#define kCAAlignmentRight GSkCAAlignmentRight
+#define kCAAlignmentCenter GSkCAAlignmentCenter
+#define kCAAlignmentJustified GSkCAAlignmentJustified
+#define kCATruncationNone GSkCATruncationNone
+#define kCATruncationStart GSkCATruncationStart
+#define kCATruncationEnd GSkCATruncationEnd
+#define kCATruncationMiddle GSkCATruncationMiddle
 
 /* CATiledLayer.h */
 

--- a/Headers/QuartzCore/AppleSupportRevert.h
+++ b/Headers/QuartzCore/AppleSupportRevert.h
@@ -107,6 +107,16 @@
 /* CAShapeLayer.h */
 
 /* CATextLayer.h */
+#undef CATextLayer
+#undef kCAAlignmentNatural
+#undef kCAAlignmentLeft
+#undef kCAAlignmentRight
+#undef kCAAlignmentCenter
+#undef kCAAlignmentJustified
+#undef kCATruncationNone
+#undef kCATruncationStart
+#undef kCATruncationEnd
+#undef kCATruncationMiddle
 
 /* CATiledLayer.h */
 

--- a/Headers/QuartzCore/CATextLayer.h
+++ b/Headers/QuartzCore/CATextLayer.h
@@ -22,3 +22,43 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <QuartzCore/CALayer.h>
+
+@interface CATextLayer : CALayer
+{
+  id _string;
+  CFTypeRef _font;
+  CGFloat _fontSize;
+  CGColorRef _foregroundColor;
+  NSString *_alignmentMode;
+  NSString *_truncationMode;
+  BOOL _wrapped;
+}
+
+/* The text to draw, as an NSString or an NSAttributedString. */
+@property (copy)             id string;
+
+/* The font to draw it in.  A font name is enough. */
+@property (nonatomic,assign) CFTypeRef font;
+
+@property (assign)           CGFloat fontSize;
+@property (nonatomic,assign) CGColorRef foregroundColor;
+@property (copy)             NSString *alignmentMode;
+@property (copy)             NSString *truncationMode;
+
+/* Whether a line too long for the layer is carried on to the next. */
+@property (assign,getter=isWrapped) BOOL wrapped;
+
+@end
+
+extern NSString *const kCAAlignmentNatural;
+extern NSString *const kCAAlignmentLeft;
+extern NSString *const kCAAlignmentRight;
+extern NSString *const kCAAlignmentCenter;
+extern NSString *const kCAAlignmentJustified;
+
+extern NSString *const kCATruncationNone;
+extern NSString *const kCATruncationStart;
+extern NSString *const kCATruncationEnd;
+extern NSString *const kCATruncationMiddle;

--- a/Source/CATextLayer.m
+++ b/Source/CATextLayer.m
@@ -22,3 +22,95 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CATextLayer.h"
+
+NSString *const kCAAlignmentNatural = @"natural";
+NSString *const kCAAlignmentLeft = @"left";
+NSString *const kCAAlignmentRight = @"right";
+NSString *const kCAAlignmentCenter = @"center";
+NSString *const kCAAlignmentJustified = @"justified";
+
+NSString *const kCATruncationNone = @"none";
+NSString *const kCATruncationStart = @"start";
+NSString *const kCATruncationEnd = @"end";
+NSString *const kCATruncationMiddle = @"middle";
+
+@implementation CATextLayer
+
+@synthesize string = _string;
+@synthesize fontSize = _fontSize;
+@synthesize alignmentMode = _alignmentMode;
+@synthesize truncationMode = _truncationMode;
+@synthesize wrapped = _wrapped;
+
+- (id) init
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  /* Apple starts with Helvetica at this size, held as a font object.  A
+     name is the same thing to the property, and is what there is to hold
+     here. */
+  _font = [@"Helvetica" retain];
+  _fontSize = 36.0;
+  _foregroundColor = CGColorCreateGenericRGB(1.0, 1.0, 1.0, 1.0);
+  _alignmentMode = [kCAAlignmentNatural copy];
+  _truncationMode = [kCATruncationNone copy];
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [(id)_font release];
+  CGColorRelease(_foregroundColor);
+  [_string release];
+  [_alignmentMode release];
+  [_truncationMode release];
+
+  [super dealloc];
+}
+
+- (CFTypeRef) font
+{
+  return _font;
+}
+
+- (void) setFont: (CFTypeRef)font
+{
+  if (font == _font)
+    {
+      return;
+    }
+
+  [(id)font retain];
+  [(id)_font release];
+  _font = font;
+}
+
+- (CGColorRef) foregroundColor
+{
+  return _foregroundColor;
+}
+
+- (void) setForegroundColor: (CGColorRef)foregroundColor
+{
+  if (foregroundColor == _foregroundColor)
+    {
+      return;
+    }
+
+  CGColorRetain(foregroundColor);
+  CGColorRelease(_foregroundColor);
+  _foregroundColor = foregroundColor;
+}
+
+/* TODO: draw the text.  The properties above are held and read back, but
+   nothing draws a glyph, so a text layer draws as a plain layer does. */
+
+@end

--- a/Source/CATextLayer.m
+++ b/Source/CATextLayer.m
@@ -1,8 +1,11 @@
 /* CATextLayer.m
 
-   Copyright (C) 2012 Free Software Foundation, Inc.
+   Copyright (C) 2012, 2026 Free Software Foundation, Inc.
 
    Author: Amr Aboelela <amraboelela@gmail.com>
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
 
    This file is part of QuartzCore.
 

--- a/Tests/quartzcore/CATextLayer/text.m
+++ b/Tests/quartzcore/CATextLayer/text.m
@@ -1,0 +1,121 @@
+/* CATextLayer: what a fresh text layer holds and what its setters keep.
+   Expected values checked against Apple QuartzCore.
+
+   This covers the properties.  A text layer does not draw its text yet. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CATextLayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what a text layer starts with")
+
+  CATextLayer *t = [CATextLayer layer];
+
+  PASS([t isKindOfClass: [CALayer class]], "a text layer is a layer");
+  PASS([t string] == nil, "a text layer starts with no text");
+  PASS([t fontSize] == 36.0, "the text is 36 points");
+  PASS([t isWrapped] == NO, "the text is not wrapped");
+  PASS([[t alignmentMode] isEqualToString: kCAAlignmentNatural],
+       "the text is aligned naturally");
+  PASS([[t truncationMode] isEqualToString: kCATruncationNone],
+       "the text is not truncated");
+  PASS([t font] != NULL, "a text layer starts with a font");
+
+  END_SET("what a text layer starts with")
+
+  START_SET("the colour the text is drawn in")
+
+  CATextLayer *t = [CATextLayer layer];
+  CGColorRef colour = [t foregroundColor];
+
+  PASS(colour != NULL, "a text layer starts with a colour");
+  PASS(CGColorGetNumberOfComponents(colour) == 4,
+       "the colour has four components");
+  PASS(CGColorGetAlpha(colour) == 1.0, "the colour is opaque");
+
+  const CGFloat *components = CGColorGetComponents(colour);
+
+  PASS(components[0] == 1.0 && components[1] == 1.0 && components[2] == 1.0,
+       "the colour is white");
+
+  END_SET("the colour the text is drawn in")
+
+  START_SET("the alignment names")
+
+  PASS([kCAAlignmentNatural isEqualToString: @"natural"], "natural");
+  PASS([kCAAlignmentLeft isEqualToString: @"left"], "left");
+  PASS([kCAAlignmentRight isEqualToString: @"right"], "right");
+  PASS([kCAAlignmentCenter isEqualToString: @"center"], "center");
+  PASS([kCAAlignmentJustified isEqualToString: @"justified"], "justified");
+
+  END_SET("the alignment names")
+
+  START_SET("the truncation names")
+
+  PASS([kCATruncationNone isEqualToString: @"none"], "none");
+  PASS([kCATruncationStart isEqualToString: @"start"], "start");
+  PASS([kCATruncationEnd isEqualToString: @"end"], "end");
+  PASS([kCATruncationMiddle isEqualToString: @"middle"], "middle");
+
+  END_SET("the truncation names")
+
+  START_SET("what the setters keep")
+
+  CATextLayer *t = [CATextLayer layer];
+
+  [t setString: @"hello"];
+  PASS([[t string] isEqualToString: @"hello"], "the text reads back");
+
+  [t setFontSize: 12.0];
+  PASS([t fontSize] == 12.0, "the size reads back");
+
+  [t setWrapped: YES];
+  PASS([t isWrapped] == YES, "wrapping reads back");
+
+  [t setAlignmentMode: kCAAlignmentCenter];
+  PASS([[t alignmentMode] isEqualToString: kCAAlignmentCenter],
+       "the alignment reads back");
+
+  [t setTruncationMode: kCATruncationEnd];
+  PASS([[t truncationMode] isEqualToString: kCATruncationEnd],
+       "the truncation reads back");
+
+  /* Apple does not check the name against the ones it knows. */
+  [t setAlignmentMode: @"notAnAlignment"];
+  PASS([[t alignmentMode] isEqualToString: @"notAnAlignment"],
+       "an alignment that is not one of them is kept as it was given");
+
+  [t setFont: (CFTypeRef)@"Times"];
+  PASS([(id)[t font] isEqualToString: @"Times"],
+       "a font named by a string reads back as that string");
+
+  [t setString: nil];
+  PASS([t string] == nil, "the text can be taken away again");
+
+  END_SET("what the setters keep")
+
+  START_SET("the colour it is given")
+
+  CATextLayer *t = [CATextLayer layer];
+  CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
+  CGFloat values[4] = {1.0, 0.0, 0.0, 1.0};
+  CGColorRef red = CGColorCreate(space, values);
+
+  [t setForegroundColor: red];
+  PASS([t foregroundColor] == red,
+       "the colour it is given is the colour it answers");
+  CGColorRelease(red);
+  CGColorSpaceRelease(space);
+
+  PASS(CGColorGetAlpha([t foregroundColor]) == 1.0,
+       "the colour it kept is still there after the caller let go");
+
+  END_SET("the colour it is given")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`Source/CATextLayer.m` and `Headers/QuartzCore/CATextLayer.h` held the copyright banner and nothing else. There was no class, so `[CATextLayer layer]` had nothing to message.

Adds `string`, `font`, `fontSize`, `foregroundColor`, `alignmentMode`, `truncationMode` and `wrapped`, with the five alignment names and the four truncation names.

A fresh text layer holds what Apple holds: no text, 36 points, not wrapped, aligned `natural`, truncated `none`, and drawn in opaque white. An alignment or truncation name that is not one of the ones it knows is kept as it was given, which is also what Apple does.

Apple holds the default font as a CTFont for Helvetica at that size. There is no CoreText here, so the default is the name `Helvetica`. The property takes a name as readily as a font, and a font set by name reads back as that name on Apple as well.

`foregroundColor` is a `CGColorRef`, so it is declared `(nonatomic, assign)` with a written setter that retains, following the colours on CALayer.

This covers the properties. A text layer does not draw its text yet, which needs the layer display path and text drawing rather than anything in this diff. There is a TODO in the source saying so.

`Tests/quartzcore/CATextLayer/text.m` is 30 assertions. Whole suite 228 passed, with 8 dashed hopes that belong to test files already on master whose fixes are still open.
