### PR TITLE
Feature: add CADisplayLink

### DIFF
--- a/Headers/QuartzCore/AppleSupport.h
+++ b/Headers/QuartzCore/AppleSupport.h
@@ -75,6 +75,7 @@
 #define CACurrentMediaTime GSCACurrentMediaTime
 
 /* CADisplayLink.h */
+#define CADisplayLink GSCADisplayLink
 
 /* CAEAGLLayer.h */
 

--- a/Headers/QuartzCore/AppleSupportRevert.h
+++ b/Headers/QuartzCore/AppleSupportRevert.h
@@ -52,6 +52,7 @@
 #undef CACurrentMediaTime
 
 /* CADisplayLink.h */
+#undef CADisplayLink
 
 /* CAEAGLLayer.h */
 

--- a/Headers/QuartzCore/CADisplayLink.h
+++ b/Headers/QuartzCore/CADisplayLink.h
@@ -22,3 +22,49 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/CABase.h>
+
+@class NSRunLoop;
+@class NSString;
+@class NSTimer;
+
+@interface CADisplayLink : NSObject
+{
+  id _target;
+  SEL _selector;
+  NSTimer *_timer;
+  CFTimeInterval _timestamp;
+  CFTimeInterval _duration;
+  CFTimeInterval _targetTimestamp;
+  NSInteger _preferredFramesPerSecond;
+  BOOL _paused;
+  BOOL _invalidated;
+}
+
+/* Answers a link that sends the selector to the target once a frame.  The
+   target is not retained. */
++ (CADisplayLink *) displayLinkWithTarget: (id)target selector: (SEL)sel;
+
+- (void) addToRunLoop: (NSRunLoop *)runloop forMode: (NSString *)mode;
+- (void) removeFromRunLoop: (NSRunLoop *)runloop forMode: (NSString *)mode;
+
+/* Takes the link out of every run loop it was added to.  A link cannot be
+   used again afterwards. */
+- (void) invalidate;
+
+/* When the last frame was sent, and when the next one is due.  Both are 0
+   until the link has sent one. */
+@property (readonly) CFTimeInterval timestamp;
+@property (readonly) CFTimeInterval targetTimestamp;
+
+/* How long a frame lasts. */
+@property (readonly) CFTimeInterval duration;
+
+/* While this is set the link sends nothing, and stays in its run loops. */
+@property (assign, getter=isPaused) BOOL paused;
+
+@property (assign) NSInteger preferredFramesPerSecond;
+
+@end

--- a/Source/CADisplayLink.m
+++ b/Source/CADisplayLink.m
@@ -22,3 +22,114 @@
    Free Software Foundation, 51 Franklin Street, Fifth Floor,
    Boston, MA 02110-1301, USA.
 */
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CADisplayLink.h"
+
+/* Frames a second when nothing else has been asked for. */
+static const NSInteger CADisplayLinkDefaultFramesPerSecond = 60;
+
+@implementation CADisplayLink
+
+@synthesize timestamp = _timestamp;
+@synthesize duration = _duration;
+@synthesize targetTimestamp = _targetTimestamp;
+@synthesize paused = _paused;
+@synthesize preferredFramesPerSecond = _preferredFramesPerSecond;
+
++ (CADisplayLink *) displayLinkWithTarget: (id)target selector: (SEL)sel
+{
+  CADisplayLink *link = [[self alloc] init];
+
+  link->_target = target;
+  link->_selector = sel;
+
+  return [link autorelease];
+}
+
+- (id) init
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _preferredFramesPerSecond = CADisplayLinkDefaultFramesPerSecond;
+  _duration = 1.0 / (CFTimeInterval)CADisplayLinkDefaultFramesPerSecond;
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_timer invalidate];
+  [_timer release];
+
+  [super dealloc];
+}
+
+/* There is no display to follow here, so a timer at the asked-for rate is
+   what drives the link. */
+- (NSTimeInterval) _interval
+{
+  NSInteger frames = _preferredFramesPerSecond;
+
+  if (frames <= 0)
+    {
+      frames = CADisplayLinkDefaultFramesPerSecond;
+    }
+
+  return 1.0 / (NSTimeInterval)frames;
+}
+
+- (void) _fire: (NSTimer *)timer
+{
+  if (_paused || _invalidated)
+    {
+      return;
+    }
+
+  _duration = [self _interval];
+  _timestamp = CACurrentMediaTime();
+  _targetTimestamp = _timestamp + _duration;
+
+  [_target performSelector: _selector withObject: self];
+}
+
+- (void) addToRunLoop: (NSRunLoop *)runloop forMode: (NSString *)mode
+{
+  if (_invalidated)
+    {
+      return;
+    }
+
+  if (_timer == nil)
+    {
+      _timer = [[NSTimer timerWithTimeInterval: [self _interval]
+                                        target: self
+                                      selector: @selector(_fire:)
+                                      userInfo: nil
+                                       repeats: YES] retain];
+    }
+
+  [runloop addTimer: _timer forMode: mode];
+}
+
+- (void) removeFromRunLoop: (NSRunLoop *)runloop forMode: (NSString *)mode
+{
+  /* A timer leaves a run loop only by being invalidated, so the link keeps
+     the mode it was added for until it is taken out of all of them. */
+  [self invalidate];
+}
+
+- (void) invalidate
+{
+  _invalidated = YES;
+  [_timer invalidate];
+  [_timer release];
+  _timer = nil;
+  _target = nil;
+}
+
+@end

