### PR TITLE
Fix: ask for a layout when the sublayers or the bounds change

### DIFF
--- a/Headers/QuartzCore/CAConstraint.h
+++ b/Headers/QuartzCore/CAConstraint.h
@@ -1,0 +1,102 @@
+/* CAConstraint.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CABase.h"
+
+@class CALayer;
+
+/* The geometry a constraint relates.  The four X attributes come first so
+   that an attribute's axis is decided by its value. */
+typedef enum _CAConstraintAttribute
+{
+  kCAConstraintMinX = 0,
+  kCAConstraintMidX = 1,
+  kCAConstraintMaxX = 2,
+  kCAConstraintWidth = 3,
+  kCAConstraintMinY = 4,
+  kCAConstraintMidY = 5,
+  kCAConstraintMaxY = 6,
+  kCAConstraintHeight = 7
+} CAConstraintAttribute;
+
+/* *********************************** */
+
+/* One relationship between an attribute of the layer holding the constraint
+   and an attribute of another layer, named by its -name.  The name
+   "superlayer" refers to the superlayer. */
+@interface CAConstraint : NSObject <NSCoding>
+{
+  /* property-backing ivars */
+  CAConstraintAttribute _attribute;
+  CAConstraintAttribute _sourceAttribute;
+  NSString * _sourceName;
+  CGFloat _scale;
+  CGFloat _offset;
+}
+
++ (id) constraintWithAttribute: (CAConstraintAttribute)attr
+                    relativeTo: (NSString *)srcId
+                     attribute: (CAConstraintAttribute)srcAttr;
++ (id) constraintWithAttribute: (CAConstraintAttribute)attr
+                    relativeTo: (NSString *)srcId
+                     attribute: (CAConstraintAttribute)srcAttr
+                        offset: (CGFloat)c;
++ (id) constraintWithAttribute: (CAConstraintAttribute)attr
+                    relativeTo: (NSString *)srcId
+                     attribute: (CAConstraintAttribute)srcAttr
+                         scale: (CGFloat)m
+                        offset: (CGFloat)c;
+
+- (id) initWithAttribute: (CAConstraintAttribute)attr
+              relativeTo: (NSString *)srcId
+               attribute: (CAConstraintAttribute)srcAttr
+                   scale: (CGFloat)m
+                  offset: (CGFloat)c;
+
+@property (readonly) CAConstraintAttribute attribute;
+@property (readonly) CAConstraintAttribute sourceAttribute;
+@property (readonly) NSString * sourceName;
+@property (readonly) CGFloat scale;
+@property (readonly) CGFloat offset;
+
+@end
+
+/* *********************************** */
+
+/* Lays out the sublayers of a layer under the constraints each of them
+   carries.  Set it as a layer's layoutManager. */
+@interface CAConstraintLayoutManager : NSObject
+{
+}
+
++ (id) layoutManager;
+
+- (void) layoutSublayersOfLayer: (CALayer *)layer;
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -65,6 +65,7 @@ extern NSString *const kCATransition;
 
 @class CABackingStore;
 @class CAGLSimpleFramebuffer;
+@class CAConstraint;
 
 @interface CALayer : NSObject<CAMediaTiming>
 {
@@ -117,6 +118,8 @@ extern NSString *const kCATransition;
   float _speed;
 
   /* i-vars */
+  NSString * _name;
+  NSArray * _constraints;
   BOOL _needsDisplay;
   BOOL _needsLayout;
   NSMutableDictionary *_animations;
@@ -139,6 +142,8 @@ extern NSString *const kCATransition;
 @property (assign)                   id delegate;
 @property (retain)                   id contents;
 @property (retain)                   id layoutManager;
+@property (copy)                     NSString *name;
+@property (copy)                     NSArray *constraints;
 @property (nonatomic,readonly)       CALayer *superlayer;
 @property (nonatomic,copy)           NSArray *sublayers;
 @property (assign)                   CGRect frame;
@@ -206,6 +211,8 @@ extern NSString *const kCATransition;
 - (BOOL) needsLayout;
 - (void) setNeedsLayout;
 - (void) layoutIfNeeded;
+- (void) layoutSublayers;
+- (void) addConstraint: (CAConstraint *)constraint;
 
 - (id) presentationLayer;
 - (id) modelLayer;

--- a/Headers/QuartzCore/CoreAnimation.h
+++ b/Headers/QuartzCore/CoreAnimation.h
@@ -30,6 +30,7 @@
 
 #import "QuartzCore/CABase.h"
 #import "QuartzCore/CAAction.h"
+#import "QuartzCore/CAConstraint.h"
 #import "QuartzCore/CAFilter.h"
 #import "QuartzCore/CALayer.h"
 #import "QuartzCore/CAAnimation.h"

--- a/Source/CAConstraint.m
+++ b/Source/CAConstraint.m
@@ -1,0 +1,486 @@
+/* CAConstraint.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CAConstraint.h"
+#import "QuartzCore/CALayer.h"
+#import <stdlib.h>
+
+@implementation CAConstraint
+@synthesize attribute=_attribute;
+@synthesize sourceAttribute=_sourceAttribute;
+@synthesize sourceName=_sourceName;
+@synthesize scale=_scale;
+@synthesize offset=_offset;
+
++ (id) constraintWithAttribute: (CAConstraintAttribute)attr
+                    relativeTo: (NSString *)srcId
+                     attribute: (CAConstraintAttribute)srcAttr
+{
+  return [self constraintWithAttribute: attr
+                            relativeTo: srcId
+                             attribute: srcAttr
+                                 scale: 1.0
+                                offset: 0.0];
+}
+
++ (id) constraintWithAttribute: (CAConstraintAttribute)attr
+                    relativeTo: (NSString *)srcId
+                     attribute: (CAConstraintAttribute)srcAttr
+                        offset: (CGFloat)c
+{
+  return [self constraintWithAttribute: attr
+                            relativeTo: srcId
+                             attribute: srcAttr
+                                 scale: 1.0
+                                offset: c];
+}
+
++ (id) constraintWithAttribute: (CAConstraintAttribute)attr
+                    relativeTo: (NSString *)srcId
+                     attribute: (CAConstraintAttribute)srcAttr
+                         scale: (CGFloat)m
+                        offset: (CGFloat)c
+{
+  return [[[self alloc] initWithAttribute: attr
+                               relativeTo: srcId
+                                attribute: srcAttr
+                                    scale: m
+                                   offset: c] autorelease];
+}
+
+- (id) initWithAttribute: (CAConstraintAttribute)attr
+              relativeTo: (NSString *)srcId
+               attribute: (CAConstraintAttribute)srcAttr
+                   scale: (CGFloat)m
+                  offset: (CGFloat)c
+{
+  self = [super init];
+  if (!self)
+    return nil;
+
+  _attribute = attr;
+  _sourceAttribute = srcAttr;
+  _sourceName = [srcId copy];
+  _scale = m;
+  _offset = c;
+
+  return self;
+}
+
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [super init];
+  if (!self)
+    return nil;
+
+  _attribute = [aDecoder decodeIntForKey: @"attribute"];
+  _sourceAttribute = [aDecoder decodeIntForKey: @"sourceAttribute"];
+  _sourceName = [[aDecoder decodeObjectForKey: @"sourceName"] copy];
+  _scale = [aDecoder decodeDoubleForKey: @"scale"];
+  _offset = [aDecoder decodeDoubleForKey: @"offset"];
+
+  return self;
+}
+
+- (void) encodeWithCoder: (NSCoder *)aCoder
+{
+  [aCoder encodeInt: _attribute forKey: @"attribute"];
+  [aCoder encodeInt: _sourceAttribute forKey: @"sourceAttribute"];
+  [aCoder encodeObject: _sourceName forKey: @"sourceName"];
+  [aCoder encodeDouble: _scale forKey: @"scale"];
+  [aCoder encodeDouble: _offset forKey: @"offset"];
+}
+
+- (void) dealloc
+{
+  [_sourceName release];
+
+  [super dealloc];
+}
+
+@end
+
+/* *********************************** */
+
+/* The attributes of an axis in the order they are preferred when an axis
+   carries more than the two relationships it needs. */
+typedef enum
+{
+  GSConstraintMin = 0,
+  GSConstraintMid = 1,
+  GSConstraintMax = 2,
+  GSConstraintSize = 3
+} GSConstraintRank;
+
+static BOOL isVerticalAttribute(CAConstraintAttribute attribute)
+{
+  return attribute >= kCAConstraintMinY;
+}
+
+static GSConstraintRank rankOfAttribute(CAConstraintAttribute attribute)
+{
+  if (isVerticalAttribute(attribute))
+    return (GSConstraintRank)(attribute - kCAConstraintMinY);
+
+  return (GSConstraintRank)attribute;
+}
+
+static CGFloat valueOfAttribute(CGRect rect, CAConstraintAttribute attribute)
+{
+  switch (rankOfAttribute(attribute))
+    {
+      case GSConstraintMin:
+        return isVerticalAttribute(attribute) ? CGRectGetMinY(rect)
+                                              : CGRectGetMinX(rect);
+      case GSConstraintMid:
+        return isVerticalAttribute(attribute) ? CGRectGetMidY(rect)
+                                              : CGRectGetMidX(rect);
+      case GSConstraintMax:
+        return isVerticalAttribute(attribute) ? CGRectGetMaxY(rect)
+                                              : CGRectGetMaxX(rect);
+      case GSConstraintSize:
+        return isVerticalAttribute(attribute) ? CGRectGetHeight(rect)
+                                              : CGRectGetWidth(rect);
+    }
+
+  return 0.0;
+}
+
+/* Solve an axis from the two relationships it was given.  'a' holds the
+   lower ranked of the two. */
+static void solveAxis(GSConstraintRank rankA, CGFloat valueA,
+                      GSConstraintRank rankB, CGFloat valueB,
+                      CGFloat *origin, CGFloat *size)
+{
+  if (rankA == GSConstraintMin && rankB == GSConstraintMid)
+    {
+      *size = 2 * (valueB - valueA);
+      *origin = valueA;
+    }
+  else if (rankA == GSConstraintMin && rankB == GSConstraintMax)
+    {
+      *size = valueB - valueA;
+      *origin = valueA;
+    }
+  else if (rankA == GSConstraintMin && rankB == GSConstraintSize)
+    {
+      *size = valueB;
+      *origin = valueA;
+    }
+  else if (rankA == GSConstraintMid && rankB == GSConstraintMax)
+    {
+      *size = 2 * (valueB - valueA);
+      *origin = valueB - *size;
+    }
+  else if (rankA == GSConstraintMid && rankB == GSConstraintSize)
+    {
+      *size = valueB;
+      *origin = valueA - *size / 2;
+    }
+  else if (rankA == GSConstraintMax && rankB == GSConstraintSize)
+    {
+      *size = valueB;
+      *origin = valueA - *size;
+    }
+}
+
+/* One relationship, with the size the layer already has as the other. */
+static void solveAxisFromOne(GSConstraintRank rank, CGFloat value,
+                             CGFloat *origin, CGFloat size)
+{
+  switch (rank)
+    {
+      case GSConstraintMin: *origin = value; break;
+      case GSConstraintMid: *origin = value - size / 2; break;
+      case GSConstraintMax: *origin = value - size; break;
+      case GSConstraintSize: break;
+    }
+}
+
+/* What is known about one sublayer while its superlayer is being laid out. */
+typedef struct
+{
+  CGRect frame;
+  BOOL constrainedHorizontally;
+  BOOL constrainedVertically;
+  BOOL laidOutHorizontally;
+  BOOL laidOutVertically;
+} GSConstraintLayoutState;
+
+static BOOL axisIsLaidOut(GSConstraintLayoutState *state, BOOL vertical)
+{
+  return vertical ? state->laidOutVertically : state->laidOutHorizontally;
+}
+
+static BOOL axisIsConstrained(GSConstraintLayoutState *state, BOOL vertical)
+{
+  return vertical ? state->constrainedVertically : state->constrainedHorizontally;
+}
+
+/* The sublayer of that name, or nil.  Where two carry the same name the
+   later one answers. */
+static NSUInteger indexOfSublayerNamed(NSArray *sublayers, NSString *name,
+                                       NSUInteger except)
+{
+  NSUInteger index;
+  NSUInteger found = NSNotFound;
+
+  for (index = 0; index < [sublayers count]; index++)
+    {
+      if (index == except)
+        continue;
+      if ([name isEqualToString: [[sublayers objectAtIndex: index] name]])
+        found = index;
+    }
+
+  return found;
+}
+
+/* Try to lay one axis of one sublayer out.  Answers NO while it is waiting
+   for a sibling the axis is measured against. */
+static BOOL layOutAxis(NSArray *sublayers, GSConstraintLayoutState *state,
+                       NSUInteger index, CGRect bounds, BOOL vertical)
+{
+  CALayer *layer = [sublayers objectAtIndex: index];
+  NSArray *constraints = [layer constraints];
+  NSUInteger count = [constraints count];
+  GSConstraintRank *ranks;
+  CGFloat *values;
+  NSUInteger found = 0;
+  NSUInteger i;
+  BOOL waiting = NO;
+  CGRect frame = state[index].frame;
+  CGFloat origin;
+  CGFloat size;
+
+  ranks = calloc(count ? count : 1, sizeof(*ranks));
+  values = calloc(count ? count : 1, sizeof(*values));
+  if (!ranks || !values)
+    {
+      free(ranks);
+      free(values);
+      return YES;
+    }
+
+  for (i = 0; i < count && !waiting; i++)
+    {
+      CAConstraint *constraint = [constraints objectAtIndex: i];
+      CAConstraintAttribute attribute = [constraint attribute];
+      CAConstraintAttribute sourceAttribute;
+      NSUInteger source;
+      CGFloat value;
+
+      if (isVerticalAttribute(attribute) != vertical)
+        continue;
+
+      sourceAttribute = [constraint sourceAttribute];
+      if ([[constraint sourceName] isEqualToString: @"superlayer"])
+        {
+          value = valueOfAttribute(bounds, sourceAttribute);
+        }
+      else
+        {
+          BOOL sourceVertical = isVerticalAttribute(sourceAttribute);
+
+          source = indexOfSublayerNamed(sublayers, [constraint sourceName],
+                                        index);
+          /* A layer nothing answers to, and a layer that is not laid out on
+             the axis being read, leave the relationship out altogether. */
+          if (source == NSNotFound
+              || !axisIsConstrained(&state[source], sourceVertical))
+            continue;
+
+          if (!axisIsLaidOut(&state[source], sourceVertical))
+            {
+              waiting = YES;
+              continue;
+            }
+
+          value = valueOfAttribute(state[source].frame, sourceAttribute);
+        }
+
+      ranks[found] = rankOfAttribute(attribute);
+      values[found] = value * [constraint scale] + [constraint offset];
+      found++;
+    }
+
+  if (waiting)
+    {
+      free(ranks);
+      free(values);
+      return NO;
+    }
+
+  origin = vertical ? CGRectGetMinY(frame) : CGRectGetMinX(frame);
+  size = vertical ? CGRectGetHeight(frame) : CGRectGetWidth(frame);
+
+  /* The same attribute twice describes no layout at all. */
+  for (i = 0; i < found; i++)
+    {
+      NSUInteger j;
+
+      for (j = i + 1; j < found; j++)
+        {
+          if (ranks[i] == ranks[j])
+            {
+              found = 0;
+              i = 0;
+              break;
+            }
+        }
+    }
+
+  if (found > 0)
+    {
+      /* The relationship given last decides the axis; where there are others
+         it is paired with the lowest ranked of them. */
+      NSUInteger last = found - 1;
+      NSUInteger partner = NSNotFound;
+
+      for (i = 0; i < last; i++)
+        {
+          if (partner == NSNotFound || ranks[i] < ranks[partner])
+            partner = i;
+        }
+
+      if (partner == NSNotFound)
+        {
+          /* A size on its own leaves the layer where it is. */
+          solveAxisFromOne(ranks[last], values[last], &origin, size);
+        }
+      else if (ranks[partner] < ranks[last])
+        {
+          solveAxis(ranks[partner], values[partner], ranks[last], values[last],
+                    &origin, &size);
+        }
+      else
+        {
+          solveAxis(ranks[last], values[last], ranks[partner], values[partner],
+                    &origin, &size);
+        }
+    }
+
+  if (vertical)
+    {
+      frame.origin.y = origin;
+      frame.size.height = size;
+    }
+  else
+    {
+      frame.origin.x = origin;
+      frame.size.width = size;
+    }
+  state[index].frame = frame;
+
+  free(ranks);
+  free(values);
+  return YES;
+}
+
+@implementation CAConstraintLayoutManager
+
++ (id) layoutManager
+{
+  static CAConstraintLayoutManager *shared = nil;
+
+  if (!shared)
+    shared = [[self alloc] init];
+
+  return shared;
+}
+
+- (void) layoutSublayersOfLayer: (CALayer *)layer
+{
+  NSArray *sublayers = [layer sublayers];
+  NSUInteger count = [sublayers count];
+  CGRect bounds = [layer bounds];
+  GSConstraintLayoutState *state;
+  NSUInteger index;
+  BOOL settling = YES;
+
+  if (count == 0)
+    return;
+
+  state = calloc(count, sizeof(*state));
+  if (!state)
+    return;
+
+  for (index = 0; index < count; index++)
+    {
+      CALayer *sublayer = [sublayers objectAtIndex: index];
+      NSEnumerator *enumerator = [[sublayer constraints] objectEnumerator];
+      CAConstraint *constraint;
+
+      state[index].frame = [sublayer frame];
+      while ((constraint = [enumerator nextObject]) != nil)
+        {
+          if (isVerticalAttribute([constraint attribute]))
+            state[index].constrainedVertically = YES;
+          else
+            state[index].constrainedHorizontally = YES;
+        }
+      state[index].laidOutHorizontally = !state[index].constrainedHorizontally;
+      state[index].laidOutVertically = !state[index].constrainedVertically;
+    }
+
+  /* A layer measured against a sibling waits for that sibling, whatever
+     order the two are in.  Constraints that lead in a circle never settle,
+     and those layers are left as they are. */
+  while (settling)
+    {
+      settling = NO;
+      for (index = 0; index < count; index++)
+        {
+          if (!state[index].laidOutHorizontally
+              && layOutAxis(sublayers, state, index, bounds, NO))
+            {
+              state[index].laidOutHorizontally = YES;
+              settling = YES;
+            }
+          if (!state[index].laidOutVertically
+              && layOutAxis(sublayers, state, index, bounds, YES))
+            {
+              state[index].laidOutVertically = YES;
+              settling = YES;
+            }
+        }
+    }
+
+  for (index = 0; index < count; index++)
+    {
+      CALayer *sublayer = [sublayers objectAtIndex: index];
+
+      if (!CGRectEqualToRect(state[index].frame, [sublayer frame]))
+        [sublayer setFrame: state[index].frame];
+    }
+
+  free(state);
+}
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -250,6 +250,15 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
          just like Opal's Objective-C class instances */
       return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
     }
+  if ([key isEqualToString: @"borderColor"])
+    {
+      /* opaque black, as for the shadow colour above */
+      return [(id)CGColorCreateGenericRGB(0.0, 0.0, 0.0, 1.0) autorelease];
+    }
+  if ([key isEqualToString: @"contentsGravity"])
+    {
+      return kCAGravityResize;
+    }
   if ([key isEqualToString: @"shadowOffset"])
     {
       CGSize offset = CGSizeMake(0.0, -3.0);
@@ -301,6 +310,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
         @"anchorPoint", @"transform", @"sublayerTransform",
         @"opacity", @"delegate", @"contentsRect", @"shouldRasterize",
         @"backgroundColor", @"borderColor", @"contentsScale",
+        @"contentsGravity",
 
         @"beginTime", @"duration", @"speed", @"autoreverses",
         @"repeatCount",
@@ -690,7 +700,34 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
 - (id) modelLayer
 {
-  return _modelLayer;
+  /* A layer that is not standing in for another one is its own model.
+     -isPresentationLayer reads the ivar directly, so it is unaffected. */
+  return _modelLayer ? _modelLayer : self;
+}
+
+- (void) setSublayers: (NSArray *)sublayers
+{
+  NSArray *oldSublayers = _sublayers;
+  CALayer *layer;
+
+  if (sublayers == _sublayers)
+    return;
+
+  /* The layers on their way out lose their superlayer, and the ones coming
+     in take this layer as theirs. */
+  for (layer in oldSublayers)
+    {
+      if (![sublayers containsObject: layer])
+        [layer setSuperlayer: nil];
+    }
+
+  _sublayers = [sublayers mutableCopy];
+  [oldSublayers release];
+
+  for (layer in _sublayers)
+    {
+      [layer setSuperlayer: self];
+    }
 }
 
 - (void) setModelLayer: (id)modelLayer

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -595,6 +595,10 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
     {
       [self setNeedsDisplay];
     }
+
+  /* The sublayers are placed within these bounds, so they want placing
+     again. */
+  [self setNeedsLayout];
 }
 
 - (void)setBackgroundColor: (CGColorRef)backgroundColor
