### PR TITLE
Feature: honour fillMode outside an animation's active duration

### DIFF
--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -30,6 +30,9 @@
 
 #import "QuartzCore/CAMediaTiming.h"
 #import "QuartzCore/CAAction.h"
+#if GNUSTEP
+#import <CoreGraphics/CoreGraphics.h>
+#endif
 
 @class CAMediaTimingFunction;
 @class CAValueFunction;
@@ -106,11 +109,13 @@
   NSArray * _values;
   NSArray * _keyTimes;
   NSArray * _timingFunctions;
+  CGPathRef _path;
 }
 @property(copy) NSString* calculationMode;
 @property(copy) NSArray* values;
 @property(copy) NSArray* keyTimes;
 @property(copy) NSArray* timingFunctions;
+@property(assign) CGPathRef path; /* retained by CG */
 
 @end
 

--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -104,9 +104,13 @@
   /* property-backing ivars */
   NSString * _calculationMode;
   NSArray * _values;
+  NSArray * _keyTimes;
+  NSArray * _timingFunctions;
 }
 @property(copy) NSString* calculationMode;
 @property(copy) NSArray* values;
+@property(copy) NSArray* keyTimes;
+@property(copy) NSArray* timingFunctions;
 
 @end
 

--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -110,12 +110,18 @@
   NSArray * _keyTimes;
   NSArray * _timingFunctions;
   CGPathRef _path;
+  NSArray * _tensionValues;
+  NSArray * _continuityValues;
+  NSArray * _biasValues;
 }
 @property(copy) NSString* calculationMode;
 @property(copy) NSArray* values;
 @property(copy) NSArray* keyTimes;
 @property(copy) NSArray* timingFunctions;
 @property(assign) CGPathRef path; /* retained by CG */
+@property(copy) NSArray* tensionValues;
+@property(copy) NSArray* continuityValues;
+@property(copy) NSArray* biasValues;
 
 @end
 

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -251,13 +251,30 @@ NSString *const kCATransitionFromRight = @"fromRight";
 - (CFTimeInterval) activeTimeWithTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime
 {
   /* Slides */
-  CFTimeInterval activeTime = (timeAuthorityLocalTime - [self beginTime]) * [self speed] + [self timeOffset];
+  CFTimeInterval activeTime =
+    [self unclampedActiveTimeWithTimeAuthorityLocalTime: timeAuthorityLocalTime];
 
   /* FIXME: should not be necessary */
   if (activeTime < 0)
     activeTime = 0;
 
   return activeTime;
+}
+
+/* The active time as the slides give it, before the line above hides the
+   part of it that runs before the animation begins.  Whether an animation
+   has begun, and whether it is over, can only be told from this. */
+- (CFTimeInterval) unclampedActiveTimeWithTimeAuthorityLocalTime: (CFTimeInterval)timeAuthorityLocalTime
+{
+  return (timeAuthorityLocalTime - [self beginTime]) * [self speed]
+    + [self timeOffset];
+}
+
+/* How long the animation runs for altogether, which is what the layer uses
+   to decide it is over.  Zero means it has no end. */
+- (CFTimeInterval) activeDuration
+{
+  return [self duration] * [self repeatCount] * ([self autoreverses] ? 2 : 1);
 }
 
 - (CFTimeInterval) localTimeWithTimeAuthority: (id<CAMediaTiming>)timeAuthority
@@ -410,13 +427,44 @@ NSString *const kCATransitionFromRight = @"fromRight";
 
 - (void) applyToLayer: (CALayer *)layer
 {
-  CFTimeInterval theTime = [self localTimeWithTimeAuthority: [layer modelLayer]];
+  /* The model layer keeps the time, falling back to the layer itself, since
+     -modelLayer answers nothing until #35 lands. */
+  CALayer * authority = [layer modelLayer] ? [layer modelLayer] : layer;
+  CFTimeInterval activeTime =
+    [self unclampedActiveTimeWithTimeAuthorityLocalTime: [authority localTime]];
+  CFTimeInterval activeDuration = [self activeDuration];
+  NSString * fillMode = [self fillMode];
+  CFTimeInterval theTime;
 
-  /* FIXME: temporary check until we have fillMode implementation */
-  /* Also, why do we get theTime < 0? */
-  if (theTime < 0)
+  /* Outside its own run an animation leaves the layer alone unless its fill
+     mode says otherwise: backwards holds the value it starts from before it
+     begins, forwards holds the one it ends at once it is over, and both does
+     the two.  Any other fill mode, the one an animation starts with among
+     them, shows nothing at either end. */
+  if (activeTime < 0)
     {
-      return;
+      if (![fillMode isEqualToString: kCAFillModeBackwards]
+          && ![fillMode isEqualToString: kCAFillModeBoth])
+        {
+          return;
+        }
+
+      theTime = 0;
+    }
+  else if (activeDuration > 0 && activeTime > activeDuration)
+    {
+      if (![fillMode isEqualToString: kCAFillModeForwards]
+          && ![fillMode isEqualToString: kCAFillModeBoth])
+        {
+          return;
+        }
+
+      /* An animation that reverses ends where it began. */
+      theTime = [self autoreverses] ? 0.0 : [self duration];
+    }
+  else
+    {
+      theTime = [self localTimeWithTimeAuthority: authority];
     }
 
   id modelValue = [[layer modelLayer] valueForKeyPath: [self keyPath]];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1260,6 +1260,104 @@ static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
       + 3 * u * t * t * segment.control2.y + t * t * t * segment.end.y);
 }
 
+/* How many pieces a curve is measured in.  A line is exact either way. */
+#define GSCA_PATH_STEPS 32
+
+static float distanceBetweenPoints(CGPoint a, CGPoint b)
+{
+  return sqrt((b.x - a.x) * (b.x - a.x) + (b.y - a.y) * (b.y - a.y));
+}
+
+/* The length of a segment, measured along it rather than across it. */
+static float pathSegmentLength(GSCAPathSegment segment)
+{
+  CGPoint previous = segment.start;
+  float length = 0.0;
+  int step;
+
+  if (!segment.curved)
+    {
+      return distanceBetweenPoints(segment.start, segment.end);
+    }
+
+  for (step = 1; step <= GSCA_PATH_STEPS; step++)
+    {
+      CGPoint point = pointOnPathSegment(segment,
+                                         (float)step / GSCA_PATH_STEPS);
+
+      length += distanceBetweenPoints(previous, point);
+      previous = point;
+    }
+
+  return length;
+}
+
+/* How far along a segment to be in order to have travelled DISTANCE along
+   it.  A curve is not covered evenly as the fraction rises, so it is
+   measured in pieces and the piece the distance falls in is interpolated. */
+static float pathSegmentFractionForDistance(GSCAPathSegment segment,
+                                            float distance)
+{
+  CGPoint previous = segment.start;
+  float covered = 0.0;
+  int step;
+
+  if (distance <= 0.0)
+    return 0.0;
+
+  if (!segment.curved)
+    {
+      float length = distanceBetweenPoints(segment.start, segment.end);
+
+      return length > 0.0 ? distance / length : 0.0;
+    }
+
+  for (step = 1; step <= GSCA_PATH_STEPS; step++)
+    {
+      float fraction = (float)step / GSCA_PATH_STEPS;
+      CGPoint point = pointOnPathSegment(segment, fraction);
+      float piece = distanceBetweenPoints(previous, point);
+
+      if (covered + piece >= distance && piece > 0.0)
+        {
+          float within = (distance - covered) / piece;
+
+          return ((float)(step - 1) + within) / GSCA_PATH_STEPS;
+        }
+
+      covered += piece;
+      previous = point;
+    }
+
+  return 1.0;
+}
+
+/* The distance between two values, for pacing.  A type that cannot be
+   measured answers a negative number, and the animation is then spaced
+   evenly rather than by distance. */
+static float distanceBetweenValues(id from, id to)
+{
+  if ([from isKindOfClass: [NSNumber class]]
+      && [to isKindOfClass: [NSNumber class]])
+    {
+      return fabs([to doubleValue] - [from doubleValue]);
+    }
+
+  if ([from isKindOfClass: [NSValue class]]
+      && [to isKindOfClass: [NSValue class]]
+      && !strcmp([from objCType], [to objCType])
+      && !strcmp([from objCType], @encode(CGPoint)))
+    {
+      CGPoint a, b;
+
+      [from getValue: &a];
+      [to getValue: &b];
+      return distanceBetweenPoints(a, b);
+    }
+
+  return -1.0;
+}
+
 @implementation CAKeyframeAnimation
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
@@ -1318,6 +1416,70 @@ static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
   [super dealloc];
 }
 
+/* Whether the animation is paced, which means it covers the same distance in
+   each moment rather than spending the same time between each pair of
+   values.  Apple's cubic pacing is taken as pacing. */
+- (BOOL) isPaced
+{
+  return [_calculationMode isEqualToString: kCAAnimationPaced]
+    || [_calculationMode isEqualToString: kCAAnimationCubicPaced];
+}
+
+/* Which pair of values a paced animation is between FRACTION of the way
+   through, and how far between them it is.  The values are placed by the
+   distance from one to the next; a type whose values cannot be measured is
+   spaced evenly, as an unpaced animation would space it. */
+- (NSUInteger) pacedSegmentForFraction: (float)fraction
+                                within: (float *)within
+{
+  NSUInteger count = [_values count];
+  NSUInteger index;
+  float * lengths = malloc((count - 1) * sizeof(float));
+  float total = 0.0;
+  float covered = 0.0;
+  float target;
+
+  for (index = 0; index + 1 < count; index++)
+    {
+      float length = distanceBetweenValues([_values objectAtIndex: index],
+                                           [_values objectAtIndex: index + 1]);
+
+      if (length < 0.0)
+        {
+          free(lengths);
+          return segmentForFraction(nil, count - 1, fraction, within);
+        }
+
+      lengths[index] = length;
+      total += length;
+    }
+
+  if (total <= 0.0)
+    {
+      free(lengths);
+      return segmentForFraction(nil, count - 1, fraction, within);
+    }
+
+  target = fraction * total;
+  for (index = 0; index + 2 < count; index++)
+    {
+      if (covered + lengths[index] >= target)
+        break;
+
+      covered += lengths[index];
+    }
+
+  *within = lengths[index] > 0.0 ? (target - covered) / lengths[index] : 0.0;
+  if (*within < 0.0)
+    *within = 0.0;
+  if (*within > 1.0)
+    *within = 1.0;
+
+  free(lengths);
+
+  return index;
+}
+
 /* The point the path has reached FRACTION of the way through the animation.
    The end of each line or curve is a keyframe, and the points between two of
    them are taken from the line or the curve itself. */
