### PR TITLE
Feature: add CAAnimationGroup and run the animations it holds

### DIFF
--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -134,6 +134,17 @@ extern NSString *const kCAAnimationCubicPaced;
 
 /* *********************************** */
 
+@interface CAAnimationGroup : CAAnimation
+{
+  /* property-backing ivars */
+  NSArray * _animations;
+}
+@property(copy) NSArray* animations;
+
+@end
+
+/* *********************************** */
+
 @interface CATransition : CAAnimation
 {
   NSString * _type;

--- a/Source/CAAnimation+FrameworkPrivate.h
+++ b/Source/CAAnimation+FrameworkPrivate.h
@@ -31,8 +31,14 @@
 @interface CAAnimation (FrameworkPrivate)
 - (void) handleAddedToLayer: (CALayer *)layer;
 - (void) handleRemovedFromLayer: (CALayer *)layer;
-@end
 
-@interface CAPropertyAnimation (FrameworkPrivate)
+/* Local time in the receiver's own time space, given the local time of the
+   time authority it runs in.  The authority is the model layer for an
+   animation added to a layer, and the group for an animation inside a
+   CAAnimationGroup. */
+- (CFTimeInterval) localTimeWithTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime;
+
 - (void) applyToLayer: (CALayer *)layer;
+- (void) applyToLayer: (CALayer *)layer
+  withTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime;
 @end

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -262,8 +262,12 @@ NSString *const kCATransitionFromRight = @"fromRight";
 
 - (CFTimeInterval) localTimeWithTimeAuthority: (id<CAMediaTiming>)timeAuthority
 {
+  return [self localTimeWithTimeAuthorityLocalTime: [timeAuthority localTime]];
+}
+
+- (CFTimeInterval) localTimeWithTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime
+{
   /* Slides */
-  CFTimeInterval timeAuthorityLocalTime = [timeAuthority localTime];
   CFTimeInterval activeTime = [self activeTimeWithTimeAuthorityLocalTime: timeAuthorityLocalTime];
   if (isinf([self duration]))
     return activeTime;
@@ -276,6 +280,18 @@ NSString *const kCATransitionFromRight = @"fromRight";
     }
 
   return localTime;
+}
+
+- (void) applyToLayer: (CALayer *)layer
+{
+  [self applyToLayer: layer
+    withTimeAuthorityLocalTime: [[layer modelLayer] localTime]];
+}
+
+- (void) applyToLayer: (CALayer *)layer
+  withTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime
+{
+  /* noop. */
 }
 
 - (void)runActionForKey: (NSString *)key
@@ -409,8 +425,9 @@ NSString *const kCATransitionFromRight = @"fromRight";
 }
 
 - (void) applyToLayer: (CALayer *)layer
+  withTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime
 {
-  CFTimeInterval theTime = [self localTimeWithTimeAuthority: [layer modelLayer]];
+  CFTimeInterval theTime = [self localTimeWithTimeAuthorityLocalTime: timeAuthorityLocalTime];
 
   /* FIXME: temporary check until we have fillMode implementation */
   /* Also, why do we get theTime < 0? */
@@ -1028,6 +1045,55 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize damping = _damping;
 @synthesize initialVelocity = _initialVelocity;
 @synthesize settlingDuration = _settlingDuration;
+@end
+
+@implementation CAAnimationGroup
+@synthesize animations=_animations;
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"animations"])
+    {
+      return nil;
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  id theCopy = [super copyWithZone: zone];
+  if (!theCopy)
+    return nil;
+
+  [theCopy setAnimations: [self animations]];
+
+  return theCopy;
+}
+
+- (void) dealloc
+{
+  [_animations release];
+
+  [super dealloc];
+}
+
+- (void) applyToLayer: (CALayer *)layer
+  withTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime
+{
+  /* The grouped animations are evaluated in the time space of the receiver.
+     Their durations are left as they are, so one that outlasts the group is
+     clipped by the group rather than scaled into it. */
+  CFTimeInterval theTime =
+    [self localTimeWithTimeAuthorityLocalTime: timeAuthorityLocalTime];
+
+  for (CAAnimation * animation in [self animations])
+    {
+      [animation applyToLayer: layer
+        withTimeAuthorityLocalTime: theTime];
+    }
+}
+
 @end
 
 @implementation CATransition

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -900,16 +900,14 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
       if (nextFrameTime > CACurrentMediaTime())
         {
           /* TODO: update for correctness once we support fillMode */
-          /* TODO: take into account animation groups once we support them */
 
           continue;
         }
 
