### PR TITLE
Feature: run a keyframe animation along a path

### DIFF
--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -30,6 +30,9 @@
 
 #import "QuartzCore/CAMediaTiming.h"
 #import "QuartzCore/CAAction.h"
+#if GNUSTEP
+#import <CoreGraphics/CoreGraphics.h>
+#endif
 
 @class CAMediaTimingFunction;
 @class CAValueFunction;
@@ -106,11 +109,13 @@
   NSArray * _values;
   NSArray * _keyTimes;
   NSArray * _timingFunctions;
+  CGPathRef _path;
 }
 @property(copy) NSString* calculationMode;
 @property(copy) NSArray* values;
 @property(copy) NSArray* keyTimes;
 @property(copy) NSArray* timingFunctions;
+@property(assign) CGPathRef path; /* retained by CG */
 
 @end
 

--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -104,9 +104,13 @@
   /* property-backing ivars */
   NSString * _calculationMode;
   NSArray * _values;
+  NSArray * _keyTimes;
+  NSArray * _timingFunctions;
 }
 @property(copy) NSString* calculationMode;
 @property(copy) NSArray* values;
+@property(copy) NSArray* keyTimes;
+@property(copy) NSArray* timingFunctions;
 
 @end
 

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -616,6 +616,66 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
     return qr;
 
 }
+/* VALUE plus BYVALUE, or minus it where SIGN is -1.  Answers nil for a pair
+   of values a by value cannot be added to, which leaves the animation to
+   settle its ends some other way. */
+static id addValues(id value, id byValue, CGFloat sign)
+{
+  const char *type;
+
+  if ([value isKindOfClass: [NSNumber class]]
+      && [byValue isKindOfClass: [NSNumber class]])
+    {
+      return [NSNumber numberWithFloat:
+        [value floatValue] + sign * [byValue floatValue]];
+    }
+
+  if (![value isKindOfClass: [NSValue class]]
+      || ![byValue isKindOfClass: [NSValue class]])
+    {
+      return nil;
+    }
+
+  type = [value objCType];
+  if (strcmp(type, [byValue objCType]))
+    {
+      return nil;
+    }
+
+  if (!strcmp(type, @encode(CGPoint)))
+    {
+      CGPoint a = { 0 }; [value getValue: &a];
+      CGPoint b = { 0 }; [byValue getValue: &b];
+      CGPoint r = CGPointMake(a.x + sign * b.x, a.y + sign * b.y);
+
+      return [NSValue valueWithBytes: &r objCType: @encode(CGPoint)];
+    }
+
+  if (!strcmp(type, @encode(CGSize)))
+    {
+      CGSize a = { 0 }; [value getValue: &a];
+      CGSize b = { 0 }; [byValue getValue: &b];
+      CGSize r = CGSizeMake(a.width + sign * b.width,
+                            a.height + sign * b.height);
+
+      return [NSValue valueWithBytes: &r objCType: @encode(CGSize)];
+    }
+
+  if (!strcmp(type, @encode(CGRect)))
+    {
+      CGRect a = { { 0 } }; [value getValue: &a];
+      CGRect b = { { 0 } }; [byValue getValue: &b];
+      CGRect r = CGRectMake(a.origin.x + sign * b.origin.x,
+                            a.origin.y + sign * b.origin.y,
+                            a.size.width + sign * b.size.width,
+                            a.size.height + sign * b.size.height);
+
+      return [NSValue valueWithBytes: &r objCType: @encode(CGRect)];
+    }
+
+  return nil;
+}
+
 /** End helper math functions **/
 /*******************************/
 
@@ -638,22 +698,13 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
                               onLayer: (CALayer *)layer
 {
   /*
-    Currently supporting scenarios with:
-     - fromValue != nil
-     - toValue != nil
-     - byValue == nil
-    and
-     - fromValue != nil
-     - toValue == nil
-     - byValue == nil
-    and
-     - fromValue == nil
-     - toValue == nil
-     - byValue == nil
-    and
-     - fromValue == nil
-     - toValue != nil
-     - byValue == nil
+    A from value and a to value are interpolated between.  A by value
+    stands in for whichever end was not given: with a from value the
+    animation runs to that value plus the by value, with a to value it
+    starts at that value minus the by value, and on its own it works from
+    the value the layer already has.  A by value has no effect on a type it
+    cannot be added to, which is every type but a number, a point, a size
+    and a rectangle.
 
     All supplied values need to be of same data type.
    */
@@ -669,6 +720,23 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
   /* Calculate what will our actual from and to values be */
   id fromValue = _fromValue;
   id toValue = _toValue;
+
+  if (_byValue)
+    {
+      if (fromValue && !toValue)
+        {
+          toValue = addValues(fromValue, _byValue, 1.0);
+        }
+      else if (!fromValue && toValue)
+        {
+          fromValue = addValues(toValue, _byValue, -1.0);
+        }
+      else if (!fromValue && !toValue && _keyPath)
+        {
+          fromValue = [[layer modelLayer] valueForKeyPath: _keyPath];
+          toValue = addValues(fromValue, _byValue, 1.0);
+        }
+    }
 
   if (!toValue)
     toValue = [[layer modelLayer] valueForKeyPath: _keyPath];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -709,7 +709,9 @@ static id addValues(id value, id byValue, CGFloat sign)
     All supplied values need to be of same data type.
    */
 
-  float fraction = theTime / _duration;
+  /* An animation with no duration has no extent to be part way through: it
+     is at its end from the moment it begins. */
+  float fraction = _duration > 0.0 ? theTime / _duration : 1.0;
 
   /* apply media timing function, if set */
   if ([self timingFunction])
@@ -1211,7 +1213,7 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
       return [_values objectAtIndex: 0];
     }
 