@@ -1350,6 +1512,36 @@ static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
       point = index == 0 ? list.segments[0].start
                          : list.segments[index - 1].end;
     }
+  else if ([self isPaced])
+    {
+      /* Constant speed: the fraction says how far along the whole path to
+         be, not which segment to be in. */
+      float total = 0.0;
+      float target;
+      float covered = 0.0;
+
+      for (index = 0; index < list.count; index++)
+        {
+          total += pathSegmentLength(list.segments[index]);
+        }
+
+      target = fraction * total;
+      point = list.segments[list.count - 1].end;
+      for (index = 0; index < list.count; index++)
+        {
+          float length = pathSegmentLength(list.segments[index]);
+
+          if (covered + length >= target || index + 1 == list.count)
+            {
+              within = pathSegmentFractionForDistance(list.segments[index],
+                                                      target - covered);
+              point = pointOnPathSegment(list.segments[index], within);
+              break;
+            }
+
+          covered += length;
+        }
+    }
   else
     {
       index = segmentForFraction(_keyTimes, list.count, fraction, &within);
@@ -1372,8 +1564,9 @@ static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
     which is what a basic animation does with a from value and a to value.
 
     A path stands in place of the values, and the point it reaches is the
-    value.  Only the linear and discrete modes are calculated; the paced
-    modes are taken as linear.
+    value.  A paced animation covers the same distance in each moment
+    instead, so keyTimes says nothing and is not read.  The cubic modes are
+    taken as their linear counterparts.
    */
 
   NSUInteger count = [_values count];
@@ -1415,7 +1608,9 @@ static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
       return [_values objectAtIndex: index];
     }
 
-  index = segmentForFraction(_keyTimes, count - 1, fraction, &within);
+  index = [self isPaced]
+    ? [self pacedSegmentForFraction: fraction within: &within]
+    : segmentForFraction(_keyTimes, count - 1, fraction, &within);
 
   segment = [CABasicAnimation animationWithKeyPath: [self keyPath]];
   [segment setDuration: 1.0];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1358,11 +1358,42 @@ static float distanceBetweenValues(id from, id to)
   return -1.0;
 }
 
+/* One component of a curve through the keyframes, in the shape Apple's
+   tension, continuity and bias describe: tension tightens the curve,
+   continuity breaks it either side of a point, and bias leans it towards the
+   stretch before or after.  All three are zero unless given, which draws an
+   ordinary smooth curve through the points.
+
+   The stretch runs from P0 to P1, and PPREV and PNEXT are the points either
+   side of it. */
+static float curveThroughComponent(float pPrev, float p0, float p1,
+                                   float pNext,
+                                   float t0, float c0, float b0,
+                                   float t1, float c1, float b1,
+                                   float fraction)
+{
+  float leaving = (1 - t0) * (1 + b0) * (1 + c0) / 2 * (p0 - pPrev)
+                + (1 - t0) * (1 - b0) * (1 - c0) / 2 * (p1 - p0);
+  float arriving = (1 - t1) * (1 + b1) * (1 - c1) / 2 * (p1 - p0)
+                 + (1 - t1) * (1 - b1) * (1 + c1) / 2 * (pNext - p1);
+  float s = fraction;
+  float s2 = s * s;
+  float s3 = s2 * s;
+
+  return (2 * s3 - 3 * s2 + 1) * p0
+       + (s3 - 2 * s2 + s) * leaving
+       + (-2 * s3 + 3 * s2) * p1
+       + (s3 - s2) * arriving;
+}
+
 @implementation CAKeyframeAnimation
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
 @synthesize keyTimes=_keyTimes;
 @synthesize timingFunctions=_timingFunctions;
+@synthesize tensionValues=_tensionValues;
+@synthesize continuityValues=_continuityValues;
+@synthesize biasValues=_biasValues;
 
 - (CGPathRef) path
 {
@@ -1411,9 +1442,80 @@ static float distanceBetweenValues(id from, id to)
   [_values release];
   [_keyTimes release];
   [_timingFunctions release];
+  [_tensionValues release];
+  [_continuityValues release];
+  [_biasValues release];
   CGPathRelease(_path);
 
   [super dealloc];
+}
+
+/* Whether the animation draws a curve through its values rather than going
+   straight from one to the next. */
+- (BOOL) isCurved
+{
+  return [_calculationMode isEqualToString: kCAAnimationCubic]
+    || [_calculationMode isEqualToString: kCAAnimationCubicPaced];
+}
+
+/* The tension, continuity or bias at one keyframe.  Any that was not given
+   is zero, which is the curve Apple draws without them. */
+static float shapeValue(NSArray *values, NSUInteger index)
+{
+  if (index >= [values count])
+    return 0.0;
+
+  return [[values objectAtIndex: index] floatValue];
+}
+
+/* The value the curve through the keyframes has WITHIN of the way along the
+   stretch that starts at INDEX.  Answers nil for a type the curve cannot be
+   drawn through, and the animation then goes straight from value to value. */
+- (id) curvedValueForSegment: (NSUInteger)index within: (float)within
+{
+  NSUInteger count = [_values count];
+  id previous = [_values objectAtIndex: index > 0 ? index - 1 : index];
+  id from = [_values objectAtIndex: index];
+  id to = [_values objectAtIndex: index + 1];
+  id next = [_values objectAtIndex: index + 2 < count ? index + 2 : index + 1];
+  float t0 = shapeValue(_tensionValues, index);
+  float c0 = shapeValue(_continuityValues, index);
+  float b0 = shapeValue(_biasValues, index);
+  float t1 = shapeValue(_tensionValues, index + 1);
+  float c1 = shapeValue(_continuityValues, index + 1);
+  float b1 = shapeValue(_biasValues, index + 1);
+
+  if ([from isKindOfClass: [NSNumber class]]
+      && [to isKindOfClass: [NSNumber class]])
+    {
+      return [NSNumber numberWithFloat:
+        curveThroughComponent([previous floatValue], [from floatValue],
+                              [to floatValue], [next floatValue],
+                              t0, c0, b0, t1, c1, b1, within)];
+    }
+
+  if ([from isKindOfClass: [NSValue class]]
+      && [to isKindOfClass: [NSValue class]]
+      && !strcmp([from objCType], [to objCType])
+      && !strcmp([from objCType], @encode(CGPoint)))
+    {
+      CGPoint pPrev, p0, p1, pNext, point;
+
+      [previous getValue: &pPrev];
+      [from getValue: &p0];
+      [to getValue: &p1];
+      [next getValue: &pNext];
+
+      point = CGPointMake(
+        curveThroughComponent(pPrev.x, p0.x, p1.x, pNext.x,
+                              t0, c0, b0, t1, c1, b1, within),
+        curveThroughComponent(pPrev.y, p0.y, p1.y, pNext.y,
+                              t0, c0, b0, t1, c1, b1, within));
+
+      return [NSValue valueWithBytes: &point objCType: @encode(CGPoint)];
+    }
+
+  return nil;
 }
 
 /* Whether the animation is paced, which means it covers the same distance in
@@ -1565,8 +1667,8 @@ static float distanceBetweenValues(id from, id to)
 
     A path stands in place of the values, and the point it reaches is the
     value.  A paced animation covers the same distance in each moment
-    instead, so keyTimes says nothing and is not read.  The cubic modes are
-    taken as their linear counterparts.
+    instead, so keyTimes says nothing and is not read.  A cubic one draws a
+    curve through the values rather than going straight from one to the next.
    */
 
   NSUInteger count = [_values count];
@@ -1611,6 +1713,16 @@ static float distanceBetweenValues(id from, id to)
   index = [self isPaced]
     ? [self pacedSegmentForFraction: fraction within: &within]
     : segmentForFraction(_keyTimes, count - 1, fraction, &within);
+
+  if ([self isCurved])
+    {
+      id curved = [self curvedValueForSegment: index within: within];
+
+      if (curved != nil)
+        {
+          return curved;
+        }
+    }
 
   segment = [CABasicAnimation animationWithKeyPath: [self keyPath]];
   [segment setDuration: 1.0];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -616,6 +616,66 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
     return qr;
 
 }
+/* VALUE plus BYVALUE, or minus it where SIGN is -1.  Answers nil for a pair
+   of values a by value cannot be added to, which leaves the animation to
+   settle its ends some other way. */
+static id addValues(id value, id byValue, CGFloat sign)
+{
+  const char *type;
+
+  if ([value isKindOfClass: [NSNumber class]]
+      && [byValue isKindOfClass: [NSNumber class]])
+    {
+      return [NSNumber numberWithFloat:
+        [value floatValue] + sign * [byValue floatValue]];
+    }
+
+  if (![value isKindOfClass: [NSValue class]]
+      || ![byValue isKindOfClass: [NSValue class]])
+    {
+      return nil;
+    }
+
+  type = [value objCType];
+  if (strcmp(type, [byValue objCType]))
+    {
+      return nil;
+    }
+
+  if (!strcmp(type, @encode(CGPoint)))
+    {
+      CGPoint a = { 0 }; [value getValue: &a];
+      CGPoint b = { 0 }; [byValue getValue: &b];
+      CGPoint r = CGPointMake(a.x + sign * b.x, a.y + sign * b.y);
+
+      return [NSValue valueWithBytes: &r objCType: @encode(CGPoint)];
+    }
+
+  if (!strcmp(type, @encode(CGSize)))
+    {
+      CGSize a = { 0 }; [value getValue: &a];
+      CGSize b = { 0 }; [byValue getValue: &b];
+      CGSize r = CGSizeMake(a.width + sign * b.width,
+                            a.height + sign * b.height);
+
+      return [NSValue valueWithBytes: &r objCType: @encode(CGSize)];
+    }
+
+  if (!strcmp(type, @encode(CGRect)))
+    {
+      CGRect a = { { 0 } }; [value getValue: &a];
+      CGRect b = { { 0 } }; [byValue getValue: &b];
+      CGRect r = CGRectMake(a.origin.x + sign * b.origin.x,
+                            a.origin.y + sign * b.origin.y,
+                            a.size.width + sign * b.size.width,
+                            a.size.height + sign * b.size.height);
+
+      return [NSValue valueWithBytes: &r objCType: @encode(CGRect)];
+    }
+
+  return nil;
+}
+
 /** End helper math functions **/
 /*******************************/
 
