### PR TITLE
Feature: add +needsDisplayForKey: and -removeAllAnimations

### DIFF
--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -135,6 +135,7 @@ extern NSString *const kCATransition;
 + (id) layer;
 + (id) defaultValueForKey: (NSString *)key;
 + (id<CAAction>) defaultActionForKey: (NSString *)key;
++ (BOOL) needsDisplayForKey: (NSString *)key;
 
 @property (assign)                   id delegate;
 @property (retain)                   id contents;
@@ -182,6 +183,7 @@ extern NSString *const kCATransition;
 
 - (void) addAnimation: (CAAnimation *)anim forKey: (NSString *)key;
 - (void) removeAnimationForKey: (NSString *)key;
+- (void) removeAllAnimations;
 - (CAAnimation *) animationForKey:( NSString *)key;
 
 - (void) addSublayer: (CALayer *)layer;

--- a/Source/CAImplicitAnimationObserver.m
+++ b/Source/CAImplicitAnimationObserver.m
@@ -34,6 +34,18 @@
 
 static CAImplicitAnimationObserver * sharedObserver;
 
+/* A layer whose class asks to be redisplayed for a property is marked when
+   that property changes, animated or not.  It is marked after the animation
+   has been prepared rather than before, since preparing one asks for the
+   presentation layer, and building that displays the layer. */
+static void markIfRedisplaying(id object, NSString *keyPath)
+{
+  if ([[object class] needsDisplayForKey: keyPath])
+    {
+      [object setNeedsDisplay];
+    }
+}
+
 @implementation CAImplicitAnimationObserver
 + (CAImplicitAnimationObserver *)sharedObserver
 {
@@ -66,13 +78,6 @@ static CAImplicitAnimationObserver * sharedObserver;
       return;
     }
 
-  /* The property still takes its new value; only the animation that would
-     have carried it there is dropped. */
-  if ([CATransaction disableActions])
-    {
-      return;
-    }
-
   id from = [change valueForKey: NSKeyValueChangeOldKey];
   id to = [change valueForKey: NSKeyValueChangeNewKey];
 
@@ -87,9 +92,20 @@ static CAImplicitAnimationObserver * sharedObserver;
   if ([to isEqual: from])
     return;
 
+  /* The property still takes its new value; only the animation that would
+     have carried it there is dropped. */
+  if ([CATransaction disableActions])
+    {
+      markIfRedisplaying(object, keyPath);
+      return;
+    }
+
   NSObject<CAAction>* action = (id)[object actionForKey: keyPath];
   if ([action isKindOfClass: [NSNull class]])
-    return;
+    {
+      markIfRedisplaying(object, keyPath);
+      return;
+    }
 
   if (!action)
     {
@@ -110,6 +126,8 @@ static CAImplicitAnimationObserver * sharedObserver;
   [[CATransaction topTransaction] registerAction: action
                                         onObject: object
                                          keyPath: keyPath];
+
+  markIfRedisplaying(object, keyPath);
 
   // TODO: Remove once implicit animations are properly integrated into NSRunLoop.
   if ([object isKindOfClass: [CALayer class]])

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -230,6 +230,13 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
   return [[self new] autorelease];
 }
 
++ (BOOL) needsDisplayForKey: (NSString *)key
+{
+  /* A subclass overrides this to have a change to one of its properties
+     redisplay the layer. */
+  return NO;
+}
+
 + (id) defaultValueForKey: (NSString *)key
 {
   if ([key isEqualToString:@"delegate"])
@@ -842,6 +849,17 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   [[self animationForKey:key] handleRemovedFromLayer: self];
   [_animations removeObjectForKey: key];
   [_animationKeys removeObject: key];
+}
+
+- (void) removeAllAnimations
+{
+  for (CAAnimation * animation in [_animations allValues])
+    {
+      [animation handleRemovedFromLayer: self];
+    }
+
+  [_animations removeAllObjects];
+  [_animationKeys removeAllObjects];
 }
 
 - (CAAnimation *)animationForKey: (NSString *)key

