### PR TITLE
Fix: start a transition as a fade

### DIFF
--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1034,6 +1034,34 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize type=_type;
 @synthesize subtype=_subtype;
 
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"type"])
+    {
+      return kCATransitionFade;
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  if ((self = [super init]) != nil)
+    {
+      [self setType: [[self class] defaultValueForKey: @"type"]];
+    }
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_type release];
+  [_subtype release];
+
+  [super dealloc];
+}
+
 @end
 
 /* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -69,6 +69,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 @property (nonatomic, retain) NSMutableDictionary *dynamicPropertyValueDict;
 
 - (void)setModelLayer: (id)modelLayer;
+- (void)layoutTreeIfNeeded;
 @end
 
 @implementation CALayer
@@ -615,6 +616,9 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
       [self.backingStore refresh];
     }
+
+  /* Having drawn, the layer no longer wants drawing. */
+  _needsDisplay = NO;
 }
 
 - (void) displayIfNeeded
@@ -655,10 +659,52 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 /* MARK: - Layout methods */
 - (void) layoutIfNeeded
 {
+  CALayer * top = self;
+
+  /* Up through the superlayers for as long as they want laying out too, so
+     that the whole tree below the highest one is laid out at once. */
+  while ([top superlayer] && [[top superlayer] needsLayout])
+    {
+      top = [top superlayer];
+    }
+
+  [top layoutTreeIfNeeded];
+}
+
+- (void) layoutTreeIfNeeded
+{
+  CALayer * sublayer;
+
+  if (_needsLayout)
+    {
+      [self layoutSublayers];
+      _needsLayout = NO;
+    }
+
+  for (sublayer in _sublayers)
+    {
+      [sublayer layoutTreeIfNeeded];
+    }
 }
 
 - (void) layoutSublayers
 {
+  /* The delegate is asked first, and the layout manager only if the delegate
+     has nothing to say. */
+  if ([_delegate respondsToSelector: @selector(layoutSublayersOfLayer:)])
+    {
+      [_delegate layoutSublayersOfLayer: self];
+    }
+  else if ([_layoutManager respondsToSelector:
+             @selector(layoutSublayersOfLayer:)])
+    {
+      [_layoutManager layoutSublayersOfLayer: self];
+    }
+}
+
+- (BOOL) needsLayout
+{
+  return _needsLayout;
 }
 
 - (void) setNeedsLayout