@@ -638,22 +698,13 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
                               onLayer: (CALayer *)layer
 {
   /*
-    Currently supporting scenarios with:
-     - fromValue != nil
-     - toValue != nil
-     - byValue == nil
-    and
-     - fromValue != nil
-     - toValue == nil
-     - byValue == nil
-    and
-     - fromValue == nil
-     - toValue == nil
-     - byValue == nil
-    and
-     - fromValue == nil
-     - toValue != nil
-     - byValue == nil
+    A from value and a to value are interpolated between.  A by value
+    stands in for whichever end was not given: with a from value the
+    animation runs to that value plus the by value, with a to value it
+    starts at that value minus the by value, and on its own it works from
+    the value the layer already has.  A by value has no effect on a type it
+    cannot be added to, which is every type but a number, a point, a size
+    and a rectangle.
 
     All supplied values need to be of same data type.
    */
@@ -669,6 +720,23 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
   /* Calculate what will our actual from and to values be */
   id fromValue = _fromValue;
   id toValue = _toValue;
+
+  if (_byValue)
+    {
+      if (fromValue && !toValue)
+        {
+          toValue = addValues(fromValue, _byValue, 1.0);
+        }
+      else if (!fromValue && toValue)
+        {
+          fromValue = addValues(toValue, _byValue, -1.0);
+        }
+      else if (!fromValue && !toValue && _keyPath)
+        {
+          fromValue = [[layer modelLayer] valueForKeyPath: _keyPath];
+          toValue = addValues(fromValue, _byValue, 1.0);
+        }
+    }
 
   if (!toValue)
     toValue = [[layer modelLayer] valueForKeyPath: _keyPath];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -709,7 +709,9 @@ static id addValues(id value, id byValue, CGFloat sign)
     All supplied values need to be of same data type.
    */
 
-  float fraction = theTime / _duration;
+  /* An animation with no duration has no extent to be part way through: it
+     is at its end from the moment it begins. */
+  float fraction = _duration > 0.0 ? theTime / _duration : 1.0;
 
   /* apply media timing function, if set */
   if ([self timingFunction])
@@ -1211,7 +1213,7 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
       return [_values objectAtIndex: 0];
     }
 
-  fraction = theTime / _duration;
+  fraction = _duration > 0.0 ? theTime / _duration : 1.0;
   if ([self timingFunction])
     {
       fraction = [[self timingFunction] evaluateYAtX: fraction];

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1084,9 +1084,165 @@ static id addValues(id value, id byValue, CGFloat sign)
 
 @end
 
+/* Which of the SEGMENTS the fraction falls in, and how far along that one it
+   is.  KEYTIMES says where each segment ends; without it they are evenly
+   spaced. */
+static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
+                                     float fraction, float *within)
+{
+  NSUInteger index;
+
+  *within = 0.0;
+  if (segments == 0)
+    {
+      return 0;
+    }
+
+  if ([keyTimes count] >= 2)
+    {
+      NSUInteger last = [keyTimes count] - 1;
+
+      for (index = 0; index < last; index++)
+        {
+          float start = [[keyTimes objectAtIndex: index] floatValue];
+          float end = [[keyTimes objectAtIndex: index + 1] floatValue];
+
+          if (fraction <= end || index + 1 == last)
+            {
+              if (end > start)
+                {
+                  *within = (fraction - start) / (end - start);
+                  if (*within < 0.0)
+                    *within = 0.0;
+                  if (*within > 1.0)
+                    *within = 1.0;
+                }
+              return index < segments ? index : segments - 1;
+            }
+        }
+    }
+
+  {
+    float scaled = fraction * segments;
+
+    index = (NSUInteger)scaled;
+    if (index >= segments)
+      {
+        index = segments - 1;
+        *within = 1.0;
+      }
+    else
+      {
+        *within = scaled - index;
+      }
+  }
+
+  return index;
+}
+
 @implementation CAKeyframeAnimation
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
+@synthesize keyTimes=_keyTimes;
+@synthesize timingFunctions=_timingFunctions;
+
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"calculationMode"])
+    {
+      return kCAAnimationLinear;
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  return [self initWithKeyPath: nil];
+}
+
+- (id) initWithKeyPath: (NSString *)keyPath
+{
+  self = [super initWithKeyPath: keyPath];
+  if (!self)
+    return nil;
+
+  _calculationMode = [kCAAnimationLinear copy];
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_calculationMode release];
+  [_values release];
+  [_keyTimes release];
+  [_timingFunctions release];
+
+  [super dealloc];
+}
+
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer
+{
+  /*
+    The values are run through in order.  keyTimes says where each of them
+    falls between 0 and 1, and without it they are evenly spaced.  A discrete
+    animation steps from one value to the next without interpolating; every
+    other mode interpolates between the two values the time falls between,
+    which is what a basic animation does with a from value and a to value.
+
+    Only the linear and discrete modes are calculated.  The paced modes are
+    taken as linear, and an animation along a path is not supported.
+   */
+
+  NSUInteger count = [_values count];
+  NSUInteger index;
+  float fraction;
+  float within = 0.0;
+  CABasicAnimation *segment;
+
+  if (count == 0)
+    {
+      return nil;
+    }
+  if (count == 1)
+    {
+      return [_values objectAtIndex: 0];
+    }
+
+  fraction = theTime / _duration;
+  if ([self timingFunction])
+    {
+      fraction = [[self timingFunction] evaluateYAtX: fraction];
+    }
+
+  /* Asking outside the duration would run off the end of the values. */
+  if (fraction < 0.0)
+    fraction = 0.0;
+  if (fraction > 1.0)
+    fraction = 1.0;
+
+  if ([_calculationMode isEqualToString: kCAAnimationDiscrete])
+    {
+      index = segmentForFraction(_keyTimes, count, fraction, &within);
+
+      return [_values objectAtIndex: index];
+    }
+
+  index = segmentForFraction(_keyTimes, count - 1, fraction, &within);
+
+  segment = [CABasicAnimation animationWithKeyPath: [self keyPath]];
+  [segment setDuration: 1.0];
+  [segment setFromValue: [_values objectAtIndex: index]];
+  [segment setToValue: [_values objectAtIndex: index + 1]];
+  if ([_timingFunctions count] > index)
+    {
+      [segment setTimingFunction: [_timingFunctions objectAtIndex: index]];
+    }
+
+  return [segment calculatedAnimationValueAtTime: within onLayer: layer];
+}
 
 @end
 

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1142,11 +1142,144 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
   return index;
 }
 
+/* A path is run through as a list of segments: a line-to or a curve-to is one
+   segment ending at a keyframe point, and a move-to only says where the next
+   one starts.  A quadratic curve is kept as the cubic that draws it. */
+typedef struct
+{
+  CGPoint start;
+  CGPoint control1;
+  CGPoint control2;
+  CGPoint end;
+  BOOL curved;
+} GSCAPathSegment;
+
+typedef struct
+{
+  GSCAPathSegment * segments;
+  NSUInteger count;
+  NSUInteger capacity;
+  CGPoint current;
+  CGPoint subpathStart;
+} GSCAPathSegments;
+
+static void addPathSegment(GSCAPathSegments *list, GSCAPathSegment segment)
+{
+  if (list->count == list->capacity)
+    {
+      list->capacity = list->capacity ? list->capacity * 2 : 8;
+      list->segments = realloc(list->segments,
+                               list->capacity * sizeof(GSCAPathSegment));
+    }
+
+  list->segments[list->count++] = segment;
+}
+
+static void addPathLine(GSCAPathSegments *list, CGPoint end)
+{
+  GSCAPathSegment segment;
+
+  segment.start = list->current;
+  segment.control1 = list->current;
+  segment.control2 = end;
+  segment.end = end;
+  segment.curved = NO;
+  addPathSegment(list, segment);
+  list->current = end;
+}
+
+static void collectPathSegment(void *info, const CGPathElement *element)
+{
+  GSCAPathSegments * list = (GSCAPathSegments *)info;
+  GSCAPathSegment segment;
+
+  switch (element->type)
+    {
+      case kCGPathElementMoveToPoint:
+        list->current = element->points[0];
+        list->subpathStart = list->current;
+        break;
+
+      case kCGPathElementAddLineToPoint:
+        addPathLine(list, element->points[0]);
+        break;
+
+      case kCGPathElementAddQuadCurveToPoint:
+        {
+          CGPoint control = element->points[0];
+          CGPoint end = element->points[1];
+
+          segment.start = list->current;
+          segment.control1 = CGPointMake(
+            list->current.x + 2.0 / 3.0 * (control.x - list->current.x),
+            list->current.y + 2.0 / 3.0 * (control.y - list->current.y));
+          segment.control2 = CGPointMake(
+            end.x + 2.0 / 3.0 * (control.x - end.x),
+            end.y + 2.0 / 3.0 * (control.y - end.y));
+          segment.end = end;
+          segment.curved = YES;
+          addPathSegment(list, segment);
+          list->current = end;
+          break;
+        }
+
+      case kCGPathElementAddCurveToPoint:
+        segment.start = list->current;
+        segment.control1 = element->points[0];
+        segment.control2 = element->points[1];
+        segment.end = element->points[2];
+        segment.curved = YES;
+        addPathSegment(list, segment);
+        list->current = segment.end;
+        break;
+
+      case kCGPathElementCloseSubpath:
+        addPathLine(list, list->subpathStart);
+        break;
+    }
+}
+
+/* Where a segment is when it is FRACTION of the way along. */
+static CGPoint pointOnPathSegment(GSCAPathSegment segment, float fraction)
+{
+  float t = fraction;
+  float u;
+
+  if (!segment.curved)
+    {
+      return CGPointMake(
+        linearInterpolation(segment.start.x, segment.end.x, t),
+        linearInterpolation(segment.start.y, segment.end.y, t));
+    }
+
+  u = 1.0 - t;
+  return CGPointMake(
+    u * u * u * segment.start.x + 3 * u * u * t * segment.control1.x
+      + 3 * u * t * t * segment.control2.x + t * t * t * segment.end.x,
+    u * u * u * segment.start.y + 3 * u * u * t * segment.control1.y
+      + 3 * u * t * t * segment.control2.y + t * t * t * segment.end.y);
+}
+
 @implementation CAKeyframeAnimation
 @synthesize calculationMode=_calculationMode;
 @synthesize values=_values;
 @synthesize keyTimes=_keyTimes;
 @synthesize timingFunctions=_timingFunctions;
