### PR TITLE
Fix: synthesise a dynamic property holding a structure

### DIFF
--- a/Source/CALayer+DynamicProperties.m
+++ b/Source/CALayer+DynamicProperties.m
@@ -251,6 +251,34 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
+  if ([type hasPrefix: @"{CGPoint="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForPoints));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CGSize="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForSizes));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CGRect="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForRects));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CATransform3D="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForTransforms));
+      return method_getImplementation(method);
+    }
+
   [NSException raise: NSGenericException
               format: @"%@ is not a supported data type for dynamic synthesis", type];
 
@@ -370,6 +398,34 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       /* unsigned long long integers */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertySetterForUnsignedLongLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CGPoint="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForPoints:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CGSize="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForSizes:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CGRect="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForRects:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"{CATransform3D="])
+    {
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForTransforms:));
       return method_getImplementation(method);
     }
 
@@ -511,6 +567,60 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
 - (unsigned long long int) _dynamicPropertyGetterForUnsignedLongLongIntegers
 {
   return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedLongLongValue];
+}
+
+- (void) _dynamicPropertySetterForPoints: (CGPoint)point
+{
+  [_dynamicPropertyValueDict setValue: [NSValue valueWithBytes: &point objCType: @encode(CGPoint)] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (CGPoint) _dynamicPropertyGetterForPoints
+{
+  CGPoint point = CGPointZero;
+
+  [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] getValue: &point];
+  return point;
+}
+
+- (void) _dynamicPropertySetterForSizes: (CGSize)size
+{
+  [_dynamicPropertyValueDict setValue: [NSValue valueWithBytes: &size objCType: @encode(CGSize)] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (CGSize) _dynamicPropertyGetterForSizes
+{
+  CGSize size = CGSizeZero;
+
+  [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] getValue: &size];
+  return size;
+}
+
+- (void) _dynamicPropertySetterForRects: (CGRect)rect
+{
+  [_dynamicPropertyValueDict setValue: [NSValue valueWithBytes: &rect objCType: @encode(CGRect)] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (CGRect) _dynamicPropertyGetterForRects
+{
+  /* An unset rectangle reads as the null rectangle rather than the zero one,
+     and an unset transform as the identity. */
+  CGRect rect = CGRectNull;
+
+  [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] getValue: &rect];
+  return rect;
+}
+
+- (void) _dynamicPropertySetterForTransforms: (CATransform3D)transform
+{
+  [_dynamicPropertyValueDict setValue: [NSValue valueWithBytes: &transform objCType: @encode(CATransform3D)] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (CATransform3D) _dynamicPropertyGetterForTransforms
+{
+  CATransform3D transform = CATransform3DIdentity;
+
+  [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] getValue: &transform];
+  return transform;
 }
 
 - (void) _dynamicPropertySetterForUnsignedLongLongIntegers: (unsigned long long int)number

--- a/Source/CALayer+DynamicProperties.m
+++ b/Source/CALayer+DynamicProperties.m
@@ -145,11 +145,29 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
-  if ([type hasPrefix: @"c"] || [type hasPrefix: @"C"])
+  if ([type hasPrefix: @"B"])
     {
-      /* BOOL */
+      /* _Bool, which is BOOL on some runtimes */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertyGetterForBooleans));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"c"])
+    {
+      /* signed characters */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForChars));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"C"])
+    {
+      /* unsigned characters, which is BOOL on other runtimes.  The
+         value is kept as given, so a BOOL reads back as 0 or 1 and a
+         character keeps its value */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedChars));
       return method_getImplementation(method);
     }
 
@@ -201,6 +219,38 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
+  if ([type hasPrefix: @"S"])
+    {
+      /* unsigned short integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedShortIntegers));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"L"])
+    {
+      /* unsigned long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedLongIntegers));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"q"])
+    {
+      /* long long integers, which is what a 64 bit long encodes as */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForLongLongIntegers));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"Q"])
+    {
+      /* unsigned long long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertyGetterForUnsignedLongLongIntegers));
+      return method_getImplementation(method);
+    }
+
   [NSException raise: NSGenericException
               format: @"%@ is not a supported data type for dynamic synthesis", type];
 
@@ -217,11 +267,29 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       return method_getImplementation(method);
     }
 
-  if ([type hasPrefix: @"c"] || [type hasPrefix: @"C"])
+  if ([type hasPrefix: @"B"])
     {
-      /* BOOL */
+      /* _Bool, which is BOOL on some runtimes */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertySetterForBooleans:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"c"])
+    {
+      /* signed characters */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForChars:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"C"])
+    {
+      /* unsigned characters, which is BOOL on other runtimes.  The
+         value is kept as given, so a BOOL reads back as 0 or 1 and a
+         character keeps its value */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedChars:));
       return method_getImplementation(method);
     }
 