-  fraction = theTime / _duration;
+  fraction = _duration > 0.0 ? theTime / _duration : 1.0;
   if ([self timingFunction])
     {
       fraction = [[self timingFunction] evaluateYAtX: fraction];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1084,9 +1084,165 @@ static id addValues(id value, id byValue, CGFloat sign)
 
 @end
 
+/* Which of the SEGMENTS the fraction falls in, and how far along that one it
+   is.  KEYTIMES says where each segment ends; without it they are evenly
+   spaced. */
+static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
+                                     float fraction, float *within)
+{
+  NSUInteger index;
+
+  *within = 0.0;
+  if (segments == 0)
+    {
+      return 0;
+    }
+
+  if ([keyTimes count] >= 2)
+    {
+      NSUInteger last = [keyTimes count] - 1;
+
+      for (index = 0; index < last; index++)
+        {
+          float start = [[keyTimes objectAtIndex: index] floatValue];
+          float end = [[keyTimes objectAtIndex: index + 1] floatValue];
+
+          if (fraction <= end || index + 1 == last)
+            {
+              if (end > start)
+                {
+                  *within = (fraction - start) / (end - start);
+                  if (*within < 0.0)
+                    *within = 0.0;
+                  if (*within > 1.0)
+                    *within = 1.0;
+                }
+              return index < segments ? index : segments - 1;
+            }
+        }
+    }
+
+  {
+    float scaled = fraction * segments;
+
+    index = (NSUInteger)scaled;
+    if (index >= segments)
+      {
+        index = segments - 1;
+        *within = 1.0;
+      }
+    else
+      {
+        *within = scaled - index;
+      }
+  }
+
+  return index;
+}
+
 @implementation CAKeyframeAnimation
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
+@synthesize keyTimes=_keyTimes;
+@synthesize timingFunctions=_timingFunctions;
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"calculationMode"])
+    {
+      return kCAAnimationLinear;
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  return [self initWithKeyPath: nil];
+}
+
+- (id) initWithKeyPath: (NSString *)keyPath
+{
+  self = [super initWithKeyPath: keyPath];
+  if (!self)
+    return nil;
+
+  _calculationMode = [kCAAnimationLinear copy];
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_calculationMode release];
+  [_values release];
+  [_keyTimes release];
+  [_timingFunctions release];
+
+  [super dealloc];
+}
+
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer
+{
+  /*
+    The values are run through in order.  keyTimes says where each of them
+    falls between 0 and 1, and without it they are evenly spaced.  A discrete
+    animation steps from one value to the next without interpolating; every
+    other mode interpolates between the two values the time falls between,
+    which is what a basic animation does with a from value and a to value.
+
+    Only the linear and discrete modes are calculated.  The paced modes are
+    taken as linear, and an animation along a path is not supported.
+   */
+
+  NSUInteger count = [_values count];
+  NSUInteger index;
+  float fraction;
+  float within = 0.0;
+  CABasicAnimation *segment;
+
+  if (count == 0)
+    {
+      return nil;
+    }
+  if (count == 1)
+    {
+      return [_values objectAtIndex: 0];
+    }
+
+  fraction = theTime / _duration;
+  if ([self timingFunction])
+    {
+      fraction = [[self timingFunction] evaluateYAtX: fraction];
+    }
+
+  /* Asking outside the duration would run off the end of the values. */
+  if (fraction < 0.0)
+    fraction = 0.0;
+  if (fraction > 1.0)
+    fraction = 1.0;
+
+  if ([_calculationMode isEqualToString: kCAAnimationDiscrete])
+    {
+      index = segmentForFraction(_keyTimes, count, fraction, &within);
+
+      return [_values objectAtIndex: index];
+    }
+
+  index = segmentForFraction(_keyTimes, count - 1, fraction, &within);
+
+  segment = [CABasicAnimation animationWithKeyPath: [self keyPath]];
+  [segment setDuration: 1.0];
+  [segment setFromValue: [_values objectAtIndex: index]];
+  [segment setToValue: [_values objectAtIndex: index + 1]];
+  if ([_timingFunctions count] > index)
+    {
+      [segment setTimingFunction: [_timingFunctions objectAtIndex: index]];
+    }
+
+  return [segment calculatedAnimationValueAtTime: within onLayer: layer];
+}
 
 @end
 

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1142,11 +1142,144 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
   return index;
 }
 