-      if ([animation isKindOfClass: [CAPropertyAnimation class]])
+      if ([animation isKindOfClass: [CAPropertyAnimation class]] ||
+          [animation isKindOfClass: [CAAnimationGroup class]])
         {
-          CAPropertyAnimation * propertyAnimation = ((CAPropertyAnimation *)animation);
-
-          if ([propertyAnimation removedOnCompletion] && [propertyAnimation activeTimeWithTimeAuthorityLocalTime: [self localTime]] > [propertyAnimation duration] * [propertyAnimation repeatCount] * ([propertyAnimation autoreverses] ? 2 : 1))
+          if ([animation removedOnCompletion] && [animation activeTimeWithTimeAuthorityLocalTime: [self localTime]] > [animation duration] * [animation repeatCount] * ([animation autoreverses] ? 2 : 1))
             {
               /* FIXME: doesn't take into account speed */
 
@@ -917,7 +915,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
               continue; /* Prevents animation from applying for one frame longer than its duration */
             }
 
-          [propertyAnimation applyToLayer: self];
+          [animation applyToLayer: self];
 
         }
     }

--- a/Tests/quartzcore/CAAnimationGroup/TestInfo
+++ b/Tests/quartzcore/CAAnimationGroup/TestInfo
@@ -1,0 +1,3 @@
+# -applyToLayer: and the time authority an animation is evaluated in are
+# GNUstep API with no counterpart in Apple QuartzCore.
+APPLE_SKIP_TESTS="apply.m"