--- a/Tests/quartzcore/CALayer/display.m
+++ b/Tests/quartzcore/CALayer/display.m
@@ -1,0 +1,60 @@
+/* When a layer decides it needs drawing again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants drawing")
+
+  CALayer *l = [CALayer layer];
+
+  [l setBounds: CGRectMake(0, 0, 50, 50)];
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "a layer that has drawn does not want drawing");
+
+  [l setNeedsDisplay];
+  PASS([l needsDisplay] == YES, "asking for drawing sets the flag");
+
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "drawing when needed clears it");
+
+  [l setNeedsDisplayInRect: CGRectMake(0, 0, 10, 10)];
+  PASS([l needsDisplay] == YES, "asking for part of it sets the flag too");
+
+  [l displayIfNeeded];
+
+  testHopeful = YES;
+  [l setNeedsDisplay];
+  [l display];
+  PASS([l needsDisplay] == NO, "drawing outright clears it as well");
+  testHopeful = NO;
+
+  END_SET("the flag that says a layer wants drawing")
+
+  START_SET("redrawing when the bounds change")
+
+  CALayer *off = [CALayer layer];
+
+  [off displayIfNeeded];
+  [off setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([off needsDisplay] == NO,
+       "a bounds change alone does not ask for drawing");
+
+  CALayer *on = [CALayer layer];
+
+  [on setNeedsDisplayOnBoundsChange: YES];
+  [on displayIfNeeded];
+  [on setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([on needsDisplay] == YES,
+       "a layer told to redraw on a bounds change asks for drawing");
+
+  END_SET("redrawing when the bounds change")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -1,0 +1,92 @@
+/* When a layer decides it needs laying out again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+@interface QCLayoutManager : NSObject
+{
+  int _count;
+}
+- (int) count;
+@end
+
+@implementation QCLayoutManager
+
+- (void) layoutSublayersOfLayer: (CALayer *)layer
+{
+  _count++;
+}
+
+- (int) count
+{
+  return _count;
+}
+
+@end
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants laying out")
+
+  CALayer *l = [CALayer layer];
+
+  PASS([l needsLayout] == NO, "a fresh layer does not want laying out");
+
+  [l setNeedsLayout];
+  PASS([l needsLayout] == YES, "asking for layout sets the flag");
+
+  [l layoutIfNeeded];
+  PASS([l needsLayout] == NO, "laying out when needed clears it");
+
+  [l setNeedsLayout];
+  [l layoutSublayers];
+  PASS([l needsLayout] == YES,
+       "laying the sublayers out does not clear it by itself");
+
+  END_SET("the flag that says a layer wants laying out")
+
+  START_SET("who is asked to do the laying out")
+
+  CALayer *l = [CALayer layer];
+  QCLayoutManager *m = [[[QCLayoutManager alloc] init] autorelease];
+
+  PASS([l layoutManager] == nil, "a layer starts with no layout manager");
+
+  [l setLayoutManager: m];
+  [l setNeedsLayout];
+  [l layoutIfNeeded];
+  PASS([m count] == 1, "the layout manager is asked to lay the sublayers out");
+
+  END_SET("who is asked to do the laying out")
+
+  START_SET("laying out a tree")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  QCLayoutManager *rootManager = [[[QCLayoutManager alloc] init] autorelease];
+  QCLayoutManager *childManager = [[[QCLayoutManager alloc] init] autorelease];
+
+  [root setLayoutManager: rootManager];
+  [child setLayoutManager: childManager];
+  [root addSublayer: child];
+
+  [root setNeedsLayout];
+  [child setNeedsLayout];
+
+  /* Asking the child lays out from the highest layer that wants it. */
+  [child layoutIfNeeded];
+
+  PASS([root needsLayout] == NO, "the layer above is laid out as well");
+  PASS([child needsLayout] == NO, "and so is the one asked");
+  PASS([rootManager count] == 1 && [childManager count] == 1,
+       "each of them lays its own sublayers out once");
+
+  END_SET("laying out a tree")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -1,0 +1,46 @@
+/* The values a transition starts with, and what its setters keep.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a transition starts with")
+
+  CATransition *t = [CATransition animation];
+
+  PASS(t != nil, "a transition can be created");
+  PASS([t isKindOfClass: [CAAnimation class]], "a transition is an animation");
+  PASS([t subtype] == nil, "it starts with no subtype");
+  PASS([t duration] == 0.0, "it starts with a duration of 0");
+
+  /* Apple names this "fade"; the constant for it arrives with #26. */
+  testHopeful = YES;
+  PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
+  testHopeful = NO;
+
+  END_SET("the values a transition starts with")
+
+  START_SET("what a transition's setters keep")
+
+  CATransition *t = [CATransition animation];
+
+  /* Spelled out rather than named, because kCATransitionMoveIn and the
+     subtype constants beside it are declared but defined nowhere until #25. */
+  [t setType: @"moveIn"];
+  PASS([[t type] isEqualToString: @"moveIn"],
+       "the type reads back as it was set");
+
+  [t setSubtype: @"fromLeft"];
+  PASS([[t subtype] isEqualToString: @"fromLeft"],
+       "the subtype reads back as it was set");
+
+  END_SET("what a transition's setters keep")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -18,10 +18,9 @@ int main(void)
   PASS([t subtype] == nil, "it starts with no subtype");
   PASS([t duration] == 0.0, "it starts with a duration of 0");
 
-  /* Apple names this "fade"; the constant for it arrives with #26. */
-  testHopeful = YES;
   PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
-  testHopeful = NO;
+  PASS([[t type] isEqualToString: kCATransitionFade],
+       "which is the string the constant for it names");
 
   END_SET("the values a transition starts with")
 


### PR DESCRIPTION
A CATransition has no type. Apple gives a new one kCATransitionFade, and the type selects which transition is drawn. #26 added the constant; nothing assigns it.

+defaultValueForKey: returns kCATransitionFade for the type and -init takes it from there, as CAAnimation does for its own values. A type set afterwards replaces it. -dealloc is added as well: type and subtype are copy properties and neither was released.

This branches on #39 and #40, which add the test file, with origin/master merged in for the constant. Those commits show here until they land.

startProgress, endProgress and filter do not exist here, so the other values Apple gives a new transition are not covered.

Tests/quartzcore/CATransition/transition.m, which runs against Apple QuartzCore. The hopeful assertion in it becomes a plain one and a second is added; both fail before the change: 327 passed with 2 failed becomes 329 with none.