+/* A path is run through as a list of segments: a line-to or a curve-to is one
+   segment ending at a keyframe point, and a move-to only says where the next
+   one starts.  A quadratic curve is kept as the cubic that draws it. */
+typedef struct
+{
+  CGPoint start;
+  CGPoint control1;
+  CGPoint control2;
+  CGPoint end;
+  BOOL curved;
+} GSCAPathSegment;
+
+typedef struct
+{
+  GSCAPathSegment * segments;
+  NSUInteger count;
+  NSUInteger capacity;
+  CGPoint current;
+  CGPoint subpathStart;
+} GSCAPathSegments;
+
+static void addPathSegment(GSCAPathSegments *list, GSCAPathSegment segment)
+{
+  if (list->count == list->capacity)
+    {
+      list->capacity = list->capacity ? list->capacity * 2 : 8;
+      list->segments = realloc(list->segments,
+                               list->capacity * sizeof(GSCAPathSegment));
+    }
+
+  list->segments[list->count++] = segment;
+}
+
+static void addPathLine(GSCAPathSegments *list, CGPoint end)
+{
+  GSCAPathSegment segment;
+
+  segment.start = list->current;
+  segment.control1 = list->current;
+  segment.control2 = end;
+  segment.end = end;
+  segment.curved = NO;
+  addPathSegment(list, segment);
+  list->current = end;
+}
+
+static void collectPathSegment(void *info, const CGPathElement *element)
+{
+  GSCAPathSegments * list = (GSCAPathSegments *)info;
+  GSCAPathSegment segment;
+
+  switch (element->type)
+    {
+      case kCGPathElementMoveToPoint:
+        list->current = element->points[0];
+        list->subpathStart = list->current;
+        break;
+
+      case kCGPathElementAddLineToPoint:
+        addPathLine(list, element->points[0]);
+        break;
+
+      case kCGPathElementAddQuadCurveToPoint:
+        {
+          CGPoint control = element->points[0];
+          CGPoint end = element->points[1];
+
+          segment.start = list->current;
+          segment.control1 = CGPointMake(
+            list->current.x + 2.0 / 3.0 * (control.x - list->current.x),
+            list->current.y + 2.0 / 3.0 * (control.y - list->current.y));
+          segment.control2 = CGPointMake(
+            end.x + 2.0 / 3.0 * (control.x - end.x),
+            end.y + 2.0 / 3.0 * (control.y - end.y));
+          segment.end = end;
+          segment.curved = YES;
+          addPathSegment(list, segment);
+          list->current = end;
+          break;
+        }
+
+      case kCGPathElementAddCurveToPoint:
+        segment.start = list->current;
+        segment.control1 = element->points[0];
+        segment.control2 = element->points[1];
+        segment.end = element->points[2];
+        segment.curved = YES;
+        addPathSegment(list, segment);
+        list->current = segment.end;
+        break;
+
+      case kCGPathElementCloseSubpath:
+        addPathLine(list, list->subpathStart);
+        break;
+    }
+}
+
+/* Where a segment is when it is FRACTION of the way along. */
+static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
+{
+  float t = fraction;
+  float u;
+
+  if (!segment.curved)
+    {
+      return CGPointMake(
+        linearInterpolation(segment.start.x, segment.end.x, t),
+        linearInterpolation(segment.start.y, segment.end.y, t));
+    }
+
+  u = 1.0 - t;
+  return CGPointMake(
+    u * u * u * segment.start.x + 3 * u * u * t * segment.control1.x
+      + 3 * u * t * t * segment.control2.x + t * t * t * segment.end.x,
+    u * u * u * segment.start.y + 3 * u * u * t * segment.control1.y
+      + 3 * u * t * t * segment.control2.y + t * t * t * segment.end.y);
+}
+
 @implementation CAKeyframeAnimation
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
 @synthesize keyTimes=_keyTimes;
 @synthesize timingFunctions=_timingFunctions;
