### PR TITLE
Fix: take an end the animation was not given from the layer

### DIFF
--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -625,22 +625,11 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
                               onLayer: (CALayer *)layer
 {
   /*
-    Currently supporting scenarios with:
-     - fromValue != nil
-     - toValue != nil
-     - byValue == nil
-    and
-     - fromValue != nil
-     - toValue == nil
-     - byValue == nil
-    and
-     - fromValue == nil
-     - toValue == nil
-     - byValue == nil
-    and
-     - fromValue == nil
-     - toValue != nil
-     - byValue == nil
+    An end the animation was not given is taken from the layer, so an
+    animation carrying only a from value runs to the value the layer
+    already has, and one carrying only a to value starts from it.
+
+    byValue is not supported yet.
 
     All supplied values need to be of same data type.
    */
@@ -657,8 +646,23 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
   id fromValue = _fromValue;
   id toValue = _toValue;
 
-  if (!toValue)
-    toValue = [[layer modelLayer] valueForKeyPath: _keyPath];
+  if ((!fromValue || !toValue) && _keyPath)
+    {
+      /* The layer being animated is the presentation layer, and the value
+         to fall back on is the one its model holds.  A layer that stands
+         in for no other one is its own model. */
+      CALayer *modelLayer = [layer modelLayer];
+      id layerValue;
+
+      if (!modelLayer)
+        modelLayer = layer;
+      layerValue = [modelLayer valueForKeyPath: _keyPath];
+
+      if (!fromValue)
+        fromValue = layerValue;
+      if (!toValue)
+        toValue = layerValue;
+    }
 
   if ([fromValue isKindOfClass: [NSNumber class]] &&
       [toValue isKindOfClass: [NSNumber class]])


### PR DESCRIPTION
A basic animation carrying only a from value, or only a to value, calculated nothing and so animated nothing. Only the pair together did anything, which leaves out a to value on its own.

Apple takes the missing end from the layer: an animation with only a from value runs to the value the layer already has, one with only a to value starts from it. The to value was already looked up that way, the from value now is too, through one lookup. -modelLayer answers nil for a layer standing in for no other one, so the layer is used directly; that line can go once #35 lands. The lookup is skipped when there is no key path, which -valueForKeyPath: would raise on. byValue is still not read.

The tests are in #63, which this branch does not carry. With both applied the suite goes from 226 passed and 16 dashed to 228 and 14, nothing failing.