### PR TITLE
Feature: add CAEmitterLayer and CAEmitterCell

### DIFF
--- a/Headers/QuartzCore/CAEmitterCell.h
+++ b/Headers/QuartzCore/CAEmitterCell.h
@@ -1,0 +1,120 @@
+/* CAEmitterCell.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CABase.h"
+#import "QuartzCore/CAMediaTiming.h"
+#if GNUSTEP
+#import <CoreGraphics/CoreGraphics.h>
+#endif
+
+/* One source of the particles a CAEmitterLayer emits.  A cell may hold cells
+   of its own, so that a particle emits particles in turn. */
+@interface CAEmitterCell : NSObject <NSCoding, NSCopying, CAMediaTiming>
+{
+  /* property-backing ivars */
+  id _contents;
+  CGRect _contentsRect;
+  CGFloat _contentsScale;
+  NSArray * _emitterCells;
+  BOOL _enabled;
+  CGColorRef _color;
+  float _redRange, _greenRange, _blueRange, _alphaRange;
+  float _redSpeed, _greenSpeed, _blueSpeed, _alphaSpeed;
+  NSString * _magnificationFilter;
+  NSString * _minificationFilter;
+  float _minificationFilterBias;
+  CGFloat _scale, _scaleRange, _scaleSpeed;
+  NSString * _name;
+  NSDictionary * _style;
+  CGFloat _spin, _spinRange;
+  CGFloat _emissionLatitude, _emissionLongitude, _emissionRange;
+  float _lifetime, _lifetimeRange, _birthRate;
+  CGFloat _velocity, _velocityRange;
+  CGFloat _xAcceleration, _yAcceleration, _zAcceleration;
+
+  /* CAMediaTiming ivars */
+  CFTimeInterval _beginTime;
+  CFTimeInterval _timeOffset;
+  float _repeatCount;
+  float _repeatDuration;
+  BOOL _autoreverses;
+  NSString * _fillMode;
+  CFTimeInterval _duration;
+  float _speed;
+}
+
++ (id) emitterCell;
++ (id) defaultValueForKey: (NSString *)key;
+
+- (BOOL) shouldArchiveValueForKey: (NSString *)key;
+
+@property (retain) id contents;
+@property CGRect contentsRect;
+@property CGFloat contentsScale;
+@property (copy) NSArray *emitterCells;
+@property (getter=isEnabled) BOOL enabled;
+@property CGColorRef color;
+
+@property float redRange;
+@property float greenRange;
+@property float blueRange;
+@property float alphaRange;
+@property float redSpeed;
+@property float greenSpeed;
+@property float blueSpeed;
+@property float alphaSpeed;
+
+@property (copy) NSString *magnificationFilter;
+@property (copy) NSString *minificationFilter;
+@property float minificationFilterBias;
+
+@property CGFloat scale;
+@property CGFloat scaleRange;
+@property CGFloat scaleSpeed;
+
+@property (copy) NSString *name;
+@property (copy) NSDictionary *style;
+
+@property CGFloat spin;
+@property CGFloat spinRange;
+@property CGFloat emissionLatitude;
+@property CGFloat emissionLongitude;
+@property CGFloat emissionRange;
+
+@property float lifetime;
+@property float lifetimeRange;
+@property float birthRate;
+
+@property CGFloat velocity;
+@property CGFloat velocityRange;
+@property CGFloat xAcceleration;
+@property CGFloat yAcceleration;
+@property CGFloat zAcceleration;
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Headers/QuartzCore/CAEmitterLayer.h
+++ b/Headers/QuartzCore/CAEmitterLayer.h
@@ -1,0 +1,92 @@
+/* CAEmitterLayer.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CALayer.h"
+#import "QuartzCore/CAEmitterCell.h"
+
+/* A layer that emits a particle system.  The particles come from the
+   CAEmitterCells it is given. */
+@interface CAEmitterLayer : CALayer
+{
+  /* property-backing ivars */
+  NSArray * _emitterCells;
+  CGPoint _emitterPosition;
+  CGFloat _emitterZPosition;
+  CGSize _emitterSize;
+  CGFloat _emitterDepth;
+  NSString * _emitterShape;
+  NSString * _emitterMode;
+  NSString * _renderMode;
+  float _scale;
+  unsigned int _seed;
+  float _spin;
+  float _velocity;
+  float _birthRate;
+  float _lifetime;
+  BOOL _preservesDepth;
+}
+
+@property (copy) NSArray *emitterCells;
+@property CGPoint emitterPosition;
+@property CGFloat emitterZPosition;
+@property CGSize emitterSize;
+@property CGFloat emitterDepth;
+@property (copy) NSString *emitterShape;
+@property (copy) NSString *emitterMode;
+@property (copy) NSString *renderMode;
+@property float scale;
+@property unsigned int seed;
+@property float spin;
+@property float velocity;
+@property float birthRate;
+@property float lifetime;
+@property BOOL preservesDepth;
+
+@end
+
+/* emitter shapes */
+extern NSString *const kCAEmitterLayerPoint;
+extern NSString *const kCAEmitterLayerLine;
+extern NSString *const kCAEmitterLayerRectangle;
+extern NSString *const kCAEmitterLayerCuboid;
+extern NSString *const kCAEmitterLayerCircle;
+extern NSString *const kCAEmitterLayerSphere;
+
+/* emitter modes */
+extern NSString *const kCAEmitterLayerPoints;
+extern NSString *const kCAEmitterLayerOutline;
+extern NSString *const kCAEmitterLayerSurface;
+extern NSString *const kCAEmitterLayerVolume;
+
+/* the order the particles are drawn in */
+extern NSString *const kCAEmitterLayerUnordered;
+extern NSString *const kCAEmitterLayerOldestFirst;
+extern NSString *const kCAEmitterLayerOldestLast;
+extern NSString *const kCAEmitterLayerBackToFront;
+extern NSString *const kCAEmitterLayerAdditive;
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Headers/QuartzCore/CoreAnimation.h
+++ b/Headers/QuartzCore/CoreAnimation.h
@@ -30,6 +30,8 @@
 
 #import "QuartzCore/CABase.h"
 #import "QuartzCore/CAAction.h"
