### PR TITLE
Fix: make CATransformLayer and CAOpenGLLayer layers

### DIFF
--- a/Source/CAOpenGLLayer.m
+++ b/Source/CAOpenGLLayer.m
@@ -24,5 +24,8 @@
    Boston, MA 02110-1301, USA.
 */
 
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CAOpenGLLayer.h"
+
 @implementation CAOpenGLLayer
 @end

--- a/Source/CATransformLayer.m
+++ b/Source/CATransformLayer.m
@@ -23,5 +23,8 @@
    Boston, MA 02110-1301, USA.
 */
 
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CATransformLayer.h"
+
 @implementation CATransformLayer
 @end

--- a/Tests/quartzcore/CATransformLayer/subclass.m
+++ b/Tests/quartzcore/CATransformLayer/subclass.m
@@ -1,0 +1,48 @@
+/* CATransformLayer and CAOpenGLLayer are layers.  Both declare themselves a
+   subclass of CALayer in the header, so both should answer what a layer
+   answers.
+
+   CAOpenGLLayer is reached by name rather than by type, so that this file
+   does not name a class Apple has deprecated. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CATransformLayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a transform layer is a layer")
+
+  CATransformLayer *t = [CATransformLayer layer];
+
+  PASS(t != nil, "a transform layer can be made");
+  PASS([t isKindOfClass: [CALayer class]], "a transform layer is a layer");
+  PASS([t opacity] == 1.0, "it starts with what a layer starts with");
+
+  CALayer *child = [CALayer layer];
+
+  [t addSublayer: child];
+  PASS([[t sublayers] count] == 1, "it takes a sublayer");
+  PASS([child superlayer] == t, "and the sublayer knows it");
+
+  END_SET("a transform layer is a layer")
+
+  START_SET("an OpenGL layer is a layer")
+
+  Class openGLLayer = NSClassFromString(@"CAOpenGLLayer");
+
+  PASS(openGLLayer != Nil, "there is a CAOpenGLLayer class");
+
+  CALayer *g = [openGLLayer layer];
+
+  PASS(g != nil, "an OpenGL layer can be made");
+  PASS([g isKindOfClass: [CALayer class]], "an OpenGL layer is a layer");
+  PASS([g opacity] == 1.0, "it starts with what a layer starts with");
+
+  END_SET("an OpenGL layer is a layer")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`Source/CATransformLayer.m` and `Source/CAOpenGLLayer.m` do not import their own headers, or anything else. So each `@implementation` was compiled with no `@interface` in scope, and each became a class with no superclass.

Both headers declare the class as a subclass of CALayer, but that is not what was built. `[CATransformLayer layer]` raised `NSInvalidArgumentException`, the class not answering `+layer` at all, and `[CAOpenGLLayer layer]` did the same. Neither class could be used for anything.

The compiler has been saying it on every build:

```
warning: cannot find interface declaration for 'CATransformLayer'
warning: class 'CATransformLayer' defined without specifying a base class [-Wobjc-root-class]
```

Importing the header in each source is the whole change, and both warnings go with it.

`Tests/quartzcore/CATransformLayer/subclass.m` checks that each can be made, is a kind of CALayer, starts with what a layer starts with, and that a transform layer takes a sublayer. 2 failed sets and 1 passed before the change, 9 passed after. Whole suite 207 passed, with 8 dashed hopes belonging to test files already on master whose fixes are still open.

The file reaches CAOpenGLLayer through `NSClassFromString` so that it does not name a class Apple has deprecated.

Neither class gains any API here. CATransformLayer adds none over CALayer, and what it does differently is in rendering. CAOpenGLLayer's own methods are defined in terms of CGL, which this framework does not have.