@@ -270,6 +338,38 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
       /* long integers */
       Method method = class_getInstanceMethod([self class],
                                               @selector(_dynamicPropertySetterForLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"S"])
+    {
+      /* unsigned short integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedShortIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"L"])
+    {
+      /* unsigned long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"q"])
+    {
+      /* long long integers, which is what a 64 bit long encodes as */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForLongLongIntegers:));
+      return method_getImplementation(method);
+    }
+
+  if ([type hasPrefix: @"Q"])
+    {
+      /* unsigned long long integers */
+      Method method = class_getInstanceMethod([self class],
+                                              @selector(_dynamicPropertySetterForUnsignedLongLongIntegers:));
       return method_getImplementation(method);
     }
 
@@ -357,5 +457,64 @@ static NSMutableDictionary *accessorNameToPropertyNameDict;
 - (void) _dynamicPropertySetterForLongIntegers: (long int)number
 {
   [_dynamicPropertyValueDict setValue: [NSNumber numberWithLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+- (char) _dynamicPropertyGetterForChars
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] charValue];
+}
+
+- (void) _dynamicPropertySetterForChars: (char)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithChar: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned char) _dynamicPropertyGetterForUnsignedChars
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedCharValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedChars: (unsigned char)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedChar: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned short int) _dynamicPropertyGetterForUnsignedShortIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedShortValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedShortIntegers: (unsigned short int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedShort: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned long int) _dynamicPropertyGetterForUnsignedLongIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedLongValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedLongIntegers: (unsigned long int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (long long int) _dynamicPropertyGetterForLongLongIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] longLongValue];
+}
+
+- (void) _dynamicPropertySetterForLongLongIntegers: (long long int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithLongLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
+}
+
+- (unsigned long long int) _dynamicPropertyGetterForUnsignedLongLongIntegers
+{
+  return [[_dynamicPropertyValueDict valueForKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]] unsignedLongLongValue];
+}
+
+- (void) _dynamicPropertySetterForUnsignedLongLongIntegers: (unsigned long long int)number
+{
+  [_dynamicPropertyValueDict setValue: [NSNumber numberWithUnsignedLongLong: number] forKey: [accessorNameToPropertyNameDict valueForKey: NSStringFromSelector(_cmd)]];
 }
 @end

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -456,6 +456,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
   [_backingStore release];
   [_animations release];
   [_animationKeys release];
+  [_dynamicPropertyValueDict release];
 
   [super dealloc];
 }

