### PR TITLE
Fix: bind the texture, and keep an Apple parameter to Apple

### DIFF
--- a/Source/GLHelpers/CAGLTexture.m
+++ b/Source/GLHelpers/CAGLTexture.m
@@ -83,6 +83,10 @@
   glPixelStorei(GL_UNPACK_CLIENT_STORAGE_APPLE, GL_FALSE);
 #endif
 
+  /* Without this the image is made in whatever texture is bound, and this
+     one keeps a size it does not hold. */
+  glBindTexture(TEXTURE_TARGET, _textureID);
+
   /* Used for, for example, renderbuffer's target */
 #if !(USE_BUILDMIPMAPS)
   qcLoadTexImage(GL_RGBA,
@@ -221,7 +225,7 @@
   GLuint internalFormat = GL_RGBA; /* does not depend on hasAlpha, we always paint a RGBA image into CGContext (sadly) */
   #endif
 
-  #if !USE_RECT
+  #if __APPLE__ && !USE_RECT
   /* Since we release the context, we also release its pixels.
      We cannot use client storage extension. */
   glPixelStorei(GL_UNPACK_CLIENT_STORAGE_APPLE, GL_FALSE);


### PR DESCRIPTION
-loadEmptyImageWithWidth:height: never bound, so glTexImage2D made the image in whatever texture GL was holding, while the texture the caller asked about kept a width and height it did not hold. Asking GL for the level 0 width of a texture loaded that way answered 0 where the object answered 32. -loadRGBATexImage:width:height: binds first, and this now does the same. CAGLSimpleFramebuffer binds the texture before it loads into it, which is why nothing has noticed.

-loadImage: asked for GL_UNPACK_CLIENT_STORAGE_APPLE outside an __APPLE__ guard, where the two other callers of it have one. A GL without that parameter answers GL_INVALID_ENUM and keeps it until somebody reads the error, so the next unrelated check found an error that was not its own.

The tests are in #66, which this branch does not carry. With both applied the suite under Xvfb goes from 243 passed and 14 dashed to 246 and 11, nothing failing. The three that turn green are that GL holds an image of the width the texture reports, that the texture loaded into is left bound, and that loading an image leaves no error behind.
