### PR TITLE
Feature: declare the delegate and layout manager protocols by name

### DIFF
--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -158,8 +158,19 @@ extern NSString *const kCATransitionFromRight;
 
 /* *********************************** */
 
+/* What an animation tells its delegate.  Both methods are optional, so a
+   class conforms by naming the protocol whether or not it implements
+   either. */
+@protocol CAAnimationDelegate <NSObject>
+@optional
+- (void) animationDidStart: (CAAnimation *)animation;
+- (void) animationDidStop: (CAAnimation *)animation finished: (BOOL)finished;
+
+@end
+
 /* delegate methods for CAAnimation */
-/* a GNUstep extension */
+/* a GNUstep extension, kept for the code that names it; the protocol above
+   is the one Apple declares */
 @protocol GSCAAnimationDelegate <NSObject>
 - (void) animationDidStart: (CAAnimation *)animation;
 - (void) animationDidStop: (CAAnimation *)animation finished: (BOOL)finished;

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -218,6 +218,28 @@ extern NSString *const kCATransition;
 @property (nonatomic, assign) CGFloat anchorPointZ;
 @end
 
+/* What a layer asks of its delegate.  Every method is optional, so a class
+   conforms by naming the protocol whether or not it implements any of
+   them. */
+@protocol CALayerDelegate <NSObject>
+@optional
+- (void) displayLayer: (CALayer*)layer;
+- (void) drawLayer: (CALayer*)layer inContext: (CGContextRef)context;
+- (void) layerWillDraw: (CALayer*)layer;
+- (void) layoutSublayersOfLayer: (CALayer*)layer;
+- (id<CAAction>) actionForLayer: (CALayer*)layer forKey: (NSString*)eventKey;
+@end
+
+/* What a layer asks of its layoutManager. */
+@protocol CALayoutManager <NSObject>
+@optional
+- (void) invalidateLayoutOfLayer: (CALayer*)layer;
+- (CGSize) preferredSizeOfLayer: (CALayer*)layer;
+- (void) layoutSublayersOfLayer: (CALayer*)layer;
+@end
+
+/* The same methods, declared on NSObject so that they can be sent to a
+   delegate or a layout manager held as a plain id. */
 @interface NSObject (CALayerActions)
 - (void) displayLayer: (CALayer*)layer;
 - (void) drawLayer: (CALayer*)layer inContext: (CGContextRef)context;

--- a/Tests/quartzcore/protocols/TestInfo
+++ b/Tests/quartzcore/protocols/TestInfo
@@ -1,0 +1,1 @@
+# The file runs against Apple QuartzCore as well.