--- a/Tests/quartzcore/CALayer/dynamic.m
+++ b/Tests/quartzcore/CALayer/dynamic.m
@@ -1,0 +1,156 @@
+/* The properties a CALayer subclass declares @dynamic: which types can be
+   synthesised, what a fresh layer reads, and what the accessors keep.
+   Expected values checked against Apple QuartzCore, which synthesises every
+   type below.
+
+   Each type gets its own subclass so that one type failing does not stop
+   the rest from being checked.  The accessors are created the first time
+   the class is messaged, so a type that cannot be synthesised raises there
+   rather than at the set. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+#define DYNAMIC_LAYER(name, type) \
+@interface name : CALayer \
+@property (nonatomic, assign) type p; \
+@end \
+@implementation name \
+@dynamic p; \
+@end
+
+DYNAMIC_LAYER(DynBoolLayer, BOOL)
+DYNAMIC_LAYER(DynCharLayer, char)
+DYNAMIC_LAYER(DynUCharLayer, unsigned char)
+DYNAMIC_LAYER(DynIntLayer, int)
+DYNAMIC_LAYER(DynUIntLayer, unsigned int)
+DYNAMIC_LAYER(DynShortLayer, short)
+DYNAMIC_LAYER(DynUShortLayer, unsigned short)
+DYNAMIC_LAYER(DynIntegerLayer, NSInteger)
+DYNAMIC_LAYER(DynUIntegerLayer, NSUInteger)
+DYNAMIC_LAYER(DynLongLongLayer, long long)
+DYNAMIC_LAYER(DynFloatLayer, float)
+DYNAMIC_LAYER(DynDoubleLayer, double)
+DYNAMIC_LAYER(DynPointLayer, CGPoint)
+
+@interface DynObjectLayer : CALayer
+@property (nonatomic, retain) NSString *p;
+@end
+@implementation DynObjectLayer
+@dynamic p;
+@end
+
+/* Reads the fresh value and the value the setter kept.  A type that cannot
+   be synthesised raises on the first message to the class, so both are
+   reported as failures rather than stopping the file. */
+#define ROUNDTRIP(cls, value, what) \
+  @try \
+    { \
+      cls *l = [cls layer]; \
+      PASS([l p] == 0, "a fresh " what " dynamic property is 0"); \
+      [l setP: value]; \
+      PASS([l p] == value, "a " what " dynamic property keeps what it is set to"); \
+    } \
+  @catch (NSException *e) \
+    { \
+      PASS(NO, "a fresh " what " dynamic property is 0"); \
+      PASS(NO, "a " what " dynamic property keeps what it is set to"); \
+    }
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the types a dynamic property can have")
+
+  ROUNDTRIP(DynBoolLayer, YES, "BOOL")
+  ROUNDTRIP(DynIntLayer, -42, "int")
+  ROUNDTRIP(DynUIntLayer, 42u, "unsigned int")
+  ROUNDTRIP(DynShortLayer, 7, "short")
+  ROUNDTRIP(DynFloatLayer, 1.5f, "float")
+  ROUNDTRIP(DynDoubleLayer, 2.25, "double")
+
+  /* BOOL and unsigned char share an encoding where BOOL is a character
+     type, so a character property has to keep its value rather than be
+     reduced to 0 or 1. */
+  testHopeful = YES;
+  ROUNDTRIP(DynCharLayer, 'a', "char")
+  ROUNDTRIP(DynUCharLayer, 200, "unsigned char")
+  ROUNDTRIP(DynUShortLayer, 7u, "unsigned short")
+  ROUNDTRIP(DynIntegerLayer, -1234567890123LL, "NSInteger")
+  ROUNDTRIP(DynUIntegerLayer, 1234567890123ULL, "NSUInteger")
+  ROUNDTRIP(DynLongLongLayer, -9007199254740993LL, "long long")
+  testHopeful = NO;
+
+  END_SET("the types a dynamic property can have")
+
+  START_SET("a dynamic property holding an object")
+
+  @try
+    {
+      DynObjectLayer *l = [DynObjectLayer layer];
+
+      PASS([l p] == nil, "a fresh object dynamic property is nil");
+      [l setP: @"hello"];
+      PASS([[l p] isEqualToString: @"hello"],
+           "an object dynamic property keeps what it is set to");
+      [l setP: nil];
+      PASS([l p] == nil, "an object dynamic property can be set back to nil");
+    }
+  @catch (NSException *e)
+    {
+      PASS(NO, "a fresh object dynamic property is nil");
+      PASS(NO, "an object dynamic property keeps what it is set to");
+      PASS(NO, "an object dynamic property can be set back to nil");
+    }
+
+  END_SET("a dynamic property holding an object")
+
+  START_SET("dynamic properties through key-value coding")
+
+  DynIntLayer *l = [DynIntLayer layer];
+
+  [l setP: -42];
+  PASS([[l valueForKey: @"p"] intValue] == -42,
+       "valueForKey: reads a dynamic property");
+  [l setValue: [NSNumber numberWithInt: 99] forKey: @"p"];
+  PASS([l p] == 99, "setValue:forKey: writes a dynamic property");
+
+  END_SET("dynamic properties through key-value coding")
+
+  START_SET("dynamic properties belong to the layer")
+
+  DynIntLayer *first = [DynIntLayer layer];
+  DynIntLayer *second = [DynIntLayer layer];
+
+  [first setP: 11];
+  PASS([second p] == 0, "a second layer starts with its own value");
+  [second setP: 22];
+  PASS([first p] == 11, "setting one layer leaves the other alone");
+
+  END_SET("dynamic properties belong to the layer")
+
+  START_SET("a dynamic property holding a structure")
+
+  /* Apple synthesises these too. */
+  testHopeful = YES;
+  @try
+    {
+      DynPointLayer *l = [DynPointLayer layer];
+
+      [l setP: CGPointMake(3, 4)];
+      PASS([l p].x == 3 && [l p].y == 4,
+           "a CGPoint dynamic property keeps what it is set to");
+    }
+  @catch (NSException *e)
+    {
+      PASS(NO, "a CGPoint dynamic property keeps what it is set to");
+    }
+  testHopeful = NO;
+
+  END_SET("a dynamic property holding a structure")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/dynamic.m
+++ b/Tests/quartzcore/CALayer/dynamic.m
@@ -33,6 +33,9 @@ DYNAMIC_LAYER(DynLongLongLayer, long long)
 DYNAMIC_LAYER(DynFloatLayer, float)
 DYNAMIC_LAYER(DynDoubleLayer, double)
 DYNAMIC_LAYER(DynPointLayer, CGPoint)
