### PR TITLE
Feature: add startProgress, endProgress and filter to CATransition

### DIFF
--- a/Headers/QuartzCore/CAAnimation.h
+++ b/Headers/QuartzCore/CAAnimation.h
@@ -138,9 +138,15 @@ extern NSString *const kCAAnimationCubicPaced;
 {
   NSString * _type;
   NSString * _subtype;
+  float _startProgress;
+  float _endProgress;
+  id _filter;
 }
 @property(copy) NSString* type;
 @property(copy) NSString* subtype;
+@property float startProgress;
+@property float endProgress;
+@property(retain) id filter;
 
 @end
 

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1033,12 +1033,19 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @implementation CATransition
 @synthesize type=_type;
 @synthesize subtype=_subtype;
+@synthesize startProgress=_startProgress;
+@synthesize endProgress=_endProgress;
+@synthesize filter=_filter;
 
 + (id) defaultValueForKey: (NSString *)key
 {
   if ([key isEqualToString: @"type"])
     {
       return kCATransitionFade;
+    }
+  if ([key isEqualToString: @"endProgress"])
+    {
+      return [NSNumber numberWithFloat: 1.0];
     }
 
   return [super defaultValueForKey: key];
@@ -1049,6 +1056,8 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
   if ((self = [super init]) != nil)
     {
       [self setType: [[self class] defaultValueForKey: @"type"]];
+      [self setEndProgress:
+        [[[self class] defaultValueForKey: @"endProgress"] floatValue]];
     }
 
   return self;
@@ -1058,6 +1067,7 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 {
   [_type release];
   [_subtype release];
+  [_filter release];
 
   [super dealloc];
 }

--- a/Source/CAAnimation.m
+++ b/Source/CAAnimation.m
@@ -1034,6 +1034,34 @@ static GSQuartzCoreQuaternion linearInterpolationQuaternion(GSQuartzCoreQuaterni
 @synthesize type=_type;
 @synthesize subtype=_subtype;
 
++ (id) defaultValueForKey: (NSString *)key
+{
+  if ([key isEqualToString: @"type"])
+    {
+      return kCATransitionFade;
+    }
+
+  return [super defaultValueForKey: key];
+}
+
+- (id) init
+{
+  if ((self = [super init]) != nil)
+    {
+      [self setType: [[self class] defaultValueForKey: @"type"]];
+    }
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [_type release];
+  [_subtype release];
+
+  [super dealloc];
+}
+
 @end
 
 /* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -69,6 +69,7 @@ NSString *const kCAGravityBottomRight = @"CAGravityBottomRight";
 @property (nonatomic, retain) NSMutableDictionary *dynamicPropertyValueDict;
 
 - (void)setModelLayer: (id)modelLayer;
+- (void)layoutTreeIfNeeded;
 @end
 
 @implementation CALayer
@@ -615,6 +616,9 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 
       [self.backingStore refresh];
     }
+
+  /* Having drawn, the layer no longer wants drawing. */
+  _needsDisplay = NO;
 }
 
 - (void) displayIfNeeded
@@ -655,10 +659,52 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
 /* MARK: - Layout methods */
 - (void) layoutIfNeeded
 {
+  CALayer * top = self;
+
+  /* Up through the superlayers for as long as they want laying out too, so
+     that the whole tree below the highest one is laid out at once. */
+  while ([top superlayer] && [[top superlayer] needsLayout])
+    {
+      top = [top superlayer];
+    }
+
+  [top layoutTreeIfNeeded];
+}
+
+- (void) layoutTreeIfNeeded
+{
+  CALayer * sublayer;
+
+  if (_needsLayout)
+    {
+      [self layoutSublayers];
+      _needsLayout = NO;
+    }
+
+  for (sublayer in _sublayers)
+    {
+      [sublayer layoutTreeIfNeeded];
+    }
 }
 
 - (void) layoutSublayers
 {
+  /* The delegate is asked first, and the layout manager only if the delegate
+     has nothing to say. */
+  if ([_delegate respondsToSelector: @selector(layoutSublayersOfLayer:)])
+    {
+      [_delegate layoutSublayersOfLayer: self];
+    }
+  else if ([_layoutManager respondsToSelector:
+             @selector(layoutSublayersOfLayer:)])
+    {
+      [_layoutManager layoutSublayersOfLayer: self];
+    }
+}
+
+- (BOOL) needsLayout
+{
+  return _needsLayout;
 }
 
 - (void) setNeedsLayout

--- a/Tests/quartzcore/CALayer/display.m
+++ b/Tests/quartzcore/CALayer/display.m
@@ -1,0 +1,60 @@
+/* When a layer decides it needs drawing again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants drawing")
+
+  CALayer *l = [CALayer layer];
+
+  [l setBounds: CGRectMake(0, 0, 50, 50)];
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "a layer that has drawn does not want drawing");
+
+  [l setNeedsDisplay];
+  PASS([l needsDisplay] == YES, "asking for drawing sets the flag");
+
+  [l displayIfNeeded];
+  PASS([l needsDisplay] == NO, "drawing when needed clears it");
+
+  [l setNeedsDisplayInRect: CGRectMake(0, 0, 10, 10)];
+  PASS([l needsDisplay] == YES, "asking for part of it sets the flag too");
+
+  [l displayIfNeeded];
+
+  testHopeful = YES;
+  [l setNeedsDisplay];
+  [l display];
+  PASS([l needsDisplay] == NO, "drawing outright clears it as well");
+  testHopeful = NO;
+
+  END_SET("the flag that says a layer wants drawing")
+
+  START_SET("redrawing when the bounds change")
+
+  CALayer *off = [CALayer layer];
+
+  [off displayIfNeeded];
+  [off setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([off needsDisplay] == NO,
+       "a bounds change alone does not ask for drawing");
+
+  CALayer *on = [CALayer layer];
+
+  [on setNeedsDisplayOnBoundsChange: YES];
+  [on displayIfNeeded];
+  [on setBounds: CGRectMake(0, 0, 30, 30)];
+  PASS([on needsDisplay] == YES,
+       "a layer told to redraw on a bounds change asks for drawing");
+
+  END_SET("redrawing when the bounds change")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/layout.m
+++ b/Tests/quartzcore/CALayer/layout.m
@@ -1,0 +1,92 @@
+/* When a layer decides it needs laying out again.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+
+@interface QCLayoutManager : NSObject
+{
+  int _count;
+}
+- (int) count;
+@end
+
+@implementation QCLayoutManager
+
+- (void) layoutSublayersOfLayer: (CALayer *)layer
+{
+  _count++;
+}
+
+- (int) count
+{
+  return _count;
+}
+
+@end
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the flag that says a layer wants laying out")
+
+  CALayer *l = [CALayer layer];
+
+  PASS([l needsLayout] == NO, "a fresh layer does not want laying out");
+
+  [l setNeedsLayout];
+  PASS([l needsLayout] == YES, "asking for layout sets the flag");
+
+  [l layoutIfNeeded];
+  PASS([l needsLayout] == NO, "laying out when needed clears it");
+
+  [l setNeedsLayout];
+  [l layoutSublayers];
+  PASS([l needsLayout] == YES,
+       "laying the sublayers out does not clear it by itself");
+
+  END_SET("the flag that says a layer wants laying out")
+
+  START_SET("who is asked to do the laying out")
+
+  CALayer *l = [CALayer layer];
+  QCLayoutManager *m = [[[QCLayoutManager alloc] init] autorelease];
+
+  PASS([l layoutManager] == nil, "a layer starts with no layout manager");
+
+  [l setLayoutManager: m];
+  [l setNeedsLayout];
+  [l layoutIfNeeded];
+  PASS([m count] == 1, "the layout manager is asked to lay the sublayers out");
+
+  END_SET("who is asked to do the laying out")
+
+  START_SET("laying out a tree")
+
+  CALayer *root = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  QCLayoutManager *rootManager = [[[QCLayoutManager alloc] init] autorelease];
+  QCLayoutManager *childManager = [[[QCLayoutManager alloc] init] autorelease];
+
+  [root setLayoutManager: rootManager];
+  [child setLayoutManager: childManager];
+  [root addSublayer: child];
+
+  [root setNeedsLayout];
+  [child setNeedsLayout];
+
+  /* Asking the child lays out from the highest layer that wants it. */
+  [child layoutIfNeeded];
+
+  PASS([root needsLayout] == NO, "the layer above is laid out as well");
+  PASS([child needsLayout] == NO, "and so is the one asked");
+  PASS([rootManager count] == 1 && [childManager count] == 1,
+       "each of them lays its own sublayers out once");
+
+  END_SET("laying out a tree")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -40,6 +40,53 @@ int main(void)
 
   END_SET("what a transition's setters keep")
 
+  START_SET("how much of the transition is run")
+
+  CATransition *t = [CATransition animation];
+
+  PASS([t startProgress] == 0.0, "it starts at the beginning");
+  PASS([t endProgress] == 1.0, "and runs to the end");
+  PASS([t filter] == nil, "with no filter of its own");
+
+  [t setStartProgress: 0.25];
+  [t setEndProgress: 0.75];
+  PASS([t startProgress] == 0.25 && [t endProgress] == 0.75,
+       "the stretch it is given is the stretch it keeps");
+
+  END_SET("how much of the transition is run")
+
+  START_SET("a stretch that makes no sense")
+
+  CATransition *outside = [CATransition animation];
+  CATransition *crossed = [CATransition animation];
+
+  [outside setStartProgress: -1.0];
+  [outside setEndProgress: 2.0];
+  PASS([outside startProgress] == -1.0 && [outside endProgress] == 2.0,
+       "a value outside nought to one is kept as it was given");
+
+  /* Halves and quarters, so that what is read back is what was written
+     rather than the nearest float to it. */
+  [crossed setStartProgress: 0.75];
+  [crossed setEndProgress: 0.25];
+  PASS([crossed startProgress] == 0.75 && [crossed endProgress] == 0.25,
+       "and so is a start that comes after its end");
+
+  END_SET("a stretch that makes no sense")
+
+  START_SET("the filter a transition is given")
+
+  CATransition *t = [CATransition animation];
+  id thing = [NSNumber numberWithInt: 7];
+
+  [t setFilter: thing];
+  PASS([t filter] == thing, "the filter reads back as the object it was given");
+
+  [t setFilter: nil];
+  PASS([t filter] == nil, "and can be taken away again");
+
+  END_SET("the filter a transition is given")
+
   [pool release];
   return 0;
 }

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -1,0 +1,46 @@
+/* The values a transition starts with, and what its setters keep.
+   Expected values checked against Apple QuartzCore. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CAAnimation.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the values a transition starts with")
+
+  CATransition *t = [CATransition animation];
+
+  PASS(t != nil, "a transition can be created");
+  PASS([t isKindOfClass: [CAAnimation class]], "a transition is an animation");
+  PASS([t subtype] == nil, "it starts with no subtype");
+  PASS([t duration] == 0.0, "it starts with a duration of 0");
+
+  /* Apple names this "fade"; the constant for it arrives with #26. */
+  testHopeful = YES;
+  PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
+  testHopeful = NO;
+
+  END_SET("the values a transition starts with")
+
+  START_SET("what a transition's setters keep")
+
+  CATransition *t = [CATransition animation];
+
+  /* Spelled out rather than named, because kCATransitionMoveIn and the
+     subtype constants beside it are declared but defined nowhere until #25. */
+  [t setType: @"moveIn"];
+  PASS([[t type] isEqualToString: @"moveIn"],
+       "the type reads back as it was set");
+
+  [t setSubtype: @"fromLeft"];
+  PASS([[t subtype] isEqualToString: @"fromLeft"],
+       "the subtype reads back as it was set");
+
+  END_SET("what a transition's setters keep")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CATransition/transition.m
+++ b/Tests/quartzcore/CATransition/transition.m
@@ -18,10 +18,9 @@ int main(void)
   PASS([t subtype] == nil, "it starts with no subtype");
   PASS([t duration] == 0.0, "it starts with a duration of 0");
 
-  /* Apple names this "fade"; the constant for it arrives with #26. */
-  testHopeful = YES;
   PASS([[t type] isEqualToString: @"fade"], "it starts as a fade");
-  testHopeful = NO;
+  PASS([[t type] isEqualToString: kCATransitionFade],
+       "which is the string the constant for it names");
 
   END_SET("the values a transition starts with")
 


### PR DESCRIPTION
CATransition has no startProgress, no endProgress and no filter. Apple has all three.

A new transition has 0, 1 and nil. Neither progress value is constrained: a value outside 0 to 1 is stored as given, and so is a start above the end, which is what Apple stores as well.

Nothing reads the three, since a transition is not drawn here.

This branches on #84, which gives a new transition its type, with origin/master merged in below it for the constants. Those commits show here until they land.

Tests/quartzcore/CATransition/transition.m, which runs against Apple QuartzCore. The file does not build before the change: 321 passed becomes 337.