@@ -994,6 +998,18 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   [layer removeFromSuperlayer];
   [mutableSublayers addObject: layer];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
+}
+
+- (void) setSublayers: (NSArray *)sublayers
+{
+  if (_sublayers != sublayers)
+    {
+      [_sublayers release];
+      _sublayers = [sublayers copy];
+    }
+
+  [self setNeedsLayout];
 }
 
 - (void)removeFromSuperlayer
@@ -1001,6 +1017,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   NSMutableArray * mutableSublayersOfSuperlayer = (NSMutableArray*)[[self superlayer] sublayers];
 
   [mutableSublayersOfSuperlayer removeObject: self];
+  [[self superlayer] setNeedsLayout];
   [self setSuperlayer: nil];
 }
 
@@ -1011,6 +1028,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   [layer removeFromSuperlayer];
   [mutableSublayers insertObject: layer atIndex: index];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (void) insertSublayer: (CALayer *)layer below: (CALayer *)sibling;
@@ -1022,6 +1040,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (void) insertSublayer: (CALayer *)layer above: (CALayer *)sibling;
@@ -1033,6 +1052,7 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   siblingIndex = [mutableSublayers indexOfObject: sibling];
   [mutableSublayers insertObject: layer atIndex:siblingIndex+1];
   [layer setSuperlayer: self];
+  [self setNeedsLayout];
 }
 
 - (CALayer *) rootLayer

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -98,6 +98,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 @synthesize delegate=_delegate;
 @synthesize contents=_contents;
 @synthesize layoutManager=_layoutManager;
+@synthesize name=_name;
 @synthesize renderer=_renderer;
 @synthesize superlayer=_superlayer;
 @synthesize sublayers=_sublayers;
@@ -409,6 +410,8 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 
       [self setDelegate: [layer delegate]];
       [self setLayoutManager: [layer layoutManager]];
+      [self setName: [layer name]];
+      [self setConstraints: [layer constraints]];
       [self setSuperlayer: [layer superlayer]]; /* if copied for use in presentation layer, then ignored */
       [self setSublayers: [layer sublayers]]; /* if copied for use in presentation layer, then ignored */
       /* frame not copied: dynamically generated */
@@ -470,6 +473,8 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
   CGPathRelease(_shadowPath);
   [_observedKeyPaths release];
   [_layoutManager release];
+  [_name release];
+  [_constraints release];
   [_contents release];
   [_sublayers release];
   CGColorRelease(_backgroundColor);
@@ -725,15 +730,66 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 /* MARK: - Layout methods */
 - (void) layoutIfNeeded
 {
+  NSEnumerator * enumerator;
+  CALayer * sublayer;
+
+  if (_needsLayout)
+    {
+      _needsLayout = NO;
+      [self layoutSublayers];
+    }
+
+  enumerator = [[self sublayers] objectEnumerator];
+  while ((sublayer = [enumerator nextObject]) != nil)
+    {
+      [sublayer layoutIfNeeded];
+    }
 }
 
 - (void) layoutSublayers
 {
+  if ([_delegate respondsToSelector: @selector(layoutSublayersOfLayer:)])
+    {
+      [_delegate layoutSublayersOfLayer: self];
+      return;
+    }
+
+  [_layoutManager layoutSublayersOfLayer: self];
+}
+
+- (BOOL) needsLayout
+{
+  return _needsLayout;
 }
 
 - (void) setNeedsLayout
 {
   _needsLayout = YES;
+}
+
+- (void) addConstraint: (CAConstraint *)constraint
+{
+  if (_constraints)
+    [self setConstraints: [_constraints arrayByAddingObject: constraint]];
+  else
+    [self setConstraints: [NSArray arrayWithObject: constraint]];
+}
+
+- (NSArray *) constraints
+{
+  return _constraints;
+}
+
+- (void) setConstraints: (NSArray *)constraints
+{
+  if (_constraints != constraints)
+    {
+      [_constraints release];
+      _constraints = [constraints copy];
+    }
+
+  /* The superlayer is the one that lays its sublayers out. */
+  [[self superlayer] setNeedsLayout];
 }
 
 /* ************************************* */

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -24,6 +24,7 @@ QuartzCore_HEADER_FILES = \
 	CAAction.h \
 	CAAnimation.h \
 	CABase.h \
+	CAConstraint.h \
 	CADisplayLink.h \
 	CAEAGLLayer.h \
 	CAFilter.h \

--- a/Tests/quartzcore/CAConstraint/TestInfo
+++ b/Tests/quartzcore/CAConstraint/TestInfo
@@ -1,0 +1,1 @@
+# Both files run against Apple QuartzCore as well.