--- a/Tests/quartzcore/CALayer/animations.m
+++ b/Tests/quartzcore/CALayer/animations.m
@@ -1,0 +1,68 @@
+/* Removing the animations a layer holds.
+
+   The expected values are the ones Apple QuartzCore produces. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("removing every animation at once")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *one = [CABasicAnimation animationWithKeyPath: @"opacity"];
+  CABasicAnimation *two = [CABasicAnimation animationWithKeyPath: @"position"];
+
+  [layer addAnimation: one forKey: @"first"];
+  [layer addAnimation: two forKey: @"second"];
+  PASS([[layer animationKeys] count] == 2, "both animations are on the layer");
+
+  [layer removeAllAnimations];
+  PASS([[layer animationKeys] count] == 0, "removing them leaves none");
+  PASS([layer animationForKey: @"first"] == nil,
+       "and neither can be asked for by its key");
+  PASS([layer animationForKey: @"second"] == nil, "either of them");
+
+  END_SET("removing every animation at once")
+
+  START_SET("removing when there is nothing to remove")
+
+  CALayer *layer = [CALayer layer];
+
+  PASS_RUNS([layer removeAllAnimations],
+            "a layer with no animations does not raise");
+  PASS([[layer animationKeys] count] == 0, "and still has none");
+
+  END_SET("removing when there is nothing to remove")
+
+  START_SET("removing twice")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *one = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [layer addAnimation: one forKey: @"first"];
+  [layer removeAllAnimations];
+  PASS_RUNS([layer removeAllAnimations], "removing them again does not raise");
+  PASS([[layer animationKeys] count] == 0, "and they are still gone");
+
+  END_SET("removing twice")
+
+  START_SET("what removing them does to the layer")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *one = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [layer addAnimation: one forKey: @"first"];
+  [layer displayIfNeeded];
+  [layer removeAllAnimations];
+  PASS([layer needsDisplay] == NO,
+       "taking the animations away does not redisplay the layer");
+
+  END_SET("what removing them does to the layer")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/redisplay.m
+++ b/Tests/quartzcore/CALayer/redisplay.m
@@ -1,0 +1,103 @@
+/* Which property changes redisplay a layer.
+
+   +needsDisplayForKey: answers NO for every key, and a subclass overrides it
+   to have a change to one of its properties mark the layer.  The expected
+   values are the ones Apple QuartzCore produces. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+/* Redisplays for a change to the opacity and for nothing else. */
+@interface RedisplayLayer : CALayer
+@end
+
+@implementation RedisplayLayer
++ (BOOL) needsDisplayForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"opacity"])
+    return YES;
+  return [super needsDisplayForKey: key];
+}
+@end
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what a layer answers by default")
+
+  PASS([CALayer needsDisplayForKey: @"bounds"] == NO,
+       "a layer does not redisplay for its bounds");
+  PASS([CALayer needsDisplayForKey: @"position"] == NO,
+       "nor for its position");
+  PASS([CALayer needsDisplayForKey: @"opacity"] == NO,
+       "nor for its opacity");
+  PASS([CALayer needsDisplayForKey: @"contents"] == NO,
+       "nor for its contents");
+  PASS([CALayer needsDisplayForKey: @"aKeyNobodyDefines"] == NO,
+       "a key it does not have answers no rather than raising");
+  PASS([CALayer needsDisplayForKey: nil] == NO, "and so does no key at all");
+
+  END_SET("what a layer answers by default")
+
+  START_SET("a layer that asks for nothing")
+
+  CALayer *l = [CALayer layer];
+
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "a layer that has displayed wants nothing");
+
+  [l setOpacity: 0.5];
+  PASS([l needsDisplay] == NO,
+       "and a property it does not redisplay for leaves it that way");
+
+  END_SET("a layer that asks for nothing")
+
+  START_SET("a subclass that asks for one property")
+
+  RedisplayLayer *r = [RedisplayLayer layer];
+
+  PASS([RedisplayLayer needsDisplayForKey: @"opacity"] == YES,
+       "the subclass answers for the property it overrode");
+  PASS([RedisplayLayer needsDisplayForKey: @"bounds"] == NO,
+       "and leaves the rest to its superclass");
+
+  [r displayIfNeeded];
+  [r setBounds: CGRectMake(0, 0, 10, 10)];
+  PASS([r needsDisplay] == NO,
+       "a property it does not ask for does not redisplay it");
+
+  [r setOpacity: 0.25];
+  PASS([r needsDisplay] == YES, "and the one it asks for does");
+
+  END_SET("a subclass that asks for one property")
+
+  START_SET("setting a property to what it already is")
+
+  RedisplayLayer *same = [RedisplayLayer layer];
+
+  [same setOpacity: 0.25];
+  [same displayIfNeeded];
+  PASS([same needsDisplay] == NO, "the layer has displayed");
+
+  [same setOpacity: 0.25];
+  PASS([same needsDisplay] == NO,
+       "setting the same value again is not a change to redisplay for");
+
+  END_SET("setting a property to what it already is")
+
+  START_SET("setting it through the key")
+
+  RedisplayLayer *kvc = [RedisplayLayer layer];
+
+  [kvc displayIfNeeded];
+  [kvc setValue: [NSNumber numberWithFloat: 0.75] forKey: @"opacity"];
+  PASS([kvc needsDisplay] == YES,
+       "a value set by key redisplays as one set by the setter does");
+
+  END_SET("setting it through the key")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
+[CALayer needsDisplayForKey:] and -[CALayer removeAllAnimations] do not exist. Sending +needsDisplayForKey: raises, so a subclass cannot declare that one of its properties redisplays the layer. Animations can only be removed one key at a time.

+needsDisplayForKey: returns NO for every key, including an undefined key and nil, as Apple's does. CAImplicitAnimationObserver calls it when an observed property changes and calls -setNeedsDisplay if it returns YES, whether or not the change is animated. That call is made after the implicit animation is built, because building one creates the presentation layer and -presentationLayer calls -displayIfNeeded, which clears the flag. -removeAllAnimations removes every animation and sends -handleRemovedFromLayer: to each, as -removeAnimationForKey: does.

Only the properties in the observed list in -init are checked. Setting a property to its current value is not a change and does not redisplay, which matches Apple.

Tests/quartzcore/CALayer/redisplay.m and Tests/quartzcore/CALayer/animations.m, both of which run against Apple QuartzCore. redisplay.m does not build before the change and 3 of animations.m's 4 sets fail: 307 passed becomes 329.
