### PR TITLE
Fix: leave bound the framebuffer that was bound before

### DIFF
--- a/Source/GLHelpers/CAGLSimpleFramebuffer.m
+++ b/Source/GLHelpers/CAGLSimpleFramebuffer.m
@@ -42,9 +42,13 @@ static NSMutableArray * framebufferStack = nil;
 - (id)initWithWidth: (CGFloat) width
              height: (CGFloat) height
 {
+  GLint previousFramebuffer = 0;
+
   self = [super init];
   if (!self)
     return nil;
+
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING_EXT, &previousFramebuffer);
 
   glGenFramebuffers(1, &_framebufferID);
 
@@ -65,6 +69,11 @@ static NSMutableArray * framebufferStack = nil;
 
   glBindFramebuffer(GL_FRAMEBUFFER_EXT, _framebufferID);
   glFramebufferTexture2D(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, [_texture textureTarget], [_texture textureID], 0);
+
+  /* Attaching the texture needs this one bound, but a framebuffer that has
+     only been created is not on the stack -bind and -unbind keep, so leave
+     bound whatever was bound before. */
+  glBindFramebuffer(GL_FRAMEBUFFER_EXT, previousFramebuffer);
 
   return self;
 }


### PR DESCRIPTION
-initWithWidth:height: binds the new framebuffer to attach the texture to it and never unbinds, so creating one silently changed what GL draws into. A framebuffer that has only been created is not on the stack -bind and -unbind keep, so the two disagreed until the next -bind and -unbind pair reset the binding to zero.

What was bound before is now read and put back. The commented out block at the end of the file shows the same thing being done with a zero, which would be wrong inside an enclosing binding.

The tests are in #66, which this branch does not carry. With both applied the suite under Xvfb goes from 243 passed and 14 dashed to 244 and 13, nothing failing. The one that turns green is that creating a framebuffer leaves the framebuffer that was bound before.