+
+- (CGPathRef) path
+{
+  return _path;
+}
+
+- (void) setPath: (CGPathRef)path
+{
+  if (path == _path)
+    return;
+
+  CGPathRetain(path);
+  CGPathRelease(_path);
+  _path = path;
+}
 
 + (id) defaultValueForKey: (NSString *)key
 {
@@ -1180,8 +1313,52 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
   [_values release];
   [_keyTimes release];
   [_timingFunctions release];
+  CGPathRelease(_path);
 
   [super dealloc];
+}
+
+/* The point the path has reached FRACTION of the way through the animation.
+   The end of each line or curve is a keyframe, and the points between two of
+   them are taken from the line or the curve itself. */
+- (id) valueOnPathAtFraction: (float)fraction
+{
+  GSCAPathSegments list;
+  NSUInteger index;
+  float within = 0.0;
+  CGPoint point;
+
+  list.segments = NULL;
+  list.count = 0;
+  list.capacity = 0;
+  list.current = CGPointZero;
+  list.subpathStart = CGPointZero;
+
+  CGPathApply(_path, &list, collectPathSegment);
+
+  if (list.count == 0)
+    {
+      free(list.segments);
+      return nil;
+    }
+
+  if ([_calculationMode isEqualToString: kCAAnimationDiscrete])
+    {
+      /* The keyframes are the point each segment ends at, with the point the
+         path starts from before them. */
+      index = segmentForFraction(_keyTimes, list.count + 1, fraction, &within);
+      point = index == 0 ? list.segments[0].start
+                         : list.segments[index - 1].end;
+    }
+  else
+    {
+      index = segmentForFraction(_keyTimes, list.count, fraction, &within);
+      point = pointOnPathSegment(list.segments[index], within);
+    }
+
+  free(list.segments);
+
+  return [NSValue valueWithBytes: &point objCType: @encode(CGPoint)];
 }
 
 - (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
@@ -1194,8 +1371,9 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
     other mode interpolates between the two values the time falls between,
     which is what a basic animation does with a from value and a to value.
 
-    Only the linear and discrete modes are calculated.  The paced modes are
-    taken as linear, and an animation along a path is not supported.
+    A path stands in place of the values, and the point it reaches is the
+    value.  Only the linear and discrete modes are calculated; the paced
+    modes are taken as linear.
    */
 
   NSUInteger count = [_values count];
@@ -1204,11 +1382,11 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
   float within = 0.0;
   CABasicAnimation *segment;
 
-  if (count == 0)
+  if (_path == NULL && count == 0)
     {
       return nil;
     }
-  if (count == 1)
+  if (_path == NULL && count == 1)
     {
       return [_values objectAtIndex: 0];
     }
@@ -1224,6 +1402,11 @@ static NSUInteger segmentForFraction(NSArray *keyTimes, NSUInteger segments,
     fraction = 0.0;
   if (fraction > 1.0)
     fraction = 1.0;
+
+  if (_path != NULL)
+    {
+      return [self valueOnPathAtFraction: fraction];
+    }
 
   if ([_calculationMode isEqualToString: kCAAnimationDiscrete])
     {

--- a/Tests/quartzcore/CABasicAnimation/TestInfo
+++ b/Tests/quartzcore/CABasicAnimation/TestInfo
@@ -1,0 +1,3 @@
+# -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+# in Apple QuartzCore.
+APPLE_SKIP_TESTS="byvalue.m"

--- a/Tests/quartzcore/CABasicAnimation/TestInfo
+++ b/Tests/quartzcore/CABasicAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore.
-APPLE_SKIP_TESTS="byvalue.m zeroduration.m"
+APPLE_SKIP_TESTS="byvalue.m zeroduration.m fillmode.m"

--- a/Tests/quartzcore/CABasicAnimation/TestInfo
+++ b/Tests/quartzcore/CABasicAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore.
-APPLE_SKIP_TESTS="byvalue.m"
+APPLE_SKIP_TESTS="byvalue.m zeroduration.m"

--- a/Tests/quartzcore/CABasicAnimation/byvalue.m
+++ b/Tests/quartzcore/CABasicAnimation/byvalue.m
@@ -1,0 +1,210 @@
+/* The end a by value stands in for.
+
+   Apple documents three of these: a from value and a by value interpolate
+   between the from value and from plus by; a by value and a to value
+   interpolate between to minus by and the to value; and a by value on its
+   own works from the value the layer already has.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no
+   counterpart in Apple QuartzCore, so this file is named in
+   APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+#include <string.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static CABasicAnimation *
+animation(NSString *keyPath, id fromValue, id toValue, id byValue)
+{
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: keyPath];
+
+  [b setDuration: 2.0];
+  [b setFromValue: fromValue];
+  [b setToValue: toValue];
+  [b setByValue: byValue];
+  return b;
+}
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a from value and a by value")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", number(0.25), nil, number(0.5));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 0.0 onLayer: layer] floatValue],
+             0.25),
+       "it starts at the from value");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 1.0 onLayer: layer] floatValue],
+             0.5),
+       "half way along it is half the by value past it");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: layer] floatValue],
+             0.75),
+       "and it ends at the from value plus the by value");
+
+  END_SET("a from value and a by value")
+
+  START_SET("a by value and a to value")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", nil, number(0.75), number(0.5));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 0.0 onLayer: layer] floatValue],
+             0.25),
+       "it starts at the to value less the by value");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: layer] floatValue],
+             0.75),
+       "and ends at the to value");
+
+  END_SET("a by value and a to value")
+
+  START_SET("a by value on its own")
+
+  /* The value it works from is the one the layer holds, which a layer only
+     answers for when it is standing in for another. */
+  CALayer *layer = [CALayer layer];
+  CALayer *presentation;
+
+  [layer setOpacity: 0.25];
+  presentation = [layer presentationLayer];
+
+  CABasicAnimation *b = animation(@"opacity", nil, nil, number(0.5));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 0.0 onLayer: presentation]
+               floatValue], 0.25),
+       "it starts at the value the layer already has");
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: presentation]
+               floatValue], 0.75),
+       "and ends the by value past it");
+
+  END_SET("a by value on its own")
+
+  START_SET("a by value that is a point")
+
+  CALayer *layer = [CALayer layer];
+  CGPoint from = CGPointMake(10, 20);
+  CGPoint by = CGPointMake(4, 8);
+  CABasicAnimation *b =
+    animation(@"position",
+              [NSValue valueWithBytes: &from objCType: @encode(CGPoint)],
+              nil,
+              [NSValue valueWithBytes: &by objCType: @encode(CGPoint)]);
+  NSValue *v = [b calculatedAnimationValueAtTime: 2.0 onLayer: layer];
+  CGPoint p = CGPointMake(-1, -1);
+
+  PASS(v != nil && !strcmp([v objCType], @encode(CGPoint)),
+       "the value is a point");
+  if (v != nil)
+    {
+      [v getValue: &p];
+    }
+  PASS(CLOSE(p.x, 14) && CLOSE(p.y, 28),
+       "with the by value added to both members");
+
+  END_SET("a by value that is a point")
+
+  START_SET("a by value that is a size")
+
+  CALayer *layer = [CALayer layer];
+  CGSize from = CGSizeMake(10, 20);
+  CGSize by = CGSizeMake(4, 8);
+  CABasicAnimation *b =
+    animation(@"bounds",
+              [NSValue valueWithBytes: &from objCType: @encode(CGSize)],
+              nil,
+              [NSValue valueWithBytes: &by objCType: @encode(CGSize)]);
+  NSValue *v = [b calculatedAnimationValueAtTime: 2.0 onLayer: layer];
+  CGSize s = CGSizeMake(-1, -1);
+
+  if (v != nil)
+    {
+      [v getValue: &s];
+    }
+  /* The by value is added to both members, and then the interpolation
+     between the two sizes takes the height of neither: every size comes out
+     square, which is a separate matter from the by value. */
+  testHopeful = YES;
+  PASS(CLOSE(s.width, 14) && CLOSE(s.height, 28),
+       "both members of a size take the by value");
+  testHopeful = NO;
+
+  END_SET("a by value that is a size")
+
+  START_SET("a by value that is a rectangle")
+
+  CALayer *layer = [CALayer layer];
+  CGRect from = CGRectMake(1, 2, 10, 20);
+  CGRect by = CGRectMake(3, 4, 5, 6);
+  CABasicAnimation *b =
+    animation(@"bounds",
+              [NSValue valueWithBytes: &from objCType: @encode(CGRect)],
+              nil,
+              [NSValue valueWithBytes: &by objCType: @encode(CGRect)]);
+  NSValue *v = [b calculatedAnimationValueAtTime: 2.0 onLayer: layer];
+  CGRect r = CGRectMake(-1, -1, -1, -1);
+
+  if (v != nil)
+    {
+      [v getValue: &r];
+    }
+  PASS(CLOSE(r.origin.x, 4) && CLOSE(r.origin.y, 6)
+       && CLOSE(r.size.width, 15) && CLOSE(r.size.height, 26),
+       "all four members of a rectangle take the by value");
+
+  END_SET("a by value that is a rectangle")
+
+  START_SET("a by value that cannot be added")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", @"a string", nil, @"another");
+
+  PASS([b calculatedAnimationValueAtTime: 1.0 onLayer: layer] == nil,
+       "a by value of a type that cannot be added leaves nothing to animate");
+
+  CATransform3D identity = CATransform3DIdentity;
+  CABasicAnimation *t =
+    animation(@"transform",
+              [NSValue valueWithCATransform3D: identity], nil,
+              [NSValue valueWithCATransform3D: identity]);
+
+  PASS([t calculatedAnimationValueAtTime: 1.0 onLayer: layer] == nil,
+       "and a transform is one of those types");
+
+  END_SET("a by value that cannot be added")
+
+  START_SET("a by value alongside both ends")
+
+  /* Apple says no more than two of the three should be given.  Where all
+     three are, the two ends are what count. */
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation(@"opacity", number(0.0), number(1.0),
+                                  number(0.25));
+
+  PASS(CLOSE([[b calculatedAnimationValueAtTime: 2.0 onLayer: layer] floatValue],
+             1.0),
+       "the to value is where it ends, not the from value plus the by value");
+
+  END_SET("a by value alongside both ends")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CABasicAnimation/fillmode.m
+++ b/Tests/quartzcore/CABasicAnimation/fillmode.m
@@ -1,0 +1,130 @@
+/* What an animation shows outside its own duration.
+
+   Apple describes the four: removed, which an animation starts with, shows
+   nothing at either end; forwards holds the value the animation ends at
+   after it has ended; backwards holds the one it starts from before it
+   begins; and both does the two.
+
+   -applyToLayer: is GNUstep API with no counterpart in Apple QuartzCore, so
+   this file is named in APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CAMediaTiming.h>
+#import <QuartzCore/CATransaction.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (void) applyToLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+/* A layer whose opacity is a half, and an animation from nothing to whole
+   that either has not begun yet or is long over.  Applying it to the layer
+   is what the fill mode governs. */
+static float
+opacityAfterApplying(NSString *fillMode, BOOL over)
+{
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+
+  [layer setOpacity: 0.5];
+
+  [b setDuration: 1.0];
+  [b setFromValue: [NSNumber numberWithFloat: 0.0]];
+  [b setToValue: [NSNumber numberWithFloat: 1.0]];
+  [b setFillMode: fillMode];
+  [b setBeginTime: CACurrentMediaTime() + (over ? -100.0 : 100.0)];
+
+  [b applyToLayer: layer];
+
+  [CATransaction commit];
+
+  return [layer opacity];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the fill mode an animation starts with")
+
+  CABasicAnimation *b = [CABasicAnimation animation];
+
+  PASS([[b fillMode] isEqualToString: kCAFillModeRemoved]
+       || [b fillMode] == nil,
+       "an animation starts with nothing filled in at either end");
+
+  PASS(CLOSE(opacityAfterApplying([b fillMode], NO), 0.5),
+       "so before it begins the layer keeps its own value");
+  PASS(CLOSE(opacityAfterApplying([b fillMode], YES), 0.5),
+       "and after it ends the layer keeps its own value");
+
+  END_SET("the fill mode an animation starts with")
+
+  START_SET("filling forwards")
+
+  PASS(CLOSE(opacityAfterApplying(kCAFillModeForwards, YES), 1.0),
+       "after it ends the value it ended at is held");
+  PASS(CLOSE(opacityAfterApplying(kCAFillModeForwards, NO), 0.5),
+       "and before it begins the layer is still left alone");
+
+  END_SET("filling forwards")
+
+  START_SET("filling backwards")
+
+  PASS(CLOSE(opacityAfterApplying(kCAFillModeBackwards, NO), 0.0),
+       "before it begins the value it starts from is held");
+  PASS(CLOSE(opacityAfterApplying(kCAFillModeBackwards, YES), 0.5),
+       "and after it ends the layer is left alone");
+
+  END_SET("filling backwards")
+
+  START_SET("filling both ends")
+
+  PASS(CLOSE(opacityAfterApplying(kCAFillModeBoth, NO), 0.0),
+       "both holds the value at the near end");
+  PASS(CLOSE(opacityAfterApplying(kCAFillModeBoth, YES), 1.0),
+       "and at the far one");
+
+  END_SET("filling both ends")
+
+  START_SET("a fill mode that means nothing")
+
+  PASS(CLOSE(opacityAfterApplying(@"aFillModeNobodyDefines", YES), 0.5),
+       "a fill mode the framework does not know fills neither end");
+
+  END_SET("a fill mode that means nothing")
+
+  START_SET("within the duration")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+
+  [layer setOpacity: 0.5];
+  [b setDuration: 100.0];
+  [b setFromValue: [NSNumber numberWithFloat: 0.0]];
+  [b setToValue: [NSNumber numberWithFloat: 1.0]];
+  [b setBeginTime: CACurrentMediaTime() - 50.0];
+  [b applyToLayer: layer];
+
+  [CATransaction commit];
+
+  PASS([layer opacity] > 0.4 && [layer opacity] < 0.6,
+       "an animation part way through is applied whatever its fill mode");
+
+  END_SET("within the duration")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CABasicAnimation/zeroduration.m
+++ b/Tests/quartzcore/CABasicAnimation/zeroduration.m
@@ -1,0 +1,121 @@
+/* The value an animation calculates when its duration is zero.
+
+   An animation starts with a duration of zero, and a layer gives one it is
+   handed the duration of the current transaction.  An animation that is
+   asked for its value without being added to a layer keeps the zero, and
+   dividing the time by it is what this file covers.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no
+   counterpart in Apple QuartzCore, so this file is named in
+   APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CATransaction.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+/* An opacity animation from 0 to 1 which is never given a duration. */
+static CABasicAnimation *
+animation(void)
+{
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"opacity"];
+
+  [b setFromValue: number(0.0)];
+  [b setToValue: number(1.0)];
+  return b;
+}
+
+static float
+valueAt(CABasicAnimation *b, CFTimeInterval time, CALayer *layer)
+{
+  return [[b calculatedAnimationValueAtTime: time onLayer: layer] floatValue];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("an animation that was never given a duration")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation();
+
+  PASS([b duration] == 0.0, "an animation starts with a duration of zero");
+
+  PASS(CLOSE(valueAt(b, 0.0, layer), 1.0),
+       "at the time it begins it is already at its end");
+  PASS(CLOSE(valueAt(b, 1.0, layer), 1.0), "and it stays there");
+
+  END_SET("an animation that was never given a duration")
+
+  START_SET("a duration that is set to zero")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation();
+  CABasicAnimation *negative = animation();
+
+  [b setDuration: 0.0];
+  PASS(CLOSE(valueAt(b, 0.5, layer), 1.0),
+       "a duration of zero leaves no time to be part way through");
+
+  [negative setDuration: -1.0];
+  PASS(CLOSE(valueAt(negative, 0.5, layer), 1.0),
+       "and neither does one below zero");
+
+  END_SET("a duration that is set to zero")
+
+  START_SET("a value that is not a number")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = [CABasicAnimation animationWithKeyPath: @"position"];
+  CGPoint from = CGPointMake(0, 0);
+  CGPoint to = CGPointMake(10, 20);
+  NSValue *v;
+  CGPoint p = CGPointMake(-1, -1);
+
+  [b setFromValue: [NSValue valueWithBytes: &from objCType: @encode(CGPoint)]];
+  [b setToValue: [NSValue valueWithBytes: &to objCType: @encode(CGPoint)]];
+  v = [b calculatedAnimationValueAtTime: 0.5 onLayer: layer];
+  if (v != nil)
+    {
+      [v getValue: &p];
+    }
+
+  PASS(CLOSE(p.x, 10.0) && CLOSE(p.y, 20.0),
+       "a point ends up at the end of the animation as well");
+
+  END_SET("a value that is not a number")
+
+  START_SET("an animation a layer has been given")
+
+  CALayer *layer = [CALayer layer];
+  CABasicAnimation *b = animation();
+
+  [layer addAnimation: b forKey: @"opacity"];
+
+  PASS(CLOSE([b duration], [CATransaction animationDuration]),
+       "a layer gives an animation with no duration the transaction's");
+  PASS(CLOSE(valueAt(b, [b duration] / 2.0, layer), 0.5),
+       "so an animation that a layer runs is half way through half way along");
+
+  END_SET("an animation a layer has been given")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/TestInfo
+++ b/Tests/quartzcore/CAKeyframeAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore, so only the properties can be checked against it.
-APPLE_SKIP_TESTS="keyframes.m path.m"
+APPLE_SKIP_TESTS="keyframes.m path.m paced.m"

--- a/Tests/quartzcore/CAKeyframeAnimation/TestInfo
+++ b/Tests/quartzcore/CAKeyframeAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore, so only the properties can be checked against it.
-APPLE_SKIP_TESTS="keyframes.m"
+APPLE_SKIP_TESTS="keyframes.m path.m"

--- a/Tests/quartzcore/CAKeyframeAnimation/TestInfo
+++ b/Tests/quartzcore/CAKeyframeAnimation/TestInfo
@@ -1,3 +1,3 @@
 # -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
 # in Apple QuartzCore, so only the properties can be checked against it.
-APPLE_SKIP_TESTS="keyframes.m path.m paced.m"
+APPLE_SKIP_TESTS="keyframes.m path.m paced.m cubic.m"

--- a/Tests/quartzcore/CAKeyframeAnimation/TestInfo
+++ b/Tests/quartzcore/CAKeyframeAnimation/TestInfo
@@ -1,0 +1,3 @@
+# -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+# in Apple QuartzCore, so only the properties can be checked against it.
+APPLE_SKIP_TESTS="keyframes.m"

--- a/Tests/quartzcore/CAKeyframeAnimation/cubic.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/cubic.m
@@ -1,0 +1,194 @@
+/* A keyframe animation that draws a curve through its values.
+
+   Apple documents what tension, continuity and bias mean: they belong to the
+   cubic modes, they are given one per keyframe, and a keyframe without one
+   uses zero.  The expected numbers below are worked out from the curve those
+   describe rather than read back from the framework.
+
+   The first and last values have nothing before or after them, so the value
+   itself stands in for what is missing, which is what gives the curve its
+   ends.  The numbers below are worked out from that.
+
+   Take the values 0, 1 and 0.  Half way along the first stretch a straight
+   line is at 0.5.  The curve leaves the first value at half the step to the
+   second, and arrives at the second with no slope at all, the values either
+   side of it being equal; half way along that is 0.5625.  With the tension
+   at 1 there is no slope at either end and it is back at 0.5.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+   in Apple QuartzCore, so this file is named in APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+static NSArray *
+numbers(float a, float b, float c)
+{
+  return [NSArray arrayWithObjects: number(a), number(b), number(c), nil];
+}
+
+static float
+valueAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  return [[k calculatedAnimationValueAtTime: time onLayer: layer] floatValue];
+}
+
+/* Up to one and back down again, over four seconds. */
+static CAKeyframeAnimation *
+overAndBack(NSString *mode)
+{
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  [k setDuration: 4.0];
+  [k setValues: numbers(0.0, 1.0, 0.0)];
+  [k setCalculationMode: mode];
+  return k;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a curve is drawn through")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = overAndBack(kCAAnimationCubic);
+
+  PASS(CLOSE(valueAt(k, 0.0, layer), 0.0), "it starts at the first value");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0), "it passes through the second");
+  PASS(CLOSE(valueAt(k, 4.0, layer), 0.0), "and ends at the last");
+
+  END_SET("the values a curve is drawn through")
+
+  START_SET("the curve between two values")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *straight = overAndBack(kCAAnimationLinear);
+  CAKeyframeAnimation *curved = overAndBack(kCAAnimationCubic);
+
+  PASS(CLOSE(valueAt(straight, 1.0, layer), 0.5),
+       "a straight line is half way up half way along");
+  PASS(CLOSE(valueAt(curved, 1.0, layer), 0.5625),
+       "and the curve is above it, arriving at the second value level");
+
+  END_SET("the curve between two values")
+
+  START_SET("tension")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = overAndBack(kCAAnimationCubic);
+
+  [k setTensionValues: numbers(1.0, 1.0, 1.0)];
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.5),
+       "a tension of one takes the slope out of both ends");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0),
+       "and the curve still passes through the values");
+
+  END_SET("tension")
+
+  START_SET("a shape value that was not given")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = overAndBack(kCAAnimationCubic);
+  CAKeyframeAnimation *none = overAndBack(kCAAnimationCubic);
+
+  /* One entry for the first keyframe only; the rest are zero, which is what
+     an animation with no tension at all uses. */
+  [k setTensionValues: [NSArray arrayWithObject: number(0.0)]];
+
+  PASS(CLOSE(valueAt(k, 1.0, layer), valueAt(none, 1.0, layer)),
+       "a keyframe with no tension of its own is drawn as if it were zero");
+
+  END_SET("a shape value that was not given")
+
+  START_SET("continuity and bias")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *plain = overAndBack(kCAAnimationCubic);
+  CAKeyframeAnimation *biased = overAndBack(kCAAnimationCubic);
+  CAKeyframeAnimation *broken = overAndBack(kCAAnimationCubic);
+
+  [biased setBiasValues: numbers(0.0, 1.0, 0.0)];
+  [broken setContinuityValues: numbers(0.0, 1.0, 0.0)];
+
+  PASS(!CLOSE(valueAt(biased, 1.0, layer), valueAt(plain, 1.0, layer)),
+       "a bias at the second value changes the stretch before it");
+  PASS(!CLOSE(valueAt(broken, 1.0, layer), valueAt(plain, 1.0, layer)),
+       "and so does a continuity");
+  PASS(CLOSE(valueAt(biased, 2.0, layer), 1.0),
+       "neither moves the value the curve passes through");
+
+  END_SET("continuity and bias")
+
+  START_SET("a curve through points")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGPoint first = CGPointMake(0, 0);
+  CGPoint second = CGPointMake(10, 10);
+  CGPoint third = CGPointMake(20, 0);
+  CGPoint value = CGPointMake(-1, -1);
+
+  [k setDuration: 4.0];
+  [k setValues: [NSArray arrayWithObjects:
+    [NSValue valueWithBytes: &first objCType: @encode(CGPoint)],
+    [NSValue valueWithBytes: &second objCType: @encode(CGPoint)],
+    [NSValue valueWithBytes: &third objCType: @encode(CGPoint)], nil]];
+  [k setCalculationMode: kCAAnimationCubic];
+
+  [[k calculatedAnimationValueAtTime: 1.0 onLayer: layer] getValue: &value];
+  PASS(CLOSE(value.x, 4.375), "a point is curved through each way at once");
+  PASS(CLOSE(value.y, 5.625),
+       "the two ways being curved apart, since what lies either side differs");
+
+  [[k calculatedAnimationValueAtTime: 2.0 onLayer: layer] getValue: &value];
+  PASS(CLOSE(value.x, 10.0) && CLOSE(value.y, 10.0),
+       "and the curve passes through the point it was given");
+
+  END_SET("a curve through points")
+
+  START_SET("values a curve cannot be drawn through")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"transform"];
+  CATransform3D first = CATransform3DIdentity;
+  CATransform3D second = CATransform3DMakeScale(2, 2, 2);
+  CATransform3D third = CATransform3DMakeScale(3, 3, 3);
+  CATransform3D value = CATransform3DIdentity;
+
+  [k setDuration: 4.0];
+  [k setValues: [NSArray arrayWithObjects:
+    [NSValue valueWithBytes: &first objCType: @encode(CATransform3D)],
+    [NSValue valueWithBytes: &second objCType: @encode(CATransform3D)],
+    [NSValue valueWithBytes: &third objCType: @encode(CATransform3D)], nil]];
+  [k setCalculationMode: kCAAnimationCubic];
+
+  [[k calculatedAnimationValueAtTime: 1.0 onLayer: layer] getValue: &value];
+  PASS(CLOSE(value.m11, 1.5),
+       "a transform goes straight from one value to the next, as before");
+
+  END_SET("values a curve cannot be drawn through")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
@@ -1,0 +1,190 @@
+/* The value a keyframe animation calculates part way through its duration.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+   in Apple QuartzCore, so this file is named in APPLE_SKIP_TESTS.  The
+   properties it sets are Apple's and are checked in properties.m, which does
+   run there. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+#import <QuartzCore/CAMediaTimingFunction.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static NSNumber *
+number(float value)
+{
+  return [NSNumber numberWithFloat: value];
+}
+
+/* Three values, evenly spaced over four seconds unless told otherwise. */
+static CAKeyframeAnimation *
+keyframes(void)
+{
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  [k setDuration: 4.0];
+  [k setValues: [NSArray arrayWithObjects:
+    number(0.0), number(1.0), number(0.0), nil]];
+  return k;
+}
+
+static float
+valueAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  return [[k calculatedAnimationValueAtTime: time onLayer: layer] floatValue];
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("running through the values")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  PASS(CLOSE(valueAt(k, 0.0, layer), 0.0), "it starts at the first value");
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.5),
+       "a quarter of the way along it is half way to the second");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0),
+       "half way along it is at the second value");
+  PASS(CLOSE(valueAt(k, 3.0, layer), 0.5),
+       "and then half way back down to the third");
+  PASS(CLOSE(valueAt(k, 4.0, layer), 0.0), "ending at the last value");
+
+  END_SET("running through the values")
+
+  START_SET("one value and none")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  [k setDuration: 4.0];
+
+  PASS([k calculatedAnimationValueAtTime: 1.0 onLayer: layer] == nil,
+       "an animation with no values calculates nothing");
+
+  [k setValues: [NSArray arrayWithObject: number(0.75)]];
+
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.75),
+       "and one with a single value stays on it");
+
+  END_SET("one value and none")
+
+  START_SET("key times say where each value falls")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  /* The middle value now falls three quarters of the way along rather than
+     half way. */
+  [k setKeyTimes: [NSArray arrayWithObjects:
+    number(0.0), number(0.75), number(1.0), nil]];
+
+  PASS(CLOSE(valueAt(k, 3.0, layer), 1.0),
+       "the second value falls where the key times put it");
+  PASS(CLOSE(valueAt(k, 1.5, layer), 0.5),
+       "half way to it is half the first value's share along");
+  PASS(CLOSE(valueAt(k, 3.5, layer), 0.5),
+       "and the last stretch is shorter to match");
+
+  END_SET("key times say where each value falls")
+
+  START_SET("a discrete animation does not interpolate")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  [k setCalculationMode: kCAAnimationDiscrete];
+
+  /* Three values with no key times hold for a third of the duration each. */
+  PASS(CLOSE(valueAt(k, 0.5, layer), 0.0), "it holds the first value");
+  PASS(CLOSE(valueAt(k, 1.0, layer), 0.0),
+       "still holding it a quarter of the way along, where interpolating "
+       "would have reached half way");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0), "then steps to the second");
+  PASS(CLOSE(valueAt(k, 3.0, layer), 0.0), "and to the last");
+
+  END_SET("a discrete animation does not interpolate")
+
+  START_SET("the mode a keyframe animation starts in")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  PASS([[k calculationMode] isEqualToString: kCAAnimationLinear],
+       "it interpolates unless told otherwise");
+
+  END_SET("the mode a keyframe animation starts in")
+
+  START_SET("a timing function for each stretch")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+  float straight = valueAt(k, 1.0, layer);
+
+  /* One function, so it shapes the first stretch and the second is left as
+     it was. */
+  [k setTimingFunctions: [NSArray arrayWithObject:
+    [CAMediaTimingFunction functionWithName: kCAMediaTimingFunctionEaseIn]]];
+
+  PASS(CLOSE(straight, 0.5), "without one the first stretch is a straight line");
+  PASS(valueAt(k, 1.0, layer) < straight,
+       "easing into the first stretch is behind it half way along");
+  PASS(CLOSE(valueAt(k, 2.0, layer), 1.0),
+       "and the stretch still ends where it did");
+
+  END_SET("a timing function for each stretch")
+
+  START_SET("time outside the duration")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = keyframes();
+
+  PASS(CLOSE(valueAt(k, 8.0, layer), 0.0),
+       "past the end it holds the last value rather than running off it");
+  PASS(CLOSE(valueAt(k, -1.0, layer), 0.0),
+       "and before the start it holds the first");
+
+  END_SET("time outside the duration")
+
+  START_SET("values that are not numbers")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGPoint first = CGPointMake(0, 0);
+  CGPoint second = CGPointMake(10, 20);
+  NSValue *v;
+  CGPoint p = CGPointMake(-1, -1);
+
+  [k setDuration: 2.0];
+  [k setValues: [NSArray arrayWithObjects:
+    [NSValue valueWithBytes: &first objCType: @encode(CGPoint)],
+    [NSValue valueWithBytes: &second objCType: @encode(CGPoint)], nil]];
+  v = [k calculatedAnimationValueAtTime: 1.0 onLayer: layer];
+  if (v != nil)
+    {
+      [v getValue: &p];
+    }
+
+  PASS(CLOSE(p.x, 5.0) && CLOSE(p.y, 10.0),
+       "points are interpolated between as a basic animation does");
+
+  END_SET("values that are not numbers")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/keyframes.m
@@ -160,6 +160,25 @@ int main(void)
 
   END_SET("time outside the duration")
 