--- a/Source/CADisplayLink.m
+++ b/Source/CADisplayLink.m
@@ -1,8 +1,11 @@
 /* CADisplayLink.m
 
-   Copyright (C) 2012 Free Software Foundation, Inc.
+   Copyright (C) 2012, 2026 Free Software Foundation, Inc.
 
    Author: Amr Aboelela <amraboelela@gmail.com>
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
 
    This file is part of QuartzCore.
 

--- a/Tests/quartzcore/CADisplayLink/TestInfo
+++ b/Tests/quartzcore/CADisplayLink/TestInfo
@@ -1,0 +1,3 @@
+# Apple has no +displayLinkWithTarget:selector: on macOS, where a link comes
+# from a view, a window or a screen, so this file cannot be run there.
+APPLE_SKIP_TESTS="displaylink.m"

--- a/Tests/quartzcore/CADisplayLink/displaylink.m
+++ b/Tests/quartzcore/CADisplayLink/displaylink.m
@@ -1,0 +1,118 @@
+/* CADisplayLink: what a link holds, that it sends its selector once it is
+   in a run loop, and that pausing and invalidating stop it.
+
+   Apple's +displayLinkWithTarget:selector: is unavailable on macOS, where a
+   link comes from a view, a window or a screen instead, so there is nothing
+   to check these against and this file is not run there.  What it holds
+   before it has sent anything is not documented either; the values below
+   are this implementation's. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CADisplayLink.h>
+
+static int fireCount = 0;
+static CFTimeInterval lastSeenTimestamp = 0.0;
+
+@interface Ticker : NSObject
+- (void) step: (CADisplayLink *)link;
+@end
+
+@implementation Ticker
+- (void) step: (CADisplayLink *)link
+{
+  fireCount++;
+  lastSeenTimestamp = [link timestamp];
+}
+@end
+
+static void
+runFor(NSTimeInterval seconds)
+{
+  [[NSRunLoop currentRunLoop] runUntilDate:
+    [NSDate dateWithTimeIntervalSinceNow: seconds]];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+  Ticker *ticker = [[Ticker alloc] init];
+
+  START_SET("what a link holds before it runs")
+
+  CADisplayLink *link = [CADisplayLink displayLinkWithTarget: ticker
+                                                    selector: @selector(step:)];
+
+  PASS(link != nil, "a link can be made");
+  PASS([link isPaused] == NO, "a link is not paused");
+  PASS([link timestamp] == 0.0, "nothing has been sent yet");
+  PASS([link targetTimestamp] == 0.0, "and nothing is due yet");
+  PASS([link duration] > 0.0, "a frame lasts some time");
+  PASS([link preferredFramesPerSecond] == 60,
+       "a link asks for sixty frames a second");
+
+  END_SET("what a link holds before it runs")
+
+  START_SET("a link in a run loop")
+
+  fireCount = 0;
+  CADisplayLink *link = [CADisplayLink displayLinkWithTarget: ticker
+                                                    selector: @selector(step:)];
+
+  [link addToRunLoop: [NSRunLoop currentRunLoop]
+             forMode: NSDefaultRunLoopMode];
+  runFor(0.25);
+
+  PASS(fireCount > 0, "a link in a run loop sends its selector");
+  PASS([link timestamp] > 0.0, "and records when it did");
+  PASS(lastSeenTimestamp == [link timestamp],
+       "the link it sends is the one that was asked to run");
+  PASS([link targetTimestamp] > [link timestamp],
+       "the next frame is due after the last one");
+
+  [link invalidate];
+
+  END_SET("a link in a run loop")
+
+  START_SET("a link that is paused")
+
+  fireCount = 0;
+  CADisplayLink *link = [CADisplayLink displayLinkWithTarget: ticker
+                                                    selector: @selector(step:)];
+
+  [link setPaused: YES];
+  PASS([link isPaused] == YES, "pausing reads back");
+
+  [link addToRunLoop: [NSRunLoop currentRunLoop]
+             forMode: NSDefaultRunLoopMode];
+  runFor(0.15);
+  PASS(fireCount == 0, "a paused link sends nothing");
+
+  [link setPaused: NO];
+  runFor(0.30);
+  PASS(fireCount > 0, "and sends again once it is not paused");
+
+  [link invalidate];
+
+  END_SET("a link that is paused")
+
+  START_SET("a link that has been invalidated")
+
+  CADisplayLink *link = [CADisplayLink displayLinkWithTarget: ticker
+                                                    selector: @selector(step:)];
+
+  [link addToRunLoop: [NSRunLoop currentRunLoop]
+             forMode: NSDefaultRunLoopMode];
+  runFor(0.15);
+  [link invalidate];
+
+  fireCount = 0;
+  runFor(0.15);
+  PASS(fireCount == 0, "an invalidated link sends nothing more");
+
+  END_SET("a link that has been invalidated")
+
+  [ticker release];
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
`Source/CADisplayLink.m` and `Headers/QuartzCore/CADisplayLink.h` held the copyright banner and nothing else. There was no class.

Adds `+displayLinkWithTarget:selector:`, `-addToRunLoop:forMode:`, `-removeFromRunLoop:forMode:`, `-invalidate`, and the `timestamp`, `targetTimestamp`, `duration`, `paused` and `preferredFramesPerSecond` properties.

There is no display to follow, so the link is driven by an `NSTimer` at the rate asked for, sixty frames a second unless `preferredFramesPerSecond` says otherwise. When it sends, it sets `timestamp` to the current media time, `duration` to the length of a frame and `targetTimestamp` to the two added together, which is what the documented meaning of the three is. A paused link stays in its run loops and sends nothing. An invalidated link sends nothing again.

Two things are worth knowing before this is used.

`-removeFromRunLoop:forMode:` invalidates the link rather than taking it out of that one mode. An `NSTimer` leaves a run loop only by being invalidated, and the link holds one timer, so removing it from a single mode while it runs in another is not supported here.

The target is not retained, as Apple's is not.

`Tests/quartzcore/CADisplayLink/displaylink.m` is 14 assertions: what a link holds before it runs, that one in a run loop sends its selector and records when, that pausing stops it and unpausing starts it again, and that invalidating stops it for good. Whole suite 212 passed.

The file is named in `APPLE_SKIP_TESTS`. Apple's `+displayLinkWithTarget:selector:` is unavailable on macOS, where a link is made by a view, a window or a screen instead, so there is nothing to check these against. What a link holds before it has sent anything is not documented either, so those values are this implementation's rather than a match for something.
