### PR TITLE
Fix: draw a layer where the layer says it is

### DIFF
--- a/Source/CARenderer.m
+++ b/Source/CARenderer.m
@@ -252,6 +252,8 @@
    should be rendering the update region only. */
 - (void) render
 {
+  GLfloat projection[16];
+
   /* If we have nothing to render, just skip rendering */
   CGRect updateBounds = [self updateBounds];
   if (isinf(updateBounds.origin.x) &&
@@ -264,8 +266,8 @@
      they are taken as normalised device coordinates, where anything two
      units or more across covers the whole drawable.  Map the renderer's
      bounds onto it instead, so that a point is a point. */
+  glGetFloatv(GL_PROJECTION_MATRIX, projection);
   glMatrixMode(GL_PROJECTION);
-  glPushMatrix();
   glLoadIdentity();
   glOrtho(CGRectGetMinX(_bounds), CGRectGetMaxX(_bounds),
           CGRectGetMinY(_bounds), CGRectGetMaxY(_bounds),
@@ -288,7 +290,7 @@
 
   /* Restore defaults */
   glMatrixMode(GL_PROJECTION);
-  glPopMatrix();
+  glLoadMatrixf(projection);
 
   glMatrixMode(GL_MODELVIEW);
   glClearColor(0.0, 0.0, 0.0, 0.0);

--- a/Source/CARenderer.m
+++ b/Source/CARenderer.m
@@ -260,6 +260,17 @@
 
   [_GLContext makeCurrentContext];
 
+  /* A layer's vertices are its bounds, in points.  Without a projection
+     they are taken as normalised device coordinates, where anything two
+     units or more across covers the whole drawable.  Map the renderer's
+     bounds onto it instead, so that a point is a point. */
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadIdentity();
+  glOrtho(CGRectGetMinX(_bounds), CGRectGetMaxX(_bounds),
+          CGRectGetMinY(_bounds), CGRectGetMaxY(_bounds),
+          -1.0, 1.0);
+
   glMatrixMode(GL_MODELVIEW);
 
   glEnableClientState(GL_VERTEX_ARRAY);
@@ -276,6 +287,9 @@
        withTransform: CATransform3DIdentity];
 
   /* Restore defaults */
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+
   glMatrixMode(GL_MODELVIEW);
   glClearColor(0.0, 0.0, 0.0, 0.0);
   glDisableClientState(GL_VERTEX_ARRAY);


### PR DESCRIPTION
Nothing in the framework ever set a projection or a viewport, so the vertices -_renderLayer:withTransform: builds, which are the layer's bounds in points, were taken as normalised device coordinates. A layer two units or more across covered the whole drawable whatever its bounds said, -[CARenderer setBounds:] made no difference to what was drawn, and a sublayer, translated by half its superlayer's size to sit relative to its corner, was put outside the clip volume and never seen.

-render now maps the renderer's bounds onto the drawable with an orthographic projection, so a point is a point, and puts the previous projection back afterwards with the rest of the state it restores.

The offscreen passes are not addressed. Rasterization draws into a 512 by 512 framebuffer expecting its pixels, and the shadow blur draws a quad from -256 to 256 expecting the origin in the middle; each needs its own projection, and neither is reached by a layer that is not rasterized and casts no shadow.

The tests are in #72. With both applied the suite under Xvfb goes from 314 passed and 13 dashed to 318 and 9, nothing failing.