+
+- (CGPathRef) path
+{
+  return _path;
+}
+
+- (void) setPath: (CGPathRef)path
+{
+  if (path == _path)
+    return;
+
+  CGPathRetain(path);
+  CGPathRelease(_path);
+  _path = path;
+}
 
 + (id) defaultValueForKey: (NSString *)key
 {
@@ -1180,8 +1313,52 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
   [_values release];
   [_keyTimes release];
   [_timingFunctions release];
+  CGPathRelease(_path);
 
   [super dealloc];
+}
+
+/* The point the path has reached FRACTION of the way through the animation.
+   The end of each line or curve is a keyframe, and the points between two of
+   them are taken from the line or the curve itself. */
+- (id) valueOnPathAtFraction: (float)fraction
+{
+  GSCAPathSegments list;
+  NSUInteger index;
+  float within = 0.0;
+  CGPoint point;
+
+  list.segments = NULL;
+  list.count = 0;
+  list.capacity = 0;
+  list.current = CGPointZero;
+  list.subpathStart = CGPointZero;
+
+  CGPathApply(_path, &list, collectPathSegment);
+
+  if (list.count == 0)
+    {
+      free(list.segments);
+      return nil;
+    }
+
+  if ([_calculationMode isEqualToString: kCAAnimationDiscrete])
+    {
+      /* The keyframes are the point each segment ends at, with the point the
+         path starts from before them. */
+      index = segmentForFraction(_keyTimes, list.count + 1, fraction, &within);
+      point = index == 0 ? list.segments[0].start
+                         : list.segments[index - 1].end;
+    }
+  else
+    {
+      index = segmentForFraction(_keyTimes, list.count, fraction, &within);
+      point = pointOnPathSegment(list.segments[index], within);
+    }
+
+  free(list.segments);
+
+  return [NSValue valueWithBytes: &point objCType: @encode(CGPoint)];
 }
 
 - (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
@@ -1194,8 +1371,9 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
     other mode interpolates between the two values the time falls between,
     which is what a basic animation does with a from value and a to value.
 
-    Only the linear and discrete modes are calculated.  The paced modes are
-    taken as linear, and an animation along a path is not supported.
+    A path stands in place of the values, and the point it reaches is the
+    value.  Only the linear and discrete modes are calculated; the paced
+    modes are taken as linear.
    */
 
   NSUInteger count = [_values count];
@@ -1204,11 +1382,11 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
   float within = 0.0;
   CABasicAnimation *segment;
 
-  if (count == 0)
+  if (_path == NULL && count == 0)
     {
       return nil;
     }
-  if (count == 1)
+  if (_path == NULL && count == 1)
     {
       return [_values objectAtIndex: 0];
     }
@@ -1224,6 +1402,11 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
     fraction = 0.0;
   if (fraction > 1.0)
     fraction = 1.0;
+
+  if (_path != NULL)
+    {
+      return [self valueOnPathAtFraction: fraction];
+    }
 
   if ([_calculationMode isEqualToString: kCAAnimationDiscrete])
     {

--- a/Tests/quartzcore/CABasicAnimation/TestInfo
+++ b/Tests/quartzcore/CABasicAnimation/TestInfo
@@ -1,0 +1,3 @@
+# -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+# in Apple QuartzCore.
+APPLE_SKIP_TESTS="byvalue.m"

--- a/Tests/quartzcore/CABasicAnimation/TestInfo
+++ b/Tests/quartzcore/CABasicAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore.
-APPLE_SKIP_TESTS="byvalue.m"
+APPLE_SKIP_TESTS="byvalue.m zeroduration.m"

--- a/Tests/quartzcore/CABasicAnimation/byvalue.m
+++ b/Tests/quartzcore/CABasicAnimation/byvalue.m
@@ -1,0 +1,210 @@
+/* The end a by value stands in for.
+
+   Apple documents three of these: a from value and a by value interpolate
+   between the from value and from plus by; a by value and a to value
+   interpolate between to minus by and the to value; and a by value on its
+   own works from the value the layer already has.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no
+   counterpart in Apple QuartzCore, so this file is named in
+   APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+#include <string.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static CABasicAnimation *
+animation(NSString *keyPath, id fromValue, id toValue, id byValue)
+{
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: keyPath];
+
+  [b setDuration: 2.0];
+  [b setFromValue: fromValue];
+  [b setToValue: toValue];
+  [b setByValue: byValue];
+  return b;
+}
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a from value and a by value")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", number(0.25), nil, number(0.5));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 0.0 onLayer: layer] floatValue],
+             0.25),
+       "it starts at the from value");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 1.0 onLayer: layer] floatValue],
+             0.5),
+       "half way along it is half the by value past it");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: layer] floatValue],
+             0.75),
+       "and it ends at the from value plus the by value");
+
+  END_SET("a from value and a by value")
+
+  START_SET("a by value and a to value")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", nil, number(0.75), number(0.5));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 0.0 onLayer: layer] floatValue],
+             0.25),
+       "it starts at the to value less the by value");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: layer] floatValue],
+             0.75),
+       "and ends at the to value");
+
+  END_SET("a by value and a to value")
+
+  START_SET("a by value on its own")
+
+  /* The value it works from is the one the layer holds, which a layer only
+     answers for when it is standing in for another. */
+  CALayer *layer = [CALayer layer];
+  CALayer *presentation;
+
+  [layer setOpacity: 0.25];
+  presentation = [layer presentationLayer];
+
+  CABasicAnimation *b = animation(@"opacity", nil, nil, number(0.5));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 0.0 onLayer: presentation]
+               floatValue], 0.25),
+       "it starts at the value the layer already has");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: presentation]
+               floatValue], 0.75),
+       "and ends the by value past it");
+
+  END_SET("a by value on its own")
+
+  START_SET("a by value that is a point")
+
+  CALayer *layer = [CALayer layer];
+  CGPoint from = CGPointMake(10, 20);
+  CGPoint by = CGPointMake(4, 8);
+  CABasicAnimation *b =
+    animation(@"position",
+              [NSValue valueWithBytes: &from objCType: @encode(CGPoint)],
+              nil,
+              [NSValue valueWithBytes: &by objCType: @encode(CGPoint)]);
+  NSValue *v = [b calculatedAnimationValueAtTime: 2.0 onLayer: layer];
+  CGPoint p = CGPointMake(-1, -1);
+
+  PASS(v != nil && !strcmp([v objCType], @encode(CGPoint)),
+       "the value is a point");
+  if (v != nil)
+    {
+      [v getValue: &p];
+    }
+  PASS(CLOSE(p.x, 14) && CLOSE(p.y, 28),
+       "with the by value added to both members");
+
+  END_SET("a by value that is a point")
+
+  START_SET("a by value that is a size")
+
+  CALayer *layer = [CALayer layer];
+  CGSize from = CGSizeMake(10, 20);
+  CGSize by = CGSizeMake(4, 8);
+  CABasicAnimation *b =
+    animation(@"bounds",
+              [NSValue valueWithBytes: &from objCType: @encode(CGSize)],
+              nil,
+              [NSValue valueWithBytes: &by objCType: @encode(CGSize)]);
+  NSValue *v = [b calculatedAnimationValueAtTime: 2.0 onLayer: layer];
+  CGSize s = CGSizeMake(-1, -1);
+
+  if (v != nil)
+    {
+      [v getValue: &s];
+    }
+  /* The by value is added to both members, and then the interpolation
+     between the two sizes takes the height of neither: every size comes out
+     square, which is a separate matter from the by value. */
+  testHopeful = YES;
+  PASS(CLOSE(s.width, 14) && CLOSE(s.height, 28),
+       "both members of a size take the by value");
+  testHopeful = NO;
+
+  END_SET("a by value that is a size")
+
+  START_SET("a by value that is a rectangle")
+
+  CALayer *layer = [CALayer layer];
+  CGRect from = CGRectMake(1, 2, 10, 20);
+  CGRect by = CGRectMake(3, 4, 5, 6);
+  CABasicAnimation *b =
+    animation(@"bounds",
+              [NSValue valueWithBytes: &from objCType: @encode(CGRect)],
+              nil,
+              [NSValue valueWithBytes: &by objCType: @encode(CGRect)]);
+  NSValue *v = [b calculatedAnimationValueAtTime: 2.0 onLayer: layer];
+  CGRect r = CGRectMake(-1, -1, -1, -1);
+
+  if (v != nil)
+    {
+      [v getValue: &r];
+    }
+  PASS(CLOSE(r.origin.x, 4) && CLOSE(r.origin.y, 6)
+       && CLOSE(r.size.width, 15) && CLOSE(r.size.height, 26),
+       "all four members of a rectangle take the by value");
+
+  END_SET("a by value that is a rectangle")
+
+  START_SET("a by value that cannot be added")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", @"a string", nil, @"another");
+
+  PASS([b calculatedAnimationValueAtTime: 1.0 onLayer: layer] == nil,
+       "a by value of a type that cannot be added leaves nothing to animate");
+
+  CATransform3D identity = CATransform3DIdentity;
+  CABasicAnimation *t =
+    animation(@"transform",
+              [NSValue valueWithCATransform3D: identity], nil,
+              [NSValue valueWithCATransform3D: identity]);
+
+  PASS([t calculatedAnimationValueAtTime: 1.0 onLayer: layer] == nil,
+       "and a transform is one of those types");
+
+  END_SET("a by value that cannot be added")
+
+  START_SET("a by value alongside both ends")
+
+  /* Apple says no more than two of the three should be given.  Where all
+     three are, the two ends are what count. */
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", number(0.0), number(1.0),
+                                  number(0.25));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: layer] floatValue],
+             1.0),
+       "the to value is where it ends, not the from value plus the by value");
+
+  END_SET("a by value alongside both ends")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CABasicAnimation/zeroduration.m
+++ b/Tests/quartzcore/CABasicAnimation/zeroduration.m
@@ -1,0 +1,121 @@
+/* The value an animation calculates when its duration is zero.
+
+   An animation starts with a duration of zero, and a layer gives one it is
+   handed the duration of the current transaction.  An animation that is
+   asked for its value without being added to a layer keeps the zero, and
+   dividing the time by it is what this file covers.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no
+   counterpart in Apple QuartzCore, so this file is named in
+   APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CATransaction.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+/* An opacity animation from 0 to 1 which is never given a duration. */
+static CABasicAnimation *
+animation(void)
+{
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [b setFromValue: number(0.0)];
+  [b setToValue: number(1.0)];
+  return b;
+}
+
+static float
+valueAt(CABasicAnimation *b, CFTimeInterval time, CALayer *layer)
+{
+  return [[b calculatedAnimationValueAtTime: time onLayer: layer] floatValue];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("an animation that was never given a duration")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation();
+
+  PASS([b duration] == 0.0, "an animation starts with a duration of zero");
+
+  PASS(CLOSE(valueAt(b, 0.0, layer), 1.0),
+       "at the time it begins it is already at its end");
+  PASS(CLOSE(valueAt(b, 1.0, layer), 1.0), "and it stays there");
+
+  END_SET("an animation that was never given a duration")
+
+  START_SET("a duration that is set to zero")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation();
+  CABasicAnimation *negative = animation();
+
+  [b setDuration: 0.0];
+  PASS(CLOSE(valueAt(b, 0.5, layer), 1.0),
+       "a duration of zero leaves no time to be part way through");
+
+  [negative setDuration: -1.0];
+  PASS(CLOSE(valueAt(negative, 0.5, layer), 1.0),
+       "and neither does one below zero");
+
+  END_SET("a duration that is set to zero")
+
+  START_SET("a value that is not a number")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"position"];
+  CGPoint from = CGPointMake(0, 0);
+  CGPoint to = CGPointMake(10, 20);
+  NSValue *v;
+  CGPoint p = CGPointMake(-1, -1);
+
+  [b setFromValue: [NSValue valueWithBytes: &from objCType: @encode(CGPoint)]];
+  [b setToValue: [NSValue valueWithBytes: &to objCType: @encode(CGPoint)]];
+  v = [b calculatedAnimationValueAtTime: 0.5 onLayer: layer];
+  if (v != nil)
+    {
+      [v getValue: &p];
+    }
+
+  PASS(CLOSE(p.x, 10.0) && CLOSE(p.y, 20.0),
+       "a point ends up at the end of the animation as well");
+
+  END_SET("a value that is not a number")
+
+  START_SET("an animation a layer has been given")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation();
+
+  [layer addAnimation: b forKey: @"opacity"];
+
+  PASS(CLOSE([b duration], [CATransaction animationDuration]),
+       "a layer gives an animation with no duration the transaction's");
+  PASS(CLOSE(valueAt(b, [b duration] / 2.0, layer), 0.5),
+       "so an animation that a layer runs is half way through half way along");
+
+  END_SET("an animation a layer has been given")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/TestInfo
+++ b/Tests/quartzcore/CAKeyframeAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore, so only the properties can be checked against it.
-APPLE_SKIP_TESTS="keyframes.m"
+APPLE_SKIP_TESTS="keyframes.m path.m"