--- a/Tests/quartzcore/protocols/names.m
+++ b/Tests/quartzcore/protocols/names.m
@@ -1,0 +1,117 @@
+/* The protocols a delegate or a layout manager names.
+
+   Naming one of these in a class declaration is the point of the test: a
+   class written against Apple QuartzCore says
+
+     @interface Thing : NSObject <CALayerDelegate>
+
+   and this file will not compile unless the framework declares it.  Every
+   method of all three is optional, so the classes below implement nothing
+   and still conform. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+@interface GSTestLayerDelegate : NSObject <CALayerDelegate>
+@end
+@implementation GSTestLayerDelegate
+@end
+
+@interface GSTestLayoutManager : NSObject <CALayoutManager>
+@end
+@implementation GSTestLayoutManager
+@end
+
+@interface GSTestAnimationDelegate : NSObject <CAAnimationDelegate>
+@end
+@implementation GSTestAnimationDelegate
+@end
+
+/* A class that implements the methods without naming the protocol. */
+@interface GSTestQuietDelegate : NSObject
+- (void) displayLayer: (CALayer *)layer;
+@end
+@implementation GSTestQuietDelegate
+- (void) displayLayer: (CALayer *)layer {}
+@end
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the protocols exist to be named")
+
+  PASS(@protocol(CALayerDelegate) != nil, "a layer has a delegate protocol");
+  PASS(@protocol(CALayoutManager) != nil, "and a layout manager protocol");
+  PASS(@protocol(CAAnimationDelegate) != nil,
+       "an animation has a delegate protocol");
+
+  END_SET("the protocols exist to be named")
+
+  START_SET("naming one is enough to conform")
+
+  /* Nothing below implements a single method of the protocol it names. */
+  PASS([GSTestLayerDelegate conformsToProtocol: @protocol(CALayerDelegate)],
+       "a class conforms by naming the layer delegate protocol");
+  PASS([GSTestLayoutManager conformsToProtocol: @protocol(CALayoutManager)],
+       "and by naming the layout manager protocol");
+  PASS([GSTestAnimationDelegate conformsToProtocol:
+         @protocol(CAAnimationDelegate)],
+       "and by naming the animation delegate protocol");
+
+  END_SET("naming one is enough to conform")
+
+  START_SET("implementing without naming is not conforming")
+
+  GSTestQuietDelegate *quiet = [[[GSTestQuietDelegate alloc] init] autorelease];
+
+  PASS([quiet respondsToSelector: @selector(displayLayer:)],
+       "the class implements a delegate method");
+  PASS(![quiet conformsToProtocol: @protocol(CALayerDelegate)],
+       "and still does not conform, since conformance is declared");
+
+  END_SET("implementing without naming is not conforming")
+
+  START_SET("a layer takes one")
+
+  CALayer *layer = [CALayer layer];
+  GSTestLayerDelegate *delegate =
+    [[[GSTestLayerDelegate alloc] init] autorelease];
+  GSTestLayoutManager *manager =
+    [[[GSTestLayoutManager alloc] init] autorelease];
+
+  [layer setDelegate: delegate];
+  [layer setLayoutManager: manager];
+
+  PASS([layer delegate] == delegate, "a layer holds such a delegate");
+  PASS([layer layoutManager] == manager, "and such a layout manager");
+
+  END_SET("a layer takes one")
+
+  START_SET("an animation takes one")
+
+  CAAnimation *animation = [CAAnimation animation];
+  GSTestAnimationDelegate *delegate =
+    [[[GSTestAnimationDelegate alloc] init] autorelease];
+
+  [animation setDelegate: delegate];
+
+  PASS([animation delegate] == delegate, "an animation holds such a delegate");
+
+  END_SET("an animation takes one")
+
+  START_SET("the protocols the classes themselves name")
+
+  PASS([CALayer conformsToProtocol: @protocol(CAMediaTiming)],
+       "a layer has a media timing");
+  PASS([CAAnimation conformsToProtocol: @protocol(CAMediaTiming)],
+       "and so does an animation");
+  PASS([CAAnimation conformsToProtocol: @protocol(CAAction)],
+       "an animation is also an action");
+
+  END_SET("the protocols the classes themselves name")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
A class written against Apple QuartzCore says `@interface Thing : NSObject <CALayerDelegate>` and would not compile here, because the framework named none of the three protocols. Their methods were declared informally on NSObject instead, which lets the messages be sent but leaves a caller nothing to conform to.

CALayerDelegate, CALayoutManager and CAAnimationDelegate are now declared with the methods Apple puts in them, every one optional as Apple has them: five, three and two respectively. A class conforms by naming the protocol whether or not it implements any of them, which is what the test relies on.

The informal NSObject categories stay, since the framework sends those messages to a delegate held as a plain id, and GSCAAnimationDelegate stays for the code that names it. The delegate and layoutManager properties are still typed id; typing them would want every class assigned to them to declare conformance, which is a wider change. Nothing calls layerWillDraw:, invalidateLayoutOfLayer: or preferredSizeOfLayer: yet.

The test is Tests/quartzcore/protocols/names.m and runs against Apple QuartzCore too.

It did not compile before this change, which is the whole problem. Its 14 assertions pass now, and the suite goes from 305 passed and 9 dashed hopes to 319 and 9.
