### PR TITLE
Fix: do not compile a shader that has no source

### DIFF
--- a/Source/GLHelpers/CAGLShader.m
+++ b/Source/GLHelpers/CAGLShader.m
@@ -96,6 +96,11 @@
   if (_compiled)
     return;
 
+  /* A shader that was not built from a file has nothing to hand GL, and
+     handing it nothing is an error rather than an empty shader. */
+  if (!_source)
+    return;
+
   _compiled = YES;
 
   /* Upload the shader to the GPU */


### PR DESCRIPTION
-compile handed GL the result of [nil UTF8String] as the shader source, which is an error rather than an empty shader, and marked the shader compiled on the way past so a later call would do nothing at all. A shader only holds source when it was built from a file, and -initWithFile:ofType: answers nil when the file is not there, so the case arises from -init on its own.

It now returns before the compiled flag is set, leaving the shader as it was and GL's error state alone.

The tests are in #66, which this branch does not carry. With both applied the suite under Xvfb goes from 358 passed and 18 dashed to 359 and 17, nothing failing. The one that turns green is that asking a shader with no source to compile leaves no error behind.