--- a/Tests/quartzcore/CAKeyframeAnimation/TestInfo
+++ b/Tests/quartzcore/CAKeyframeAnimation/TestInfo
@@ -1,0 +1,3 @@
+# -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+# in Apple QuartzCore, so only the properties can be checked against it.
+APPLE_SKIP_TESTS="keyframes.m"

--- a/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
@@ -1,0 +1,190 @@
+/* The value a keyframe animation calculates part way through its duration.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+   in Apple QuartzCore, so this file is named in APPLE_SKIP_TESTS.  The
+   properties it sets are Apple's and are checked in properties.m, which does
+   run there. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CAMediaTimingFunction.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+/* Three values, evenly spaced over four seconds unless told otherwise. */
+static CAKeyframeAnimation *
+keyframes(void)
+{
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  [k setDuration: 4.0];
+  [k setValues: [NSArray arrayWithObjects:
+    number(0.0), number(1.0), number(0.0), nil]];
+  return k;
+}
+
+static float
+valueAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  return [[k calculatedAnimationValueAtTime: time onLayer: layer] floatValue];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("running through the values")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  PASS(CLOSE(valueAt(k, 0.0, layer), 0.0), "it starts at the first value");
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.5),
+       "a quarter of the way along it is half way to the second");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0),
+       "half way along it is at the second value");
+  PASS(CLOSE(valueAt(k, 3.0, layer), 0.5),
+       "and then half way back down to the third");
+  PASS(CLOSE(valueAt(k, 4.0, layer), 0.0), "ending at the last value");
+
+  END_SET("running through the values")
+
+  START_SET("one value and none")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  [k setDuration: 4.0];
+
+  PASS([k calculatedAnimationValueAtTime: 1.0 onLayer: layer] == nil,
+       "an animation with no values calculates nothing");
+
+  [k setValues: [NSArray arrayWithObject: number(0.75)]];
+
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.75),
+       "and one with a single value stays on it");
+
+  END_SET("one value and none")
+
+  START_SET("key times say where each value falls")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  /* The middle value now falls three quarters of the way along rather than
+     half way. */
+  [k setKeyTimes: [NSArray arrayWithObjects:
+    number(0.0), number(0.75), number(1.0), nil]];
+
+  PASS(CLOSE(valueAt(k, 3.0, layer), 1.0),
+       "the second value falls where the key times put it");
+  PASS(CLOSE(valueAt(k, 1.5, layer), 0.5),
+       "half way to it is half the first value's share along");
+  PASS(CLOSE(valueAt(k, 3.5, layer), 0.5),
+       "and the last stretch is shorter to match");
+
+  END_SET("key times say where each value falls")
+
+  START_SET("a discrete animation does not interpolate")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  [k setCalculationMode: kCAAnimationDiscrete];
+
+  /* Three values with no key times hold for a third of the duration each. */
+  PASS(CLOSE(valueAt(k, 0.5, layer), 0.0), "it holds the first value");
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.0),
+       "still holding it a quarter of the way along, where interpolating "
+       "would have reached half way");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0), "then steps to the second");
+  PASS(CLOSE(valueAt(k, 3.0, layer), 0.0), "and to the last");
+
+  END_SET("a discrete animation does not interpolate")
+
+  START_SET("the mode a keyframe animation starts in")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  PASS([[k calculationMode] isEqualToString: kCAAnimationLinear],
+       "it interpolates unless told otherwise");
+
+  END_SET("the mode a keyframe animation starts in")
+
+  START_SET("a timing function for each stretch")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+  float straight = valueAt(k, 1.0, layer);
+
+  /* One function, so it shapes the first stretch and the second is left as
+     it was. */
+  [k setTimingFunctions: [NSArray arrayWithObject:
+    [CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionEaseIn]]];
+
+  PASS(CLOSE(straight, 0.5), "without one the first stretch is a straight line");
+  PASS(valueAt(k, 1.0, layer) < straight,
+       "easing into the first stretch is behind it half way along");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0),
+       "and the stretch still ends where it did");
+
+  END_SET("a timing function for each stretch")
+
+  START_SET("time outside the duration")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  PASS(CLOSE(valueAt(k, 8.0, layer), 0.0),
+       "past the end it holds the last value rather than running off it");
+  PASS(CLOSE(valueAt(k, -1.0, layer), 0.0),
+       "and before the start it holds the first");
+
+  END_SET("time outside the duration")
+
+  START_SET("values that are not numbers")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGPoint first = CGPointMake(0, 0);
+  CGPoint second = CGPointMake(10, 20);
+  NSValue *v;
+  CGPoint p = CGPointMake(-1, -1);
+
+  [k setDuration: 2.0];
+  [k setValues: [NSArray arrayWithObjects:
+    [NSValue valueWithBytes: &first objCType: @encode(CGPoint)],
+    [NSValue valueWithBytes: &second objCType: @encode(CGPoint)], nil]];
+  v = [k calculatedAnimationValueAtTime: 1.0 onLayer: layer];
+  if (v != nil)
+    {
+      [v getValue: &p];
+    }
+
+  PASS(CLOSE(p.x, 5.0) && CLOSE(p.y, 10.0),
+       "points are interpolated between as a basic animation does");
+
+  END_SET("values that are not numbers")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
@@ -160,6 +160,25 @@ int main(void)
 
   END_SET("time outside the duration")
 