--- a/Tests/quartzcore/CAConstraint/constraint.m
+++ b/Tests/quartzcore/CAConstraint/constraint.m
@@ -1,0 +1,150 @@
+/* What a CAConstraint holds, and how a layer holds its constraints.
+
+   The expected values are the ones Apple QuartzCore produces.  Apple declares
+   these classes in a header of another name, so the umbrella is imported
+   rather than QuartzCore/CAConstraint.h. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what a constraint was made with")
+
+  CAConstraint *c = [CAConstraint constraintWithAttribute: kCAConstraintMidX
+                                               relativeTo: @"superlayer"
+                                                attribute: kCAConstraintMidY];
+
+  PASS(c != nil, "a constraint is made by the three argument form");
+  PASS([c attribute] == kCAConstraintMidX, "it holds the attribute given");
+  PASS([c sourceAttribute] == kCAConstraintMidY,
+       "and the attribute it is measured against");
+  PASS([[c sourceName] isEqualToString: @"superlayer"],
+       "and the name of what it is measured against");
+  PASS([c scale] == 1.0, "the scale of that form is one");
+  PASS([c offset] == 0.0, "and its offset is zero");
+
+  END_SET("what a constraint was made with")
+
+  START_SET("the scale and the offset")
+
+  CAConstraint *withOffset =
+    [CAConstraint constraintWithAttribute: kCAConstraintMinX
+                               relativeTo: @"other"
+                                attribute: kCAConstraintMaxX
+                                   offset: 7.0];
+  CAConstraint *withBoth =
+    [CAConstraint constraintWithAttribute: kCAConstraintMinX
+                               relativeTo: @"other"
+                                attribute: kCAConstraintMaxX
+                                    scale: 0.25
+                                   offset: 7.0];
+
+  PASS([withOffset offset] == 7.0, "the four argument form takes an offset");
+  PASS([withOffset scale] == 1.0, "and leaves the scale at one");
+  PASS([withBoth scale] == 0.25 && [withBoth offset] == 7.0,
+       "the five argument form takes both");
+
+  END_SET("the scale and the offset")
+
+  START_SET("the attributes of the two axes")
+
+  /* The four horizontal attributes come before the four vertical ones. */
+  PASS(kCAConstraintMinX < kCAConstraintMidX
+       && kCAConstraintMidX < kCAConstraintMaxX
+       && kCAConstraintMaxX < kCAConstraintWidth,
+       "the horizontal attributes run from the left edge to the width");
+  PASS(kCAConstraintWidth < kCAConstraintMinY
+       && kCAConstraintMinY < kCAConstraintMidY
+       && kCAConstraintMidY < kCAConstraintMaxY
+       && kCAConstraintMaxY < kCAConstraintHeight,
+       "and the vertical ones follow in the same order");
+
+  END_SET("the attributes of the two axes")
+
+  START_SET("a layer's name")
+
+  CALayer *layer = [CALayer layer];
+
+  PASS([layer name] == nil, "a layer has no name to begin with");
+
+  [layer setName: @"a"];
+
+  PASS([[layer name] isEqualToString: @"a"], "and takes the one it is given");
+
+  END_SET("a layer's name")
+
+  START_SET("the constraints a layer holds")
+
+  CALayer *layer = [CALayer layer];
+  CAConstraint *c = [CAConstraint constraintWithAttribute: kCAConstraintMinX
+                                               relativeTo: @"superlayer"
+                                                attribute: kCAConstraintMinX];
+  NSMutableArray *given = [NSMutableArray arrayWithObject: c];
+
+  PASS([layer constraints] == nil, "a layer holds no constraints to begin with");
+
+  [layer setConstraints: given];
+
+  PASS([[layer constraints] count] == 1, "it holds the ones it is given");
+  PASS([[layer constraints] objectAtIndex: 0] == c, "the constraints themselves");
+
+  [given removeAllObjects];
+
+  PASS([[layer constraints] count] == 1,
+       "the array is copied, so emptying the original leaves the layer alone");
+
+  [layer setConstraints: nil];
+
+  PASS([layer constraints] == nil, "and the layer can be emptied again");
+
+  END_SET("the constraints a layer holds")
+
+  START_SET("adding one constraint at a time")
+
+  CALayer *layer = [CALayer layer];
+  CAConstraint *first = [CAConstraint constraintWithAttribute: kCAConstraintMinX
+                                                   relativeTo: @"superlayer"
+                                                    attribute: kCAConstraintMinX];
+  CAConstraint *second = [CAConstraint constraintWithAttribute: kCAConstraintMinY
+                                                    relativeTo: @"superlayer"
+                                                     attribute: kCAConstraintMinY];
+
+  [layer addConstraint: first];
+
+  PASS([[layer constraints] count] == 1,
+       "adding to a layer that holds none makes a set of one");
+
+  [layer addConstraint: second];
+
+  PASS([[layer constraints] count] == 2, "and adding again appends");
+  PASS([[layer constraints] objectAtIndex: 0] == first
+       && [[layer constraints] objectAtIndex: 1] == second,
+       "in the order they were added");
+
+  END_SET("adding one constraint at a time")
+
+  START_SET("adding a constraint asks for a layout")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+
+  [root addSublayer: child];
+  [root setNeedsLayout];
+  [root layoutIfNeeded];
+  [child addConstraint:
+    [CAConstraint constraintWithAttribute: kCAConstraintMinX
+                               relativeTo: @"superlayer"
+                                attribute: kCAConstraintMinX]];
+
+  PASS([root needsLayout],
+       "the superlayer is the one asked to lay out again");
+
+  END_SET("adding a constraint asks for a layout")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAConstraint/layout.m
+++ b/Tests/quartzcore/CAConstraint/layout.m
@@ -1,0 +1,449 @@
+/* What CAConstraintLayoutManager does to the frames of the sublayers.
+
+   Every expected frame here was measured against Apple QuartzCore.  The
+   superlayer's bounds are (0,0,200,100) throughout, so its minX is 0, its
+   midX 100, its maxX 200 and its width 200, and each sublayer starts at
+   (3,5,40,20). */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/QuartzCore.h>
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static CAConstraint *
+c3(CAConstraintAttribute a, NSString *src, CAConstraintAttribute sa)
+{
+  return [CAConstraint constraintWithAttribute: a relativeTo: src attribute: sa];
+}
+
+static CAConstraint *
+c4(CAConstraintAttribute a, NSString *src, CAConstraintAttribute sa,
+   CGFloat offset)
+{
+  return [CAConstraint constraintWithAttribute: a relativeTo: src
+                                     attribute: sa offset: offset];
+}
+
+static CAConstraint *
+c5(CAConstraintAttribute a, NSString *src, CAConstraintAttribute sa,
+   CGFloat scale, CGFloat offset)
+{
+  return [CAConstraint constraintWithAttribute: a relativeTo: src
+                                     attribute: sa scale: scale offset: offset];
+}
+
+static CALayer *
+rootLayer(void)
+{
+  CALayer *root = [CALayer layer];
+
+  [root setBounds: CGRectMake(0, 0, 200, 100)];
+  [root setLayoutManager: [CAConstraintLayoutManager layoutManager]];
+  return root;
+}
+
+/* One sublayer under the constraints given, laid out, and its frame. */
+static CGRect
+laidOut(NSArray *constraints)
+{
+  CALayer *root = rootLayer();
+  CALayer *child = [CALayer layer];
+
+  [child setName: @"child"];
+  [child setFrame: CGRectMake(3, 5, 40, 20)];
+  [root addSublayer: child];
+  [child setConstraints: constraints];
+  [root layoutSublayers];
+  return [child frame];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the shared layout manager")
+
+  PASS([CAConstraintLayoutManager layoutManager] != nil,
+       "a layout manager is made by +layoutManager");
+  PASS([CAConstraintLayoutManager layoutManager] ==
+       [CAConstraintLayoutManager layoutManager],
+       "and it is the same one every time");
+
+  END_SET("the shared layout manager")
+
+  START_SET("one constraint on an axis keeps the size the layer has")
+
+  CGRect min = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX)]);
+  CGRect mid = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMidX, @"superlayer", kCAConstraintMidX)]);
+  CGRect max = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX)]);
+
+  PASS(CLOSE(min.origin.x, 0) && CLOSE(min.size.width, 40),
+       "a left edge on the superlayer's puts it there and keeps the width");
+  PASS(CLOSE(mid.origin.x, 80), "a centre on the superlayer's centres it");
+  PASS(CLOSE(max.origin.x, 160), "a right edge on the superlayer's ends it there");
+  PASS(CLOSE(min.origin.y, 5) && CLOSE(min.size.height, 20),
+       "and the axis with no constraints is left alone");
+
+  END_SET("one constraint on an axis keeps the size the layer has")
+
+  START_SET("the vertical axis runs from the bottom")
+
+  CGRect min = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMinY, @"superlayer", kCAConstraintMinY)]);
+  CGRect max = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMaxY, @"superlayer", kCAConstraintMaxY)]);
+
+  PASS(CLOSE(min.origin.y, 0), "the minimum edge is the bottom one");
+  PASS(CLOSE(max.origin.y, 80), "and the maximum edge the top");
+
+  END_SET("the vertical axis runs from the bottom")
+
+  START_SET("a size on its own does nothing")
+
+  CGRect f = laidOut([NSArray arrayWithObject:
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.5, 0)]);
+
+  PASS(CLOSE(f.origin.x, 3) && CLOSE(f.size.width, 40),
+       "a width with no edge to put it against leaves the layer alone");
+
+  END_SET("a size on its own does nothing")
+
+  START_SET("two constraints on an axis")
+
+  CGRect minMax = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX),
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX), nil]);
+  CGRect minWidth = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX),
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.5, 0), nil]);
+  CGRect maxWidth = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX),
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.5, 0), nil]);
+  CGRect midWidth = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMidX, @"superlayer", kCAConstraintMidX),
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.5, 0), nil]);
+  CGRect minMid = laidOut([NSArray arrayWithObjects:
+    c4(kCAConstraintMinX, @"superlayer", kCAConstraintMinX, 20),
+    c3(kCAConstraintMidX, @"superlayer", kCAConstraintMidX), nil]);
+  CGRect midMax = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMidX, @"superlayer", kCAConstraintMidX),
+    c4(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX, -20), nil]);
+
+  PASS(CLOSE(minMax.origin.x, 0) && CLOSE(minMax.size.width, 200),
+       "two edges stretch the layer between them");
+  PASS(CLOSE(minWidth.origin.x, 0) && CLOSE(minWidth.size.width, 100),
+       "a left edge and a width put it there at that width");
+  PASS(CLOSE(maxWidth.origin.x, 100) && CLOSE(maxWidth.size.width, 100),
+       "a right edge and a width end it there");
+  PASS(CLOSE(midWidth.origin.x, 50) && CLOSE(midWidth.size.width, 100),
+       "a centre and a width centre it");
+  PASS(CLOSE(minMid.origin.x, 20) && CLOSE(minMid.size.width, 160),
+       "a left edge and a centre give twice the distance between them");
+  PASS(CLOSE(midMax.origin.x, 20) && CLOSE(midMax.size.width, 160),
+       "and so do a centre and a right edge");
+
+  END_SET("two constraints on an axis")
+
+  START_SET("more relationships than an axis needs")
+
+  /* The one given last decides the axis, and it is paired with the lowest
+     of the others: the left edge before the centre, the centre before the
+     right edge, and any of them before a width. */
+  CGRect a = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX),
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX),
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.25, 0), nil]);
+  CGRect b = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX),
+    c4(kCAConstraintMidX, @"superlayer", kCAConstraintMidX, -30),
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.25, 0), nil]);
+  CGRect c = laidOut([NSArray arrayWithObjects:
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.25, 0),
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX),
+    c4(kCAConstraintMidX, @"superlayer", kCAConstraintMidX, -30), nil]);
+  CGRect d = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX),
+    c4(kCAConstraintMidX, @"superlayer", kCAConstraintMidX, -30),
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX), nil]);
+  CGRect e = laidOut([NSArray arrayWithObjects:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX),
+    c4(kCAConstraintMidX, @"superlayer", kCAConstraintMidX, -30),
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX),
+    c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.25, 0), nil]);
+
+  PASS(CLOSE(a.origin.x, 0) && CLOSE(a.size.width, 50),
+       "a width given last takes the left edge as the other relationship");
+  PASS(CLOSE(b.origin.x, 45) && CLOSE(b.size.width, 50),
+       "and the centre where there is no left edge");
+  PASS(CLOSE(c.origin.x, -60) && CLOSE(c.size.width, 260),
+       "a centre given last takes the right edge over a width");
+  PASS(CLOSE(d.origin.x, 0) && CLOSE(d.size.width, 140),
+       "a left edge given last takes the centre over the right edge");
+  PASS(CLOSE(e.origin.x, 0) && CLOSE(e.size.width, 50),
+       "all four together come to the left edge and the width");
+
+  END_SET("more relationships than an axis needs")
+
+  START_SET("relationships that describe nothing")
+
+  CGRect twice = laidOut([NSArray arrayWithObjects:
+    c4(kCAConstraintMinX, @"superlayer", kCAConstraintMinX, 10),
+    c4(kCAConstraintMinX, @"superlayer", kCAConstraintMinX, 40), nil]);
+  CGRect nobody = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMinX, @"nobody", kCAConstraintMinX)]);
+  CGRect itself = laidOut([NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"child", kCAConstraintMinX, 10)]);
+
+  PASS(CLOSE(twice.origin.x, 3) && CLOSE(twice.size.width, 40),
+       "the same edge twice leaves the axis alone, taking neither value");
+  PASS(CLOSE(nobody.origin.x, 3),
+       "a layer of a name nothing answers to leaves it alone");
+  PASS(CLOSE(itself.origin.x, 3), "and so does a layer naming itself");
+
+  END_SET("relationships that describe nothing")
+
+  START_SET("the scale and the offset")
+
+  CGRect scaled = laidOut([NSArray arrayWithObject:
+    c5(kCAConstraintMinX, @"superlayer", kCAConstraintMaxX, 0.25, 7)]);
+  CGRect crossed = laidOut([NSArray arrayWithObject:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMaxY)]);
+
+  PASS(CLOSE(scaled.origin.x, 57),
+       "the value read is scaled and then offset");
+  PASS(CLOSE(crossed.origin.x, 100),
+       "and it may be read from the other axis");
+
+  END_SET("the scale and the offset")
+
+  START_SET("the superlayer is measured by its bounds")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  CGRect f;
+
+  [root setBounds: CGRectMake(30, 70, 200, 100)];
+  [root setLayoutManager: [CAConstraintLayoutManager layoutManager]];
+  [child setFrame: CGRectMake(3, 5, 40, 20)];
+  [root addSublayer: child];
+  [child setConstraints: [NSArray arrayWithObjects:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX),
+    c3(kCAConstraintMinY, @"superlayer", kCAConstraintMinY), nil]];
+  [root layoutSublayers];
+  f = [child frame];
+
+  PASS(CLOSE(f.origin.x, 30) && CLOSE(f.origin.y, 70),
+       "a layer pinned to the corner of bounds that do not start at zero");
+
+  END_SET("the superlayer is measured by its bounds")
+
+  START_SET("a sibling as the source")
+
+  CALayer *root = rootLayer();
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [a setName: @"a"];
+  [a setFrame: CGRectMake(10, 0, 30, 20)];
+  [a setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"superlayer", kCAConstraintMinX, 10)]];
+  [b setName: @"b"];
+  [b setFrame: CGRectMake(0, 0, 50, 20)];
+  [b setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"a", kCAConstraintMaxX, 5)]];
+  [root addSublayer: a];
+  [root addSublayer: b];
+  [root layoutSublayers];
+
+  PASS(CLOSE([b frame].origin.x, 45),
+       "a layer is placed against the edge of the sibling it names");
+
+  END_SET("a sibling as the source")
+
+  START_SET("a sibling that is not itself laid out")
+
+  /* The source is read from the layout, so a sibling with nothing to lay it
+     out on that axis offers nothing to read. */
+  CALayer *root = rootLayer();
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [a setName: @"a"];
+  [a setFrame: CGRectMake(10, 0, 30, 20)];
+  [b setName: @"b"];
+  [b setFrame: CGRectMake(0, 0, 50, 20)];
+  [b setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"a", kCAConstraintMaxX, 5)]];
+  [root addSublayer: a];
+  [root addSublayer: b];
+  [root layoutSublayers];
+
+  PASS(CLOSE([b frame].origin.x, 0),
+       "naming a sibling with no constraints of its own leaves the layer alone");
+
+  END_SET("a sibling that is not itself laid out")
+
+  START_SET("a sibling laid out on the other axis only")
+
+  CALayer *root = rootLayer();
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [a setName: @"a"];
+  [a setFrame: CGRectMake(10, 0, 30, 20)];
+  [a setConstraints: [NSArray arrayWithObject:
+    c3(kCAConstraintMinY, @"superlayer", kCAConstraintMinY)]];
+  [b setName: @"b"];
+  [b setFrame: CGRectMake(0, 0, 50, 20)];
+  [b setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"a", kCAConstraintMaxX, 5)]];
+  [root addSublayer: a];
+  [root addSublayer: b];
+  [root layoutSublayers];
+
+  PASS(CLOSE([b frame].origin.x, 0),
+       "the axis the value is read from is the one that has to be laid out");
+
+  END_SET("a sibling laid out on the other axis only")
+
+  START_SET("the order the sublayers are in does not matter")
+
+  CALayer *root = rootLayer();
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [a setName: @"a"];
+  [a setFrame: CGRectMake(0, 0, 50, 20)];
+  [a setConstraints: [NSArray arrayWithObject:
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMidX)]];
+  [b setName: @"b"];
+  [b setFrame: CGRectMake(0, 0, 30, 20)];
+  [b setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"a", kCAConstraintMinX, 10)]];
+  [root addSublayer: b];
+  [root addSublayer: a];
+  [root layoutSublayers];
+
+  PASS(CLOSE([a frame].origin.x, 100), "the layer depended on is laid out");
+  PASS(CLOSE([b frame].origin.x, 110),
+       "and the one that depends on it follows, though it comes first");
+
+  END_SET("the order the sublayers are in does not matter")
+
+  START_SET("constraints that lead in a circle")
+
+  CALayer *root = rootLayer();
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+
+  [a setName: @"a"];
+  [a setFrame: CGRectMake(0, 0, 50, 20)];
+  [a setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"b", kCAConstraintMaxX, 1)]];
+  [b setName: @"b"];
+  [b setFrame: CGRectMake(0, 0, 30, 20)];
+  [b setConstraints: [NSArray arrayWithObject:
+    c4(kCAConstraintMinX, @"a", kCAConstraintMaxX, 1)]];
+  [root addSublayer: a];
+  [root addSublayer: b];
+  [root layoutSublayers];
+
+  PASS(CLOSE([a frame].origin.x, 0) && CLOSE([b frame].origin.x, 0),
+       "two layers waiting on each other are both left where they were");
+
+  END_SET("constraints that lead in a circle")
+
+  START_SET("two sublayers of one superlayer")
+
+  /* The example Apple gives: two layers each half the width, filling their
+     superlayer between them. */
+  CALayer *root = rootLayer();
+  CALayer *left = [CALayer layer];
+  CALayer *right = [CALayer layer];
+  CAConstraint *height = c3(kCAConstraintHeight, @"superlayer", kCAConstraintHeight);
+  CAConstraint *width = c5(kCAConstraintWidth, @"superlayer", kCAConstraintWidth, 0.5, 0);
+  CAConstraint *bottom = c3(kCAConstraintMinY, @"superlayer", kCAConstraintMinY);
+
+  [left setName: @"left"];
+  [left setFrame: CGRectMake(0, 0, 20, 20)];
+  [right setName: @"right"];
+  [right setFrame: CGRectMake(0, 0, 20, 20)];
+  [root addSublayer: left];
+  [root addSublayer: right];
+  [left setConstraints: [NSArray arrayWithObjects: height, width, bottom,
+    c3(kCAConstraintMinX, @"superlayer", kCAConstraintMinX), nil]];
+  [right setConstraints: [NSArray arrayWithObjects: height, width, bottom,
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX), nil]];
+  [root layoutSublayers];
+
+  PASS(CGRectEqualToRect([left frame], CGRectMake(0, 0, 100, 100)),
+       "the first fills the left half");
+  PASS(CGRectEqualToRect([right frame], CGRectMake(100, 0, 100, 100)),
+       "and the second the right half");
+
+  END_SET("two sublayers of one superlayer")
+
+  START_SET("asking the manager itself")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+
+  [root setBounds: CGRectMake(0, 0, 200, 100)];
+  [child setFrame: CGRectMake(3, 5, 40, 20)];
+  [root addSublayer: child];
+  [child setConstraints: [NSArray arrayWithObject:
+    c3(kCAConstraintMidX, @"superlayer", kCAConstraintMidX)]];
+  [[CAConstraintLayoutManager layoutManager] layoutSublayersOfLayer: root];
+
+  PASS(CLOSE([child frame].origin.x, 80),
+       "the manager lays a layer's sublayers out without being its own");
+
+  END_SET("asking the manager itself")
+
+  START_SET("laying out what needs it")
+
+  CALayer *root = rootLayer();
+  CALayer *child = [CALayer layer];
+
+  [child setFrame: CGRectMake(3, 5, 40, 20)];
+  [root addSublayer: child];
+  [child setConstraints: [NSArray arrayWithObject:
+    c3(kCAConstraintMidX, @"superlayer", kCAConstraintMidX)]];
+  [root layoutIfNeeded];
+
+  PASS(CLOSE([child frame].origin.x, 80),
+       "adding the constraint asked for the layout that then happened");
+  PASS(![root needsLayout], "and the layer no longer wants laying out");
+
+  END_SET("laying out what needs it")
+
+  START_SET("a layout reaches the whole tree")
+
+  CALayer *root = rootLayer();
+  CALayer *middle = [CALayer layer];
+  CALayer *deep = [CALayer layer];
+
+  [middle setName: @"middle"];
+  [middle setFrame: CGRectMake(0, 0, 100, 50)];
+  [middle setLayoutManager: [CAConstraintLayoutManager layoutManager]];
+  [deep setName: @"deep"];
+  [deep setFrame: CGRectMake(1, 1, 10, 10)];
+  [root addSublayer: middle];
+  [middle addSublayer: deep];
+  [deep setConstraints: [NSArray arrayWithObject:
+    c3(kCAConstraintMaxX, @"superlayer", kCAConstraintMaxX)]];
+  [root layoutIfNeeded];
+
+  PASS(CLOSE([deep frame].origin.x, 90),
+       "a layer two levels down is laid out by its own superlayer");
+
+  END_SET("a layout reaches the whole tree")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -118,6 +118,21 @@ int main(void)
 
   END_SET("replacing the sublayers outright")
 