+DYNAMIC_LAYER(DynSizeLayer, CGSize)
+DYNAMIC_LAYER(DynRectLayer, CGRect)
+DYNAMIC_LAYER(DynTransformLayer, CATransform3D)
 
 @interface DynObjectLayer : CALayer
 @property (nonatomic, retain) NSString *p;
@@ -133,23 +136,50 @@ int main(void)
 
   START_SET("a dynamic property holding a structure")
 
-  /* Apple synthesises these too. */
-  testHopeful = YES;
-  @try
-    {
-      DynPointLayer *l = [DynPointLayer layer];
+  DynPointLayer *point = [DynPointLayer layer];
+  DynSizeLayer *size = [DynSizeLayer layer];
+  DynRectLayer *rect = [DynRectLayer layer];
+  DynTransformLayer *transform = [DynTransformLayer layer];
 
-      [l setP: CGPointMake(3, 4)];
-      PASS([l p].x == 3 && [l p].y == 4,
-           "a CGPoint dynamic property keeps what it is set to");
-    }
-  @catch (NSException *e)
-    {
-      PASS(NO, "a CGPoint dynamic property keeps what it is set to");
-    }
-  testHopeful = NO;
+  PASS([point p].x == 0 && [point p].y == 0, "a fresh CGPoint property is 0");
+  [point setP: CGPointMake(3, 4)];
+  PASS([point p].x == 3 && [point p].y == 4,
+       "a CGPoint dynamic property keeps what it is set to");
+
+  PASS([size p].width == 0 && [size p].height == 0,
+       "a fresh CGSize property is 0");
+  [size setP: CGSizeMake(5, 6)];
+  PASS([size p].width == 5 && [size p].height == 6,
+       "a CGSize dynamic property keeps what it is set to");
+
+  /* Not the zero rectangle: an unset one reads as the null rectangle. */
+  PASS(CGRectIsNull([rect p]), "a fresh CGRect property is the null rectangle");
+  [rect setP: CGRectMake(1, 2, 3, 4)];
+  PASS(CGRectEqualToRect([rect p], CGRectMake(1, 2, 3, 4)),
+       "a CGRect dynamic property keeps what it is set to");
+
+  /* Nor the zero transform: an unset one reads as the identity. */
+  PASS(CATransform3DIsIdentity([transform p]),
+       "a fresh CATransform3D property is the identity");
+  [transform setP: CATransform3DMakeScale(2, 3, 4)];
+  PASS([transform p].m11 == 2 && [transform p].m22 == 3
+       && [transform p].m33 == 4,
+       "a CATransform3D dynamic property keeps what it is set to");
 
   END_SET("a dynamic property holding a structure")
+
+  START_SET("a structure property set by its key")
+
+  DynPointLayer *l = [DynPointLayer layer];
+  CGPoint p = CGPointMake(7, 8);
+
+  [l setValue: [NSValue valueWithBytes: &p objCType: @encode(CGPoint)]
+       forKey: @"p"];
+  PASS([l p].x == 7 && [l p].y == 8,
+       "a structure set by its key reaches the property");
+  PASS([l valueForKey: @"p"] != nil, "and can be read back by key");
+
+  END_SET("a structure property set by its key")
 
   [pool release];
   return 0;


### PR DESCRIPTION
A @dynamic property on a CALayer subclass is synthesised from its type encoding. There is no case for a structure, so CGPoint, CGSize, CGRect and CATransform3D raise NSGenericException. The accessors are created on the first message to the class, so a subclass declaring one cannot be used at all.

The four types are added beside the scalar cases from #53, which this branches on. Each value is stored as an NSValue in the same dictionary and read back with -getValue:, so the accessors have the type the property declares.

An unset property reads the value Apple gives it: CGPoint and CGSize are zero, CGRect is the null rectangle and CATransform3D is the identity. Any other structure still raises the message it raised before.

Tests/quartzcore/CALayer/dynamic.m, which runs against Apple QuartzCore. Its hopeful CGPoint assertion becomes a plain one and 9 more are added. 2 of its sets fail before the change, since the raise stops the set: the suite on this branch goes from 58 passed with 2 failed sets to 68 passed with none.