+  START_SET("a keyframe animation with no duration")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  /* The values end somewhere other than they start, so that holding the
+     last one can be told apart from holding the first. */
+  [k setValues: [NSArray arrayWithObjects:
+    number(0.0), number(0.25), number(1.0), nil]];
+  [k setDuration: 0.0];
+
+  PASS(CLOSE(valueAt(k, 1.0, layer), 1.0),
+       "with no time to run through them it holds the last value");
+  PASS(CLOSE(valueAt(k, 0.0, layer), 1.0),
+       "and it holds it at the time it begins as well");
+
+  END_SET("a keyframe animation with no duration")
+
   START_SET("values that are not numbers")
 
   CALayer *layer = [CALayer layer];

--- a/Tests/quartzcore/CAKeyframeAnimation/paced.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/paced.m
@@ -103,8 +103,13 @@ int main(void)
 
   [k setCalculationMode: kCAAnimationCubicPaced];
 
-  PASS(CLOSE(pointAt(k, 1.0, layer).x, 55),
-       "cubic pacing paces as well, the smoothing not being calculated");
+  /* Cubic pacing places the values by distance as pacing does, and then
+     draws its curve through them, which moves the point a little off the
+     straight line between the two it falls between. */
+  PASS(fabs(pointAt(k, 1.0, layer).x - 55) < 1.5,
+       "cubic pacing paces as well, its curve moving the point only a little");
+  PASS(pointAt(k, 1.0, layer).x > 20,
+       "and nowhere near where an animation that did not pace would put it");
 
   END_SET("cubic pacing")
 