+  START_SET("a keyframe animation with no duration")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  /* The values end somewhere other than they start, so that holding the
+     last one can be told apart from holding the first. */
+  [k setValues: [NSArray arrayWithObjects:
+    number(0.0), number(0.25), number(1.0), nil]];
+  [k setDuration: 0.0];
+
+  PASS(CLOSE(valueAt(k, 1.0, layer), 1.0),
+       "with no time to run through them it holds the last value");
+  PASS(CLOSE(valueAt(k, 0.0, layer), 1.0),
+       "and it holds it at the time it begins as well");
+
+  END_SET("a keyframe animation with no duration")
+
   START_SET("values that are not numbers")
 
   CALayer *layer = [CALayer layer];

--- a/Tests/quartzcore/CAKeyframeAnimation/path.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/path.m
@@ -1,0 +1,190 @@
+/* A keyframe animation that follows a path.
+
+   Apple documents the contract this checks: for a property holding a CGPoint
+   the path stands in place of the values, the end of each line or curve is a
+   keyframe, a move-to is not one, and the points between two keyframes come
+   from the line or the curve itself.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+   in Apple QuartzCore, so this file is named in APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static CGPoint
+pointAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  CGPoint point = CGPointMake(-1, -1);
+  NSValue *value = [k calculatedAnimationValueAtTime: time onLayer: layer];
+
+  if (value != nil)
+    {
+      [value getValue: &point];
+    }
+  return point;
+}
+
+/* Two straight sides of a square, drawn over four seconds. */
+static CAKeyframeAnimation *
+cornerPath(void)
+{
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddLineToPoint(path, NULL, 100, 0);
+  CGPathAddLineToPoint(path, NULL, 100, 100);
+
+  [k setDuration: 4.0];
+  [k setPath: path];
+  CGPathRelease(path);
+  return k;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the path a keyframe animation is given")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  PASS([k path] == NULL, "an animation starts with no path");
+
+  CGPathMoveToPoint(path, NULL, 1, 2);
+  [k setPath: path];
+  PASS([k path] == path, "the path reads back as it was set");
+
+  [k setPath: NULL];
+  PASS([k path] == NULL, "and it can be taken away again");
+  CGPathRelease(path);
+
+  END_SET("the path a keyframe animation is given")
+
+  START_SET("running along a path of straight lines")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = cornerPath();
+
+  PASS(CLOSE(pointAt(k, 0.0, layer).x, 0)
+       && CLOSE(pointAt(k, 0.0, layer).y, 0),
+       "it starts where the path starts");
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 50)
+       && CLOSE(pointAt(k, 1.0, layer).y, 0),
+       "a quarter of the way along it is half way down the first side");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "half way along it is at the corner");
+  PASS(CLOSE(pointAt(k, 3.0, layer).x, 100)
+       && CLOSE(pointAt(k, 3.0, layer).y, 50),
+       "and then half way down the second side");
+  PASS(CLOSE(pointAt(k, 4.0, layer).x, 100)
+       && CLOSE(pointAt(k, 4.0, layer).y, 100),
+       "ending where the path ends");
+
+  END_SET("running along a path of straight lines")
+
+  START_SET("a path standing in place of the values")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = cornerPath();
+  CGPoint ignored = CGPointMake(-50, -50);
+
+  [k setValues: [NSArray arrayWithObject:
+    [NSValue valueWithBytes: &ignored objCType: @encode(CGPoint)]]];
+
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "the values are left alone while there is a path");
+
+  END_SET("a path standing in place of the values")
+
+  START_SET("running along a curve")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+  CGPoint middle;
+
+  /* A curve whose control points both sit above the straight line between
+     its ends, so the middle of it is above that line as well. */
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddCurveToPoint(path, NULL, 0, 100, 100, 100, 100, 0);
+  [k setDuration: 2.0];
+  [k setPath: path];
+  CGPathRelease(path);
+
+  PASS(CLOSE(pointAt(k, 0.0, layer).x, 0) && CLOSE(pointAt(k, 0.0, layer).y, 0),
+       "a curve starts where it starts");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "and ends where it ends");
+
+  middle = pointAt(k, 1.0, layer);
+  PASS(CLOSE(middle.x, 50), "half way along it is half way across");
+  PASS(CLOSE(middle.y, 75),
+       "and it is on the curve rather than on the line between the ends");
+
+  END_SET("running along a curve")
+
+  START_SET("stepping from point to point")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = cornerPath();
+
+  [k setCalculationMode: kCAAnimationDiscrete];
+
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 0) && CLOSE(pointAt(k, 1.0, layer).y, 0),
+       "a discrete animation holds the point it started from");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "then steps to the end of the first line");
+  PASS(CLOSE(pointAt(k, 4.0, layer).x, 100)
+       && CLOSE(pointAt(k, 4.0, layer).y, 100),
+       "and to the end of the last one");
+
+  END_SET("stepping from point to point")
+
+  START_SET("a move to in the middle of a path")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  /* Two separate lines.  The move-to between them is not a keyframe, so the
+     animation is in two halves, jumping across at the middle. */
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddLineToPoint(path, NULL, 10, 0);
+  CGPathMoveToPoint(path, NULL, 50, 50);
+  CGPathAddLineToPoint(path, NULL, 60, 50);
+  [k setDuration: 2.0];
+  [k setPath: path];
+  CGPathRelease(path);
+
+  PASS(CLOSE(pointAt(k, 0.5, layer).x, 5) && CLOSE(pointAt(k, 0.5, layer).y, 0),
+       "the first half runs along the first line");
+  PASS(CLOSE(pointAt(k, 1.5, layer).x, 55)
+       && CLOSE(pointAt(k, 1.5, layer).y, 50),
+       "and the second along the second, the move-to not being a keyframe");
+
+  END_SET("a move to in the middle of a path")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/properties.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/properties.m
@@ -1,0 +1,69 @@
+/* What a keyframe animation holds.  These are Apple's properties and the
+   values below were measured against it. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what it starts with")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  PASS([CAKeyframeAnimation superclass] == [CAPropertyAnimation class],
+       "a keyframe animation is a property animation");
+  PASS([[k calculationMode] isEqualToString: kCAAnimationLinear],
+       "it interpolates between its values unless told otherwise");
+  PASS([k values] == nil, "with no values");
+  PASS([k keyTimes] == nil, "no key times");
+  PASS([k timingFunctions] == nil, "and no timing functions");
+
+  END_SET("what it starts with")
+
+  START_SET("the calculation modes")
+
+  PASS([kCAAnimationLinear isEqualToString: @"linear"], "linear");
+  PASS([kCAAnimationDiscrete isEqualToString: @"discrete"], "discrete");
+  PASS([kCAAnimationPaced isEqualToString: @"paced"], "paced");
+  PASS([kCAAnimationCubic isEqualToString: @"cubic"], "cubic");
+  PASS([kCAAnimationCubicPaced isEqualToString: @"cubicPaced"], "cubic paced");
+
+  END_SET("the calculation modes")
+
+  START_SET("what it answers for")
+
+  PASS([[CAKeyframeAnimation defaultValueForKey: @"calculationMode"]
+         isEqualToString: kCAAnimationLinear],
+       "the class names the mode it starts in");
+  PASS([CAKeyframeAnimation defaultValueForKey: @"values"] == nil,
+       "and names no values");
+
+  END_SET("what it answers for")
+
+  START_SET("the arrays are copied")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+  NSMutableArray *given = [NSMutableArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.0], [NSNumber numberWithFloat: 1.0], nil];
+
+  [k setValues: given];
+  [given removeAllObjects];
+
+  PASS([[k values] count] == 2,
+       "emptying the array afterwards leaves the animation alone");
+
+  [k setCalculationMode: @"nonsense"];
+
+  PASS([[k calculationMode] isEqualToString: @"nonsense"],
+       "a mode it does not know is kept as it was given");
+
+  END_SET("the arrays are copied")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
CAKeyframeAnimation has no path property, so an animation along a path cannot be expressed.

Apple's contract: for a property holding a CGPoint the path replaces the values; the end point of each line-to and curve-to is a keyframe; a move-to is not one; the points between two keyframes come from the line or the curve. CGPathApply collects the path into segments, with a quadratic curve converted to the cubic that draws it, and segmentForFraction places the segments as it places values. The discrete mode steps between keyframes. The paced modes are still taken as linear.

This branches on #80, with #79 and #81 below it, in the same method. rotationMode is not included: it rotates the layer to the tangent of the path, and an animation writes one key path.

Tests/quartzcore/CAKeyframeAnimation/path.m, named in APPLE_SKIP_TESTS because -calculatedAnimationValueAtTime:onLayer: is GNUstep API. 18 assertions, none of which pass before the change, with 6 of its 7 sets failing: 363 passed becomes 381.
