### PR TITLE
Fix: ask GL to validate a program when it is asked to validate one

### DIFF
--- a/Source/GLHelpers/CAGLProgram.m
+++ b/Source/GLHelpers/CAGLProgram.m
@@ -78,22 +78,19 @@
 
 - (void) validate
 {
-  [_shaders makeObjectsPerformSelector: @selector(compile)
-                            withObject: nil];
+  /* A program has to be linked before GL will validate it, and linking a
+     second time would attach every shader twice. */
+  if ([self linkStatus] == GL_FALSE)
+    {
+      [self link];
+    }
 
-  /* TODO: Make printing logs depend on a user default */
-  [_shaders makeObjectsPerformSelector: @selector(printLog)
-                            withObject: nil];
-
-  [_shaders makeObjectsPerformSelector: @selector(attachToProgram:)
-                            withObject: self];
-
-  glLinkProgram(_programID);
+  glValidateProgram(_programID);
 }
 - (GLint) validateStatus
 {
   GLint status;
-  glGetProgramiv(_programID, GL_LINK_STATUS, &status);
+  glGetProgramiv(_programID, GL_VALIDATE_STATUS, &status);
   return status;
 }
 - (void) printValidateLog


### PR DESCRIPTION
-validate was a copy of -link: it compiled the shaders, attached them and linked, and never called glValidateProgram. -validateStatus read GL_LINK_STATUS, so it answered true for a program GL had never validated. Calling -validate after -link also attached every shader a second time, which is an error, so a caller doing the two in order was left with GL_INVALID_OPERATION set.

-validate now links only if the program has not been linked, then asks GL to validate it, and -validateStatus reads GL_VALIDATE_STATUS. Nothing in the framework calls either; CARenderer links its three programs and never validates them.

The tests are in #66, which this branch does not carry. With both applied the suite under Xvfb goes from 358 passed and 18 dashed to 361 and 15, nothing failing. The three that turn green are that validating asks GL to validate, that the status read back is the validation status, and that validating leaves no error behind.
