### PR TITLE
Fix: give a backing store its texture before its context

### DIFF
--- a/Source/CABackingStore.m
+++ b/Source/CABackingStore.m
@@ -104,9 +104,12 @@ static CGContextRef createCGBitmapContext (int pixelsWide,
     return nil;
 
   CGContextRef context = createCGBitmapContext(width, height);
-  [self setContext: context];
+
+  /* -setContext: refreshes, and there is nowhere to refresh into until the
+     texture is here. */
   [self setContentsTexture: [CAGLTexture texture]];
   [self setOffscreenRenderTexture: nil]; /* set at a later time by layer */
+  [self setContext: context];
 
   CGContextRelease(context);
 


### PR DESCRIPTION
-initWithWidth:height: set the context first, and -setContext: calls -refresh, which loads the contents into the contents texture. The texture was set on the line after, so the refresh had nothing to load into and the contents never reached GL. A newly built backing store answered 64 by 48 for itself and 0 by 0 for its texture until something called -refresh a second time.

The texture and the offscreen texture are now set before the context.

The tests are in #66, which this branch does not carry. With both applied the suite under Xvfb goes from 243 passed and 14 dashed to 244 and 13, nothing failing. The one that turns green is that a backing store's texture holds the contents once it has been created.