+#import "QuartzCore/CAEmitterCell.h"
+#import "QuartzCore/CAEmitterLayer.h"
 #import "QuartzCore/CAFilter.h"
 #import "QuartzCore/CALayer.h"
 #import "QuartzCore/CAAnimation.h"

--- a/Source/CAEmitterCell.m
+++ b/Source/CAEmitterCell.m
@@ -1,0 +1,235 @@
+/* CAEmitterCell.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CAEmitterCell.h"
+#import "QuartzCore/CAFilter.h"
+
+@implementation CAEmitterCell
+
+@synthesize contents=_contents;
+@synthesize contentsRect=_contentsRect;
+@synthesize contentsScale=_contentsScale;
+@synthesize emitterCells=_emitterCells;
+@synthesize enabled=_enabled;
+
+@synthesize redRange=_redRange;
+@synthesize greenRange=_greenRange;
+@synthesize blueRange=_blueRange;
+@synthesize alphaRange=_alphaRange;
+@synthesize redSpeed=_redSpeed;
+@synthesize greenSpeed=_greenSpeed;
+@synthesize blueSpeed=_blueSpeed;
+@synthesize alphaSpeed=_alphaSpeed;
+
+@synthesize magnificationFilter=_magnificationFilter;
+@synthesize minificationFilter=_minificationFilter;
+@synthesize minificationFilterBias=_minificationFilterBias;
+
+@synthesize scale=_scale;
+@synthesize scaleRange=_scaleRange;
+@synthesize scaleSpeed=_scaleSpeed;
+
+@synthesize name=_name;
+@synthesize style=_style;
+
+@synthesize spin=_spin;
+@synthesize spinRange=_spinRange;
+@synthesize emissionLatitude=_emissionLatitude;
+@synthesize emissionLongitude=_emissionLongitude;
+@synthesize emissionRange=_emissionRange;
+
+@synthesize lifetime=_lifetime;
+@synthesize lifetimeRange=_lifetimeRange;
+@synthesize birthRate=_birthRate;
+
+@synthesize velocity=_velocity;
+@synthesize velocityRange=_velocityRange;
+@synthesize xAcceleration=_xAcceleration;
+@synthesize yAcceleration=_yAcceleration;
+@synthesize zAcceleration=_zAcceleration;
+
+/* CAMediaTiming */
+@synthesize beginTime=_beginTime;
+@synthesize timeOffset=_timeOffset;
+@synthesize repeatCount=_repeatCount;
+@synthesize repeatDuration=_repeatDuration;
+@synthesize autoreverses=_autoreverses;
+@synthesize fillMode=_fillMode;
+@synthesize duration=_duration;
+@synthesize speed=_speed;
+
++ (id) emitterCell
+{
+  return [[[self alloc] init] autorelease];
+}
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"enabled"])
+    {
+      return [NSNumber numberWithBool: YES];
+    }
+  if ([key isEqualToString: @"scale"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+
+  return nil;
+}
+
+- (id) init
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _contentsRect = CGRectMake(0.0, 0.0, 1.0, 1.0);
+  _contentsScale = 1.0;
+  _enabled = YES;
+  _color = CGColorCreateGenericRGB(1.0, 1.0, 1.0, 1.0);
+  _magnificationFilter = [kCAFilterLinear copy];
+  _minificationFilter = [kCAFilterLinear copy];
+  _scale = 1.0;
+
+  return self;
+}
+
+- (void) dealloc
+{
+  CGColorRelease(_color);
+  [_contents release];
+  [_emitterCells release];
+  [_magnificationFilter release];
+  [_minificationFilter release];
+  [_name release];
+  [_style release];
+  [_fillMode release];
+
+  [super dealloc];
+}
+
+- (CGColorRef) color
+{
+  return _color;
+}
+
+- (void) setColor: (CGColorRef)color
+{
+  if (color == _color)
+    {
+      return;
+    }
+
+  CGColorRetain(color);
+  CGColorRelease(_color);
+  _color = color;
+}
+
+- (BOOL) shouldArchiveValueForKey: (NSString *)key
+{
+  return NO;
+}
+
+/* The keys a cell carries from one of itself to another, and through an
+   archive. */
+static NSString * const GSEmitterCellKeys[] = {
+  @"contents", @"contentsRect", @"contentsScale", @"emitterCells", @"enabled",
+  @"redRange", @"greenRange", @"blueRange", @"alphaRange",
+  @"redSpeed", @"greenSpeed", @"blueSpeed", @"alphaSpeed",
+  @"magnificationFilter", @"minificationFilter", @"minificationFilterBias",
+  @"scale", @"scaleRange", @"scaleSpeed", @"name", @"style",
+  @"spin", @"spinRange", @"emissionLatitude", @"emissionLongitude",
+  @"emissionRange", @"lifetime", @"lifetimeRange", @"birthRate",
+  @"velocity", @"velocityRange",
+  @"xAcceleration", @"yAcceleration", @"zAcceleration",
+  @"beginTime", @"timeOffset", @"repeatCount", @"repeatDuration",
+  @"autoreverses", @"fillMode", @"duration", @"speed"
+};
+
+- (id) initWithCoder: (NSCoder *)aDecoder
+{
+  self = [self init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  for (unsigned i = 0;
+       i < sizeof(GSEmitterCellKeys)/sizeof(GSEmitterCellKeys[0]); i++)
+    {
+      if ([aDecoder containsValueForKey: GSEmitterCellKeys[i]])
+        {
+          [self setValue: [aDecoder decodeObjectForKey: GSEmitterCellKeys[i]]
+                  forKey: GSEmitterCellKeys[i]];
+        }
+    }
+
+  return self;
+}
+
+- (void) encodeWithCoder: (NSCoder *)aCoder
+{
+  for (unsigned i = 0;
+       i < sizeof(GSEmitterCellKeys)/sizeof(GSEmitterCellKeys[0]); i++)
+    {
+      if ([self shouldArchiveValueForKey: GSEmitterCellKeys[i]])
+        {
+          [aCoder encodeObject: [self valueForKey: GSEmitterCellKeys[i]]
+                        forKey: GSEmitterCellKeys[i]];
+        }
+    }
+}
+
+- (id) copyWithZone: (NSZone *)zone
+{
+  CAEmitterCell *theCopy = [[[self class] allocWithZone: zone] init];
+
+  if (theCopy == nil)
+    {
+      return nil;
+    }
+
+  for (unsigned i = 0;
+       i < sizeof(GSEmitterCellKeys)/sizeof(GSEmitterCellKeys[0]); i++)
+    {
+      id value = [self valueForKey: GSEmitterCellKeys[i]];
+
+      if (value != nil)
+        {
+          [theCopy setValue: value forKey: GSEmitterCellKeys[i]];
+        }
+    }
+  [theCopy setColor: [self color]];
+
+  return theCopy;
+}
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CAEmitterLayer.m
+++ b/Source/CAEmitterLayer.m
@@ -1,0 +1,124 @@
+/* CAEmitterLayer.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "QuartzCore/CAEmitterLayer.h"
+
+NSString *const kCAEmitterLayerPoint = @"point";
+NSString *const kCAEmitterLayerLine = @"line";
+NSString *const kCAEmitterLayerRectangle = @"rectangle";
+NSString *const kCAEmitterLayerCuboid = @"cuboid";
+NSString *const kCAEmitterLayerCircle = @"circle";
+NSString *const kCAEmitterLayerSphere = @"sphere";
+
+NSString *const kCAEmitterLayerPoints = @"points";
+NSString *const kCAEmitterLayerOutline = @"outline";
+NSString *const kCAEmitterLayerSurface = @"surface";
+NSString *const kCAEmitterLayerVolume = @"volume";
+
+NSString *const kCAEmitterLayerUnordered = @"unordered";
+NSString *const kCAEmitterLayerOldestFirst = @"oldestFirst";
+NSString *const kCAEmitterLayerOldestLast = @"oldestLast";
+NSString *const kCAEmitterLayerBackToFront = @"backToFront";
+NSString *const kCAEmitterLayerAdditive = @"additive";
+
+@implementation CAEmitterLayer
+
+@synthesize emitterCells=_emitterCells;
+@synthesize emitterPosition=_emitterPosition;
+@synthesize emitterZPosition=_emitterZPosition;
+@synthesize emitterSize=_emitterSize;
+@synthesize emitterDepth=_emitterDepth;
+@synthesize emitterShape=_emitterShape;
+@synthesize emitterMode=_emitterMode;
+@synthesize renderMode=_renderMode;
+@synthesize scale=_scale;
+@synthesize seed=_seed;
+@synthesize spin=_spin;
+@synthesize velocity=_velocity;
+@synthesize birthRate=_birthRate;
+@synthesize lifetime=_lifetime;
+@synthesize preservesDepth=_preservesDepth;
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"emitterShape"])
+    {
+      return kCAEmitterLayerPoint;
+    }
+  if ([key isEqualToString: @"emitterMode"])
+    {
+      return kCAEmitterLayerVolume;
+    }
+  if ([key isEqualToString: @"renderMode"])
+    {
+      return kCAEmitterLayerUnordered;
+    }
+  if ([key isEqualToString: @"scale"]
+      || [key isEqualToString: @"spin"]
+      || [key isEqualToString: @"velocity"]
+      || [key isEqualToString: @"birthRate"]
+      || [key isEqualToString: @"lifetime"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  self = [super init];
+  if (self == nil)
+    {
+      return nil;
+    }
+
+  _emitterShape = [kCAEmitterLayerPoint copy];
+  _emitterMode = [kCAEmitterLayerVolume copy];
+  _renderMode = [kCAEmitterLayerUnordered copy];
+  _scale = 1.0;
+  _spin = 1.0;
+  _velocity = 1.0;
+  _birthRate = 1.0;
+  _lifetime = 1.0;
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_emitterCells release];
+  [_emitterShape release];
+  [_emitterMode release];
+  [_renderMode release];
+
+  [super dealloc];
+}
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/GNUmakefile
+++ b/Source/GNUmakefile
@@ -25,6 +25,8 @@ QuartzCore_HEADER_FILES = \
 	CAAnimation.h \
 	CABase.h \
 	CADisplayLink.h \
+	CAEmitterCell.h \
+	CAEmitterLayer.h \
 	CAEAGLLayer.h \
 	CAFilter.h \
 	CAGradientLayer.h \

--- a/Tests/quartzcore/CAEmitterLayer/TestInfo
+++ b/Tests/quartzcore/CAEmitterLayer/TestInfo
@@ -1,0 +1,1 @@
+# Both files run against Apple QuartzCore as well.

--- a/Tests/quartzcore/CAEmitterLayer/emitter.m
+++ b/Tests/quartzcore/CAEmitterLayer/emitter.m
@@ -1,0 +1,247 @@
+/* What a CAEmitterLayer and a CAEmitterCell hold before anything is set.
+
+   Every value here was measured against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/QuartzCore.h>
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the two classes")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+
+  PASS([CAEmitterLayer superclass] == [CALayer class],
+       "an emitter layer is a layer");
+  PASS([CAEmitterCell superclass] == [NSObject class],
+       "an emitter cell is not");
+  PASS(![cell isKindOfClass: [CALayer class]],
+       "a cell is no kind of layer");
+  PASS([cell conformsToProtocol: @protocol(CAMediaTiming)],
+       "a cell has a timing of its own");
+  PASS([cell conformsToProtocol: @protocol(NSCoding)], "a cell can be coded");
+  PASS([cell conformsToProtocol: @protocol(NSCopying)], "and copied");
+
+  END_SET("the two classes")
+
+  START_SET("what an emitter layer starts with")
+
+  CAEmitterLayer *layer = [CAEmitterLayer layer];
+
+  PASS([layer emitterCells] == nil, "no cells");
+  PASS(CLOSE([layer emitterPosition].x, 0) && CLOSE([layer emitterPosition].y, 0),
+       "the emitter sits at the origin");
+  PASS(CLOSE([layer emitterZPosition], 0), "at depth zero");
+  PASS(CLOSE([layer emitterSize].width, 0)
+       && CLOSE([layer emitterSize].height, 0), "with no size");
+  PASS(CLOSE([layer emitterDepth], 0), "and no depth");
+  PASS([[layer emitterShape] isEqualToString: kCAEmitterLayerPoint],
+       "it emits from a point");
+  PASS([[layer emitterMode] isEqualToString: kCAEmitterLayerVolume],
+       "throughout the volume of that shape");
+  PASS([[layer renderMode] isEqualToString: kCAEmitterLayerUnordered],
+       "and draws the particles in no particular order");
+  PASS(CLOSE([layer scale], 1), "the scale multiplier is one");
+  PASS([layer seed] == 0, "the seed is zero");
+  PASS(CLOSE([layer spin], 1), "and so are the spin");
+  PASS(CLOSE([layer velocity], 1), "velocity");
+  PASS(CLOSE([layer birthRate], 1), "birth rate");
+  PASS(CLOSE([layer lifetime], 1), "and lifetime multipliers");
+  PASS(![layer preservesDepth], "depth is not preserved");
+
+  END_SET("what an emitter layer starts with")
+
+  START_SET("two emitter layers seed the same")
+
+  PASS([[CAEmitterLayer layer] seed] == [[CAEmitterLayer layer] seed],
+       "the seed is not random");
+
+  END_SET("two emitter layers seed the same")
+
+  START_SET("what an emitter cell starts with")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+  CGRect rect = [cell contentsRect];
+
+  PASS([cell contents] == nil, "no contents");
+  PASS(CLOSE(rect.origin.x, 0) && CLOSE(rect.origin.y, 0)
+       && CLOSE(rect.size.width, 1) && CLOSE(rect.size.height, 1),
+       "the whole of them is drawn");
+  PASS(CLOSE([cell contentsScale], 1), "at a scale of one");
+  PASS([cell emitterCells] == nil, "no cells of its own");
+  PASS([cell isEnabled], "a cell is enabled");
+  PASS([cell name] == nil, "with no name");
+  PASS([cell style] == nil, "and no style");
+
+  END_SET("what an emitter cell starts with")
+
+  START_SET("the colour a cell starts with")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+  CGColorRef color = [cell color];
+
+  PASS(color != NULL, "a cell has a colour");
+  if (color != NULL)
+    {
+      const CGFloat *c = CGColorGetComponents(color);
+
+      PASS(CGColorGetNumberOfComponents(color) == 4,
+           "of four components");
+      PASS(CLOSE(c[0], 1) && CLOSE(c[1], 1) && CLOSE(c[2], 1) && CLOSE(c[3], 1),
+           "opaque white");
+    }
+
+  END_SET("the colour a cell starts with")
+
+  START_SET("a cell varies nothing to begin with")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+
+  PASS(CLOSE([cell redRange], 0) && CLOSE([cell greenRange], 0)
+       && CLOSE([cell blueRange], 0) && CLOSE([cell alphaRange], 0),
+       "no colour component varies");
+  PASS(CLOSE([cell redSpeed], 0) && CLOSE([cell greenSpeed], 0)
+       && CLOSE([cell blueSpeed], 0) && CLOSE([cell alphaSpeed], 0),
+       "and none of them changes over a lifetime");
+  PASS(CLOSE([cell spin], 0) && CLOSE([cell spinRange], 0), "it does not spin");
+  PASS(CLOSE([cell emissionLatitude], 0) && CLOSE([cell emissionLongitude], 0)
+       && CLOSE([cell emissionRange], 0), "and emits along one direction");
+  PASS(CLOSE([cell velocity], 0) && CLOSE([cell velocityRange], 0),
+       "at no speed");
+  PASS(CLOSE([cell xAcceleration], 0) && CLOSE([cell yAcceleration], 0)
+       && CLOSE([cell zAcceleration], 0), "and no acceleration");
+
+  END_SET("a cell varies nothing to begin with")
+
+  START_SET("a cell emits nothing until it is told to")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+
+  PASS(CLOSE([cell birthRate], 0), "nothing is born");
+  PASS(CLOSE([cell lifetime], 0) && CLOSE([cell lifetimeRange], 0),
+       "and would not live if it were");
+
+  END_SET("a cell emits nothing until it is told to")
+
+  START_SET("how a cell scales and filters its contents")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+
+  PASS(CLOSE([cell scale], 1), "the scale is one");
+  PASS(CLOSE([cell scaleRange], 0) && CLOSE([cell scaleSpeed], 0),
+       "and does not vary or change");
+  PASS([[cell magnificationFilter] isEqualToString: kCAFilterLinear],
+       "contents are magnified linearly");
+  PASS([[cell minificationFilter] isEqualToString: kCAFilterLinear],
+       "and reduced linearly");
+  PASS(CLOSE([cell minificationFilterBias], 0), "with no bias");
+
+  END_SET("how a cell scales and filters its contents")
+
+  START_SET("the shapes an emitter can have")
+
+  PASS([kCAEmitterLayerPoint isEqualToString: @"point"], "point");
+  PASS([kCAEmitterLayerLine isEqualToString: @"line"], "line");
+  PASS([kCAEmitterLayerRectangle isEqualToString: @"rectangle"], "rectangle");
+  PASS([kCAEmitterLayerCuboid isEqualToString: @"cuboid"], "cuboid");
+  PASS([kCAEmitterLayerCircle isEqualToString: @"circle"], "circle");
+  PASS([kCAEmitterLayerSphere isEqualToString: @"sphere"], "sphere");
+
+  END_SET("the shapes an emitter can have")
+
+  START_SET("where in a shape the particles come from")
+
+  PASS([kCAEmitterLayerPoints isEqualToString: @"points"], "points");
+  PASS([kCAEmitterLayerOutline isEqualToString: @"outline"], "outline");
+  PASS([kCAEmitterLayerSurface isEqualToString: @"surface"], "surface");
+  PASS([kCAEmitterLayerVolume isEqualToString: @"volume"], "volume");
+
+  END_SET("where in a shape the particles come from")
+
+  START_SET("the order the particles are drawn in")
+
+  PASS([kCAEmitterLayerUnordered isEqualToString: @"unordered"], "unordered");
+  PASS([kCAEmitterLayerOldestFirst isEqualToString: @"oldestFirst"],
+       "oldest first");
+  PASS([kCAEmitterLayerOldestLast isEqualToString: @"oldestLast"],
+       "oldest last");
+  PASS([kCAEmitterLayerBackToFront isEqualToString: @"backToFront"],
+       "back to front");
+  PASS([kCAEmitterLayerAdditive isEqualToString: @"additive"], "additive");
+
+  END_SET("the order the particles are drawn in")
+
+  START_SET("the defaults each class answers for")
+
+  PASS([[CAEmitterCell defaultValueForKey: @"enabled"] boolValue],
+       "a cell is enabled by default");
+  PASS(CLOSE([[CAEmitterCell defaultValueForKey: @"scale"] floatValue], 1),
+       "and scaled by one");
+  PASS([CAEmitterCell defaultValueForKey: @"birthRate"] == nil,
+       "it names no default birth rate");
+  PASS([CAEmitterCell defaultValueForKey: @"lifetime"] == nil,
+       "and no default lifetime");
+  PASS([CAEmitterCell defaultValueForKey: @"bogus"] == nil,
+       "a key it does not know answers nothing");
+
+  PASS(CLOSE([[CAEmitterLayer defaultValueForKey: @"birthRate"] floatValue], 1),
+       "the layer does name a default birth rate");
+  PASS([[CAEmitterLayer defaultValueForKey: @"emitterShape"]
+         isEqualToString: kCAEmitterLayerPoint],
+       "and the shape it emits from");
+  PASS(CLOSE([[CAEmitterLayer defaultValueForKey: @"scale"] floatValue], 1),
+       "and its scale");
+
+  END_SET("the defaults each class answers for")
+
+  START_SET("what a cell puts in an archive")
+
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+
+  PASS(![cell shouldArchiveValueForKey: @"name"],
+       "a cell archives nothing by default");
+
+  END_SET("what a cell puts in an archive")
+
+  START_SET("giving cells to a layer")
+
+  CAEmitterLayer *layer = [CAEmitterLayer layer];
+  CAEmitterCell *cell = [CAEmitterCell emitterCell];
+  NSMutableArray *given = [NSMutableArray arrayWithObject: cell];
+
+  [layer setEmitterCells: given];
+
+  PASS([[layer emitterCells] count] == 1, "the layer holds the cell");
+  PASS([[layer emitterCells] objectAtIndex: 0] == cell,
+       "the cell itself, not a copy of it");
+
+  [given removeAllObjects];
+
+  PASS([[layer emitterCells] count] == 1,
+       "the array is copied, so emptying the original leaves the layer alone");
+
+  END_SET("giving cells to a layer")
+
+  START_SET("a cell holding cells")
+
+  CAEmitterCell *parent = [CAEmitterCell emitterCell];
+  CAEmitterCell *child = [CAEmitterCell emitterCell];
+
+  [parent setEmitterCells: [NSArray arrayWithObject: child]];
+
+  PASS([[parent emitterCells] count] == 1,
+       "a cell can hold cells of its own");
+  PASS([[parent emitterCells] objectAtIndex: 0] == child,
+       "which is how a particle emits particles");
+
+  END_SET("a cell holding cells")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Neither class existed. The layer goes in a new CAEmitterLayer.h beside its fifteen constants and the cell in CAEmitterCell.h, where Apple declares them, both with the property surface Apple documents. A cell holds cells of its own, so a particle emits particles in turn, and it conforms to CAMediaTiming as Apple's does.

The defaults are Apple's, and not all obvious: an emitter emits from a point but throughout its volume, with scale, spin, velocity, birth rate and lifetime all at one, while a cell starts opaque white and enabled with a birth rate and lifetime of zero, so it emits nothing until told to.

Nothing is emitted or drawn yet: that needs particle simulation in the renderer, and this is the surface that would drive it. A cell's eight timing properties are stored but unread, and their starting values are the only ones here not taken from Apple.

The tests are in Tests/quartzcore/CAEmitterLayer and run against Apple QuartzCore too.

None of the 74 assertions compiled before. All pass now, and the suite goes from 305 passed and 9 dashed hopes to 379 and 9, none failing.