--- a/Tests/quartzcore/CAAnimationGroup/apply.m
+++ b/Tests/quartzcore/CAAnimationGroup/apply.m
@@ -1,0 +1,186 @@
+/* Running the animations a CAAnimationGroup holds.
+
+   -applyToLayer: and the time authority an animation is evaluated in are
+   GNUstep API with no counterpart in Apple QuartzCore, so this file is named
+   in APPLE_SKIP_TESTS.  Apple documents the behaviour the values below
+   check: the grouped animations keep their own durations and are clipped by
+   the group rather than scaled into it. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAAnimation (Apply)
+- (void) applyToLayer: (CALayer *)layer;
+- (void) applyToLayer: (CALayer *)layer
+  withTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime;
+@end
+
+@interface CALayer (Apply)
+- (CFTimeInterval) applyAnimationsAtTime: (CFTimeInterval)theTime;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static CABasicAnimation *
+opacityFrom(float from, float to, CFTimeInterval duration)
+{
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [b setDuration: duration];
+  [b setFromValue: [NSNumber numberWithFloat: from]];
+  [b setToValue: [NSNumber numberWithFloat: to]];
+  return b;
+}
+
+static CAAnimationGroup *
+groupOf(CAAnimation *animation, CFTimeInterval duration)
+{
+  CAAnimationGroup *g = [CAAnimationGroup animation];
+
+  [g setDuration: duration];
+  [g setAnimations: [NSArray arrayWithObject: animation]];
+  return g;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a group runs the animations it holds")
+
+  CALayer *layer = [CALayer layer];
+  [layer setOpacity: 0.5];
+
+  CAAnimationGroup *g = groupOf(opacityFrom(0.0, 1.0, 4.0), 4.0);
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 1.0];
+
+  PASS(CLOSE([layer opacity], 0.25),
+       "a quarter of the way through, the layer holds a quarter of the value");
+
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 3.0];
+
+  PASS(CLOSE([layer opacity], 0.75), "and three quarters of the way through");
+
+  END_SET("a group runs the animations it holds")
+
+  START_SET("a group that holds nothing")
+
+  CALayer *layer = [CALayer layer];
+  [layer setOpacity: 0.5];
+
+  CAAnimationGroup *g = [CAAnimationGroup animation];
+  [g setDuration: 4.0];
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 1.0];
+
+  PASS(CLOSE([layer opacity], 0.5), "leaves the layer where it was");
+
+  END_SET("a group that holds nothing")
+
+  START_SET("an animation longer than its group")
+
+  /* Apple: the durations of the grouped animations are not scaled to the
+     duration of the group, they are clipped to it.  An eight second
+     animation in a two second group shows its first two seconds. */
+  CALayer *layer = [CALayer layer];
+  CAAnimationGroup *g = groupOf(opacityFrom(0.0, 1.0, 8.0), 2.0);
+
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 1.0];
+
+  PASS(CLOSE([layer opacity], 0.125),
+       "one second in, the animation is one eighth of its own duration along");
+
+  END_SET("an animation longer than its group")
+
+  START_SET("an animation shorter than its group")
+
+  CALayer *layer = [CALayer layer];
+  CAAnimationGroup *g = groupOf(opacityFrom(0.0, 1.0, 2.0), 8.0);
+
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 1.0];
+
+  PASS(CLOSE([layer opacity], 0.5),
+       "one second in, it is half way through its own two seconds");
+
+  END_SET("an animation shorter than its group")
+
+  START_SET("the time a grouped animation begins")
+
+  /* The animations are evaluated in the time space of the group, so a begin
+     time inside one is counted from the start of the group. */
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = opacityFrom(0.0, 1.0, 2.0);
+  [b setBeginTime: 1.0];
+
+  CAAnimationGroup *g = groupOf(b, 4.0);
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 2.0];
+
+  PASS(CLOSE([layer opacity], 0.5),
+       "a second after it begins it is half way through its two seconds");
+
+  END_SET("the time a grouped animation begins")
+
+  START_SET("the time the group itself begins")
+
+  CALayer *layer = [CALayer layer];
+  CAAnimationGroup *g = groupOf(opacityFrom(0.0, 1.0, 4.0), 4.0);
+  [g setBeginTime: 2.0];
+
+  [g applyToLayer: layer withTimeAuthorityLocalTime: 3.0];
+
+  PASS(CLOSE([layer opacity], 0.25),
+       "the group starts its animations when the group itself begins");
+
+  END_SET("the time the group itself begins")
+
+  START_SET("a group inside a group")
+
+  CALayer *layer = [CALayer layer];
+  CAAnimationGroup *inner = groupOf(opacityFrom(0.0, 1.0, 4.0), 4.0);
+  CAAnimationGroup *outer = groupOf(inner, 4.0);
+
+  [outer applyToLayer: layer withTimeAuthorityLocalTime: 1.0];
+
+  PASS(CLOSE([layer opacity], 0.25),
+       "the innermost animation is reached through both groups");
+
+  END_SET("a group inside a group")
+
+  START_SET("applying a group with no time of its own")
+
+  CALayer *layer = [CALayer layer];
+  [layer setOpacity: 0.5];
+
+  CAAnimationGroup *g = groupOf(opacityFrom(0.0, 1.0, 4.0), 4.0);
+  [g applyToLayer: layer];
+
+  PASS(CLOSE([layer opacity], 0.0),
+       "a layer that is nothing's presentation layer gives the time zero");
+
+  END_SET("applying a group with no time of its own")
+
+  START_SET("a layer runs a group it was given")
+
+  CALayer *layer = [CALayer layer];
+  [layer setOpacity: 0.25];
+
+  CAAnimationGroup *g = groupOf(opacityFrom(0.0, 1.0, 4.0), 4.0);
+  [g setBeginTime: CACurrentMediaTime()];
+  [layer addAnimation: g forKey: @"group"];
+
+  CALayer *presentation = [layer presentationLayer];
+  [presentation applyAnimationsAtTime: CACurrentMediaTime()];
+
+  PASS([presentation opacity] < 0.01,
+       "a group that has just begun writes the value its animations start at");
+  PASS(CLOSE([layer opacity], 0.25),
+       "and the model layer keeps the value it had");
+
+  END_SET("a layer runs a group it was given")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAAnimationGroup/group.m
+++ b/Tests/quartzcore/CAAnimationGroup/group.m
@@ -1,0 +1,72 @@
+/* What a CAAnimationGroup holds, and what a copy of one holds.
+
+   Running the grouped animations is checked in apply.m, against API this
+   framework declares privately.  Everything here is public API and holds
+   against Apple QuartzCore as well. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a group is an animation")
+
+  CAAnimationGroup *g = [CAAnimationGroup animation];
+
+  PASS(g != nil, "a group is made by +animation");
+  PASS([CAAnimationGroup superclass] == [CAAnimation class],
+       "a group derives from CAAnimation");
+  PASS([g animations] == nil, "it holds no animations to begin with");
+
+  END_SET("a group is an animation")
+
+  START_SET("the animations a group holds")
+
+  CAAnimationGroup *g = [CAAnimationGroup animation];
+  CABasicAnimation *a = [CABasicAnimation animationWithKeyPath: @"opacity"];
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"position"];
+  NSMutableArray *both = [NSMutableArray arrayWithObjects: a, b, nil];
+
+  [g setAnimations: both];
+
+  PASS([[g animations] count] == 2, "a group holds the animations it is given");
+  PASS([[g animations] objectAtIndex: 0] == a &&
+       [[g animations] objectAtIndex: 1] == b,
+       "in the order they were given in");
+
+  [both removeAllObjects];
+
+  PASS([[g animations] count] == 2,
+       "the array is copied, so emptying the original leaves the group alone");
+
+  [g setAnimations: nil];
+
+  PASS([g animations] == nil, "and the group can be emptied again");
+
+  END_SET("the animations a group holds")
+
+  START_SET("copying a group")
+
+  CAAnimationGroup *g = [CAAnimationGroup animation];
+  CABasicAnimation *a = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [g setAnimations: [NSArray arrayWithObject: a]];
+  [g setDuration: 3.0];
+
+  CAAnimationGroup *theCopy = [[g copy] autorelease];
+
+  PASS([[theCopy animations] count] == 1,
+       "a copy of a group carries the grouped animations");
+  PASS([[theCopy animations] objectAtIndex: 0] == a,
+       "the animations themselves, not copies of them");
+  PASS([theCopy duration] == 3.0, "along with the timing of the group");
+
+  END_SET("copying a group")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
CAAnimationGroup was missing, and -[CALayer applyAnimationsAtTime:] carried a TODO for it: only a CAPropertyAnimation was applied, so a group added to a layer was stored and did nothing.

The class is declared in CAAnimation.h beside the other animation classes, as Apple does, and holds a copied array of animations. Applying a group evaluates each animation it holds in the group's time space, so they keep their own durations: one that outlasts the group is clipped by it rather than scaled into it, and a group inside a group works the same way. An animation now takes its time from -applyToLayer:withTimeAuthorityLocalTime:; -applyToLayer: passes the model layer's local time, as before.

Archiving does not carry the animations. The coder methods on these classes are repaired in #33; this class can follow once that lands. fillMode is still unimplemented, so a group is not held at either end.

The tests are in Tests/quartzcore/CAAnimationGroup. apply.m is named in APPLE_SKIP_TESTS because the two methods above have no counterpart in Apple QuartzCore.

None of the 21 assertions compiled before, since the class did not exist. All pass now, and the suite goes from 305 passed and 9 dashed hopes to 326 and 9, none failing.