--- a/Tests/quartzcore/CAKeyframeAnimation/paced.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/paced.m
@@ -1,0 +1,234 @@
+/* A keyframe animation that covers the same distance in each moment.
+
+   Apple documents the contract this checks: a paced animation runs at a
+   constant velocity, and the keyTimes are ignored while it does.  The values
+   are therefore placed by the distance from one to the next rather than
+   evenly, which is what tells a paced animation apart from a linear one.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+   in Apple QuartzCore, so this file is named in APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-3)
+
+static NSValue *
+point(CGFloat x, CGFloat y)
+{
+  CGPoint p = CGPointMake(x, y);
+
+  return [NSValue valueWithBytes: &p objCType: @encode(CGPoint)];
+}
+
+static CGPoint
+pointAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  CGPoint p = CGPointMake(-1, -1);
+  NSValue *value = [k calculatedAnimationValueAtTime: time onLayer: layer];
+
+  if (value != nil)
+    {
+      [value getValue: &p];
+    }
+  return p;
+}
+
+static float
+numberAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  return [[k calculatedAnimationValueAtTime: time onLayer: layer] floatValue];
+}
+
+/* Two steps of very different size: ten across, then a hundred. */
+static CAKeyframeAnimation *
+unevenPoints(void)
+{
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+
+  [k setDuration: 2.0];
+  [k setValues: [NSArray arrayWithObjects:
+    point(0, 0), point(10, 0), point(110, 0), nil]];
+  return k;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("values spaced evenly when the animation is not paced")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = unevenPoints();
+
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 10),
+       "half way along a linear animation is at the middle value, however "
+       "far apart the values are");
+
+  END_SET("values spaced evenly when the animation is not paced")
+
+  START_SET("values spaced by distance when it is")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = unevenPoints();
+
+  [k setCalculationMode: kCAAnimationPaced];
+
+  PASS(CLOSE(pointAt(k, 0.0, layer).x, 0), "it starts at the first value");
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 55),
+       "half way along it has covered half the distance, not half the values");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 110), "and it ends at the last");
+
+  /* A tenth of the way is 11 of the 110 across, which is past the second
+     value rather than a tenth of the way to it. */
+  PASS(CLOSE(pointAt(k, 0.2, layer).x, 11),
+       "and the pace is the same at either end of the middle value");
+
+  END_SET("values spaced by distance when it is")
+
+  START_SET("cubic pacing")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = unevenPoints();
+
+  [k setCalculationMode: kCAAnimationCubicPaced];
+
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 55),
+       "cubic pacing paces as well, the smoothing not being calculated");
+
+  END_SET("cubic pacing")
+
+  START_SET("the key times of a paced animation")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = unevenPoints();
+
+  [k setCalculationMode: kCAAnimationPaced];
+  [k setKeyTimes: [NSArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.0],
+    [NSNumber numberWithFloat: 0.9],
+    [NSNumber numberWithFloat: 1.0], nil]];
+
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 55),
+       "key times say nothing about a paced animation and are not read");
+
+  END_SET("the key times of a paced animation")
+
+  START_SET("pacing numbers")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  [k setDuration: 2.0];
+  [k setValues: [NSArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.0],
+    [NSNumber numberWithFloat: 1.0],
+    [NSNumber numberWithFloat: 101.0], nil]];
+  [k setCalculationMode: kCAAnimationPaced];
+
+  PASS(CLOSE(numberAt(k, 1.0, layer), 50.5),
+       "numbers are paced by how far apart they are");
+
+  END_SET("pacing numbers")
+
+  START_SET("values that cannot be measured")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"transform"];
+  CATransform3D first = CATransform3DIdentity;
+  CATransform3D second = CATransform3DMakeScale(2, 2, 2);
+  CATransform3D third = CATransform3DMakeScale(3, 3, 3);
+  CATransform3D value;
+
+  [k setDuration: 2.0];
+  [k setValues: [NSArray arrayWithObjects:
+    [NSValue valueWithBytes: &first objCType: @encode(CATransform3D)],
+    [NSValue valueWithBytes: &second objCType: @encode(CATransform3D)],
+    [NSValue valueWithBytes: &third objCType: @encode(CATransform3D)], nil]];
+  [k setCalculationMode: kCAAnimationPaced];
+
+  value = CATransform3DIdentity;
+  [[k calculatedAnimationValueAtTime: 1.0 onLayer: layer] getValue: &value];
+
+  PASS(CLOSE(value.m11, 2.0),
+       "a transform has no distance to pace by, so it is spaced evenly");
+
+  END_SET("values that cannot be measured")
+
+  START_SET("pacing along a path")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  /* The same two uneven steps, as a path. */
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddLineToPoint(path, NULL, 10, 0);
+  CGPathAddLineToPoint(path, NULL, 110, 0);
+  [k setDuration: 2.0];
+  [k setPath: path];
+  CGPathRelease(path);
+
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 10),
+       "an unpaced path gives each line the same length of time");
+
+  [k setCalculationMode: kCAAnimationPaced];
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 55),
+       "a paced one gives each line time in proportion to its length");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 110), "and still ends at the end");
+
+  END_SET("pacing along a path")
+
+  START_SET("pacing along a curve")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+  CGPoint quarter, half, threeQuarters;
+  float first, second, third, fourth;
+
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddCurveToPoint(path, NULL, 0, 100, 100, 100, 100, 0);
+  [k setDuration: 4.0];
+  [k setPath: path];
+  [k setCalculationMode: kCAAnimationPaced];
+  CGPathRelease(path);
+
+  quarter = pointAt(k, 1.0, layer);
+  half = pointAt(k, 2.0, layer);
+  threeQuarters = pointAt(k, 3.0, layer);
+
+  PASS(CLOSE(half.x, 50), "half way along a symmetric curve is half way across");
+
+  /* Each quarter of the time should cover about a quarter of the curve. */
+  first = sqrt(quarter.x * quarter.x + quarter.y * quarter.y);
+  second = sqrt((half.x - quarter.x) * (half.x - quarter.x)
+                + (half.y - quarter.y) * (half.y - quarter.y));
+  third = sqrt((threeQuarters.x - half.x) * (threeQuarters.x - half.x)
+               + (threeQuarters.y - half.y) * (threeQuarters.y - half.y));
+  fourth = sqrt((100 - threeQuarters.x) * (100 - threeQuarters.x)
+                + threeQuarters.y * threeQuarters.y);
+
+  PASS(fabs(first - second) < 2.0 && fabs(second - third) < 2.0
+       && fabs(third - fourth) < 2.0,
+       "and each quarter of the time covers about as much of the curve");
+
+  END_SET("pacing along a curve")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/path.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/path.m
@@ -1,0 +1,190 @@
+/* A keyframe animation that follows a path.
+
+   Apple documents the contract this checks: for a property holding a CGPoint
+   the path stands in place of the values, the end of each line or curve is a
+   keyframe, a move-to is not one, and the points between two keyframes come
+   from the line or the curve itself.
+
+   -calculatedAnimationValueAtTime:onLayer: is GNUstep API with no counterpart
+   in Apple QuartzCore, so this file is named in APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+#include <math.h>
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAAnimation.h>
+
+/* Declared by the framework, not by a public header. */
+@interface CAPropertyAnimation (Interpolation)
+- (id) calculatedAnimationValueAtTime: (CFTimeInterval)theTime
+                              onLayer: (CALayer *)layer;
+@end
+
+#define CLOSE(a, b) (fabs((double)(a) - (double)(b)) < 1e-4)
+
+static CGPoint
+pointAt(CAKeyframeAnimation *k, CFTimeInterval time, CALayer *layer)
+{
+  CGPoint point = CGPointMake(-1, -1);
+  NSValue *value = [k calculatedAnimationValueAtTime: time onLayer: layer];
+
+  if (value != nil)
+    {
+      [value getValue: &point];
+    }
+  return point;
+}
+
+/* Two straight sides of a square, drawn over four seconds. */
+static CAKeyframeAnimation *
+cornerPath(void)
+{
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddLineToPoint(path, NULL, 100, 0);
+  CGPathAddLineToPoint(path, NULL, 100, 100);
+
+  [k setDuration: 4.0];
+  [k setPath: path];
+  CGPathRelease(path);
+  return k;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the path a keyframe animation is given")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  PASS([k path] == NULL, "an animation starts with no path");
+
+  CGPathMoveToPoint(path, NULL, 1, 2);
+  [k setPath: path];
+  PASS([k path] == path, "the path reads back as it was set");
+
+  [k setPath: NULL];
+  PASS([k path] == NULL, "and it can be taken away again");
+  CGPathRelease(path);
+
+  END_SET("the path a keyframe animation is given")
+
+  START_SET("running along a path of straight lines")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = cornerPath();
+
+  PASS(CLOSE(pointAt(k, 0.0, layer).x, 0)
+       && CLOSE(pointAt(k, 0.0, layer).y, 0),
+       "it starts where the path starts");
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 50)
+       && CLOSE(pointAt(k, 1.0, layer).y, 0),
+       "a quarter of the way along it is half way down the first side");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "half way along it is at the corner");
+  PASS(CLOSE(pointAt(k, 3.0, layer).x, 100)
+       && CLOSE(pointAt(k, 3.0, layer).y, 50),
+       "and then half way down the second side");
+  PASS(CLOSE(pointAt(k, 4.0, layer).x, 100)
+       && CLOSE(pointAt(k, 4.0, layer).y, 100),
+       "ending where the path ends");
+
+  END_SET("running along a path of straight lines")
+
+  START_SET("a path standing in place of the values")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = cornerPath();
+  CGPoint ignored = CGPointMake(-50, -50);
+
+  [k setValues: [NSArray arrayWithObject:
+    [NSValue valueWithBytes: &ignored objCType: @encode(CGPoint)]]];
+
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "the values are left alone while there is a path");
+
+  END_SET("a path standing in place of the values")
+
+  START_SET("running along a curve")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+  CGPoint middle;
+
+  /* A curve whose control points both sit above the straight line between
+     its ends, so the middle of it is above that line as well. */
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddCurveToPoint(path, NULL, 0, 100, 100, 100, 100, 0);
+  [k setDuration: 2.0];
+  [k setPath: path];
+  CGPathRelease(path);
+
+  PASS(CLOSE(pointAt(k, 0.0, layer).x, 0) && CLOSE(pointAt(k, 0.0, layer).y, 0),
+       "a curve starts where it starts");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "and ends where it ends");
+
+  middle = pointAt(k, 1.0, layer);
+  PASS(CLOSE(middle.x, 50), "half way along it is half way across");
+  PASS(CLOSE(middle.y, 75),
+       "and it is on the curve rather than on the line between the ends");
+
+  END_SET("running along a curve")
+
+  START_SET("stepping from point to point")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k = cornerPath();
+
+  [k setCalculationMode: kCAAnimationDiscrete];
+
+  PASS(CLOSE(pointAt(k, 1.0, layer).x, 0) && CLOSE(pointAt(k, 1.0, layer).y, 0),
+       "a discrete animation holds the point it started from");
+  PASS(CLOSE(pointAt(k, 2.0, layer).x, 100)
+       && CLOSE(pointAt(k, 2.0, layer).y, 0),
+       "then steps to the end of the first line");
+  PASS(CLOSE(pointAt(k, 4.0, layer).x, 100)
+       && CLOSE(pointAt(k, 4.0, layer).y, 100),
+       "and to the end of the last one");
+
+  END_SET("stepping from point to point")
+
+  START_SET("a move to in the middle of a path")
+
+  CALayer *layer = [CALayer layer];
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"position"];
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  /* Two separate lines.  The move-to between them is not a keyframe, so the
+     animation is in two halves, jumping across at the middle. */
+  CGPathMoveToPoint(path, NULL, 0, 0);
+  CGPathAddLineToPoint(path, NULL, 10, 0);
+  CGPathMoveToPoint(path, NULL, 50, 50);
+  CGPathAddLineToPoint(path, NULL, 60, 50);
+  [k setDuration: 2.0];
+  [k setPath: path];
+  CGPathRelease(path);
+
+  PASS(CLOSE(pointAt(k, 0.5, layer).x, 5) && CLOSE(pointAt(k, 0.5, layer).y, 0),
+       "the first half runs along the first line");
+  PASS(CLOSE(pointAt(k, 1.5, layer).x, 55)
+       && CLOSE(pointAt(k, 1.5, layer).y, 50),
+       "and the second along the second, the move-to not being a keyframe");
+
+  END_SET("a move to in the middle of a path")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CAKeyframeAnimation/properties.m
+++ b/Tests/quartzcore/CAKeyframeAnimation/properties.m
@@ -1,0 +1,69 @@
+/* What a keyframe animation holds.  These are Apple's properties and the
+   values below were measured against it. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("what it starts with")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+
+  PASS([CAKeyframeAnimation superclass] == [CAPropertyAnimation class],
+       "a keyframe animation is a property animation");
+  PASS([[k calculationMode] isEqualToString: kCAAnimationLinear],
+       "it interpolates between its values unless told otherwise");
+  PASS([k values] == nil, "with no values");
+  PASS([k keyTimes] == nil, "no key times");
+  PASS([k timingFunctions] == nil, "and no timing functions");
+
+  END_SET("what it starts with")
+
+  START_SET("the calculation modes")
+
+  PASS([kCAAnimationLinear isEqualToString: @"linear"], "linear");
+  PASS([kCAAnimationDiscrete isEqualToString: @"discrete"], "discrete");
+  PASS([kCAAnimationPaced isEqualToString: @"paced"], "paced");
+  PASS([kCAAnimationCubic isEqualToString: @"cubic"], "cubic");
+  PASS([kCAAnimationCubicPaced isEqualToString: @"cubicPaced"], "cubic paced");
+
+  END_SET("the calculation modes")
+
+  START_SET("what it answers for")
+
+  PASS([[CAKeyframeAnimation defaultValueForKey: @"calculationMode"]
+         isEqualToString: kCAAnimationLinear],
+       "the class names the mode it starts in");
+  PASS([CAKeyframeAnimation defaultValueForKey: @"values"] == nil,
+       "and names no values");
+
+  END_SET("what it answers for")
+
+  START_SET("the arrays are copied")
+
+  CAKeyframeAnimation *k =
+    [CAKeyframeAnimation animationWithKeyPath: @"opacity"];
+  NSMutableArray *given = [NSMutableArray arrayWithObjects:
+    [NSNumber numberWithFloat: 0.0], [NSNumber numberWithFloat: 1.0], nil];
+
+  [k setValues: given];
+  [given removeAllObjects];
+
+  PASS([[k values] count] == 2,
+       "emptying the array afterwards leaves the animation alone");
+
+  [k setCalculationMode: @"nonsense"];
+
+  PASS([[k calculationMode] isEqualToString: @"nonsense"],
+       "a mode it does not know is kept as it was given");
+
+  END_SET("the arrays are copied")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
fillMode is stored and never read, and Source/CAAnimation.m carries a FIXME saying so. Outside the active duration an animation applies its from value at both ends: -activeTimeWithTimeAuthorityLocalTime: clamps a negative active time to 0, and -localTimeWithTimeAuthority: takes the active time modulo the duration, which is near 0 after the end.

Apple: removed, the value an animation starts with, applies nothing outside the active duration; forwards applies the final value after it ends; backwards applies the initial value before it begins; both does each. -applyToLayer: now uses the unclamped active time, over the same active duration the layer uses to decide an animation is over. An autoreversing animation ends at its initial value.

-applyToLayer: also had no time source when applied to a layer directly, since -modelLayer returns nil until #35 lands. It falls back to the layer, as #65 does. Through a renderer the presentation layer has a model layer.

-calculatedAnimationValueAtTime:onLayer: still extrapolates past both ends, which #63 asserts.

Tests/quartzcore/CABasicAnimation/fillmode.m, named in APPLE_SKIP_TESTS as GNUstep API. 8 of its 11 assertions fail before the change: 414 passed becomes 422.