+  START_SET("adding to sublayers that were set outright")
+
+  CALayer *root = settled(NULL);
+  CALayer *added = [CALayer layer];
+
+  [root setSublayers: [NSArray arrayWithObject: [CALayer layer]]];
+
+  PASS_RUNS([root addSublayer: added];,
+            "a layer can be added after the sublayers were set outright")
+  PASS([[root sublayers] count] == 2,
+       "and it joins the one that was set");
+  PASS([added superlayer] == root, "with this layer as its superlayer");
+
+  END_SET("adding to sublayers that were set outright")
+
   START_SET("the bounds changing")
 
   CALayer *root = settled(NULL);

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -1,0 +1,135 @@
+/* What makes a layer want laying out again.
+
+   The expected values are the ones Apple QuartzCore produces. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+/* A superlayer with one sublayer already, laid out and settled. */
+static CALayer *
+settled(CALayer **existing)
+{
+  CALayer *root = [CALayer layer];
+  CALayer *first = [CALayer layer];
+
+  [root setBounds: CGRectMake(0, 0, 100, 100)];
+  [root addSublayer: first];
+  [root layoutIfNeeded];
+  if (existing != NULL)
+    {
+      *existing = first;
+    }
+  return root;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a layer on its own")
+
+  CALayer *layer = [CALayer layer];
+
+  PASS(![layer needsLayout], "a fresh layer does not want laying out");
+
+  [layer setNeedsLayout];
+
+  PASS([layer needsLayout], "and wants it once it is asked to");
+
+  [layer layoutIfNeeded];
+
+  PASS(![layer needsLayout], "laying it out settles it again");
+
+  END_SET("a layer on its own")
+
+  START_SET("a settled superlayer")
+
+  CALayer *root = settled(NULL);
+
+  PASS(![root needsLayout], "a superlayer that has been laid out is settled");
+
+  END_SET("a settled superlayer")
+
+  START_SET("adding a sublayer")
+
+  CALayer *root = settled(NULL);
+  CALayer *added = [CALayer layer];
+
+  [added layoutIfNeeded];
+  [root addSublayer: added];
+
+  PASS([root needsLayout], "the superlayer wants laying out again");
+  PASS(![added needsLayout], "the layer that was added does not");
+
+  END_SET("adding a sublayer")
+
+  START_SET("inserting a sublayer")
+
+  CALayer *root = settled(NULL);
+
+  [root insertSublayer: [CALayer layer] atIndex: 0];
+
+  PASS([root needsLayout], "inserting at an index wants laying out");
+
+  END_SET("inserting a sublayer")
+
+  START_SET("inserting below a sibling")
+
+  CALayer *first;
+  CALayer *root = settled(&first);
+
+  [root insertSublayer: [CALayer layer] below: first];
+
+  PASS([root needsLayout], "inserting below a sibling wants laying out");
+
+  END_SET("inserting below a sibling")
+
+  START_SET("inserting above a sibling")
+
+  CALayer *first;
+  CALayer *root = settled(&first);
+
+  [root insertSublayer: [CALayer layer] above: first];
+
+  PASS([root needsLayout], "inserting above a sibling wants laying out");
+
+  END_SET("inserting above a sibling")
+
+  START_SET("a sublayer leaving")
+
+  CALayer *first;
+  CALayer *root = settled(&first);
+
+  [first removeFromSuperlayer];
+
+  PASS([root needsLayout],
+       "the superlayer a sublayer left wants laying out");
+
+  END_SET("a sublayer leaving")
+
+  START_SET("replacing the sublayers outright")
+
+  CALayer *root = settled(NULL);
+
+  [root setSublayers: [NSArray arrayWithObject: [CALayer layer]]];
+
+  PASS([root needsLayout], "setting the sublayers wants laying out");
+
+  END_SET("replacing the sublayers outright")
+
+  START_SET("the bounds changing")
+
+  CALayer *root = settled(NULL);
+
+  [root setBounds: CGRectMake(0, 0, 200, 200)];
+
+  PASS([root needsLayout],
+       "a layer whose bounds changed wants laying out, since its sublayers "
+       "are placed inside them");
+
+  END_SET("the bounds changing")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -125,8 +125,8 @@ int main(void)
 
   [root setSublayers: [NSArray arrayWithObject: [CALayer layer]]];
 
-  PASS_RUNS([root addSublayer: added];,
-            "a layer can be added after the sublayers were set outright")
+  PASS_RUNS([root addSublayer: added],
+            "a layer can be added after the sublayers were set outright");
   PASS([[root sublayers] count] == 2,
        "and it joins the one that was set");
   PASS([added superlayer] == root, "with this layer as its superlayer");


### PR DESCRIPTION
Only -setConstraints: marked a layer as needing layout, so a tree laid out by a layout manager did not lay out again when a sublayer was added or removed, or when the layer itself was resized. -layoutIfNeeded found nothing to do, so the caller had to send -setNeedsLayout by hand.

-addSublayer:, the three -insertSublayer: methods, -setSublayers: and a sublayer's -removeFromSuperlayer now mark the superlayer, and -setBounds: marks the layer itself. That is what Apple does in each case, including leaving the layer that was added unmarked. -setSublayers: needed a setter of its own to mark anything, and it copies the array as a mutable one, since the methods above add to it in place.

This is on top of #75 and #35. #35 writes the same setter to give each layer its superlayer, and merging it here keeps one definition of -setSublayers: rather than two, which would not compile. Both PRs' commits show until they land.

The test is Tests/quartzcore/CALayer/layout.m and runs against Apple QuartzCore too. Ten of its fifteen assertions failed before this change and none do now. The suite goes from 365 passed and 9 dashed hopes to 380 and 9, none failing.
