### PR TITLE
Feature: add mask, filters and the edge antialiasing properties to CALayer

### DIFF
--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -181,7 +181,7 @@ typedef unsigned int CAEdgeAntialiasingMask;
 @property (assign,getter=isGeometryFlipped) BOOL geometryFlipped; /* not supported yet */
 @property (nonatomic, assign)        CGColorRef backgroundColor; /* retained by CG */
 @property (assign)                   BOOL masksToBounds;
-@property (assign)                   CGRect contentsRect;
+@property (NONATOMIC_GSONLY,assign)  CGRect contentsRect;
 @property (assign,getter=isHidden)   BOOL hidden;
 @property (copy)                     NSString *contentsGravity;
 @property (assign)                   BOOL needsDisplayOnBoundsChange;
@@ -243,7 +243,7 @@ typedef unsigned int CAEdgeAntialiasingMask;
 @property (copy)                     NSArray *filters;
 @property (retain)                   id compositingFilter;
 @property (copy)                     NSArray *backgroundFilters;
-@property (assign)                   CGRect contentsCenter;
+@property (NONATOMIC_GSONLY,assign)  CGRect contentsCenter;
 @property (assign)                   CAEdgeAntialiasingMask edgeAntialiasingMask;
 @property (assign)                   float minificationFilterBias;
 @property (assign)                   BOOL allowsEdgeAntialiasing;

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -52,6 +52,16 @@ extern NSString *const kCAOnOrderIn;
 extern NSString *const kCAOnOrderOut;
 extern NSString *const kCATransition;
 
+/* the edges of a layer, for -edgeAntialiasingMask */
+enum
+{
+  kCALayerLeftEdge = 1U << 0,
+  kCALayerRightEdge = 1U << 1,
+  kCALayerBottomEdge = 1U << 2,
+  kCALayerTopEdge = 1U << 3
+};
+typedef unsigned int CAEdgeAntialiasingMask;
+
 @class CAAnimation;
 @class CARenderer;
 
@@ -99,6 +109,17 @@ extern NSString *const kCATransition;
   id _modelLayer;
   CGColorRef _borderColor;
   CGFloat _contentsScale;
+
+  CALayer * _mask;
+  NSArray * _filters;
+  NSArray * _backgroundFilters;
+  id _compositingFilter;
+  CGRect _contentsCenter;
+  CAEdgeAntialiasingMask _edgeAntialiasingMask;
+  float _minificationFilterBias;
+  BOOL _allowsEdgeAntialiasing;
+  BOOL _allowsGroupOpacity;
+  BOOL _drawsAsynchronously;
 
   CGColorRef _shadowColor;
   CGSize _shadowOffset;
@@ -216,6 +237,18 @@ extern NSString *const kCATransition;
 @property (nonatomic, assign) CGColorRef borderColor; /* retained by CG */
 @property (nonatomic, assign) CGFloat contentsScale;
 @property (nonatomic, assign) CGFloat anchorPointZ;
+
+/* The renderer does not read any of the following yet. */
+@property (retain)                   CALayer *mask;
+@property (copy)                     NSArray *filters;
+@property (retain)                   id compositingFilter;
+@property (copy)                     NSArray *backgroundFilters;
+@property (assign)                   CGRect contentsCenter;
+@property (assign)                   CAEdgeAntialiasingMask edgeAntialiasingMask;
+@property (assign)                   float minificationFilterBias;
+@property (assign)                   BOOL allowsEdgeAntialiasing;
+@property (assign)                   BOOL allowsGroupOpacity;
+@property (assign)                   BOOL drawsAsynchronously;
 @end
 
 @interface NSObject (CALayerActions)

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -122,6 +122,16 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 @synthesize borderColor=_borderColor;
 @synthesize contentsScale=_contentsScale;
 
+@synthesize filters=_filters;
+@synthesize backgroundFilters=_backgroundFilters;
+@synthesize compositingFilter=_compositingFilter;
+@synthesize contentsCenter=_contentsCenter;
+@synthesize edgeAntialiasingMask=_edgeAntialiasingMask;
+@synthesize minificationFilterBias=_minificationFilterBias;
+@synthesize allowsEdgeAntialiasing=_allowsEdgeAntialiasing;
+@synthesize allowsGroupOpacity=_allowsGroupOpacity;
+@synthesize drawsAsynchronously=_drawsAsynchronously;
+
 @synthesize shadowColor=_shadowColor;
 @synthesize shadowOffset=_shadowOffset;
 @synthesize shadowOpacity=_shadowOpacity;
@@ -217,7 +227,8 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       || [key isEqualToString: @"anchorPoint"]
       || [key isEqualToString: @"transform"]
       || [key isEqualToString: @"sublayerTransform"]
-      || [key isEqualToString: @"shadowOffset"])
+      || [key isEqualToString: @"shadowOffset"]
+      || [key isEqualToString: @"contentsCenter"])
     {
       return NO;
     }
@@ -283,6 +294,30 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
     {
       return [NSNumber numberWithFloat: 3.0];
     }
+  if ([key isEqualToString: @"contentsCenter"])
+    {
+      CGRect rect = CGRectMake(0.0, 0.0, 1.0, 1.0);
+      return [NSValue valueWithBytes: &rect objCType: @encode(CGRect)];
+    }
+  if ([key isEqualToString: @"allowsEdgeAntialiasing"])
+    {
+      return [NSNumber numberWithBool: YES];
+    }
+  if ([key isEqualToString: @"allowsGroupOpacity"])
+    {
+      return [NSNumber numberWithBool: YES];
+    }
+  if ([key isEqualToString: @"edgeAntialiasingMask"])
+    {
+      return [NSNumber numberWithUnsignedInt: kCALayerLeftEdge
+                                              | kCALayerRightEdge
+                                              | kCALayerBottomEdge
+                                              | kCALayerTopEdge];
+    }
+  if ([key isEqualToString: @"drawsAsynchronously"])
+    {
+      return [NSNumber numberWithBool: NO];
+    }
 
   /* CAMediaTiming */
   if ([key isEqualToString:@"duration"])
@@ -331,6 +366,9 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 
         @"shadowColor", @"shadowOffset", @"shadowOpacity",
         @"shadowPath", @"shadowRadius",
+
+        @"contentsCenter", @"allowsEdgeAntialiasing", @"allowsGroupOpacity",
+        @"edgeAntialiasingMask", @"drawsAsynchronously",
 
         @"bounds", @"position" };
 
@@ -431,6 +469,17 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       [self setNeedsDisplayOnBoundsChange: [layer needsDisplayOnBoundsChange]];
       [self setZPosition: [layer zPosition]];
 
+      [self setMask: [layer mask]];
+      [self setFilters: [layer filters]];
+      [self setBackgroundFilters: [layer backgroundFilters]];
+      [self setCompositingFilter: [layer compositingFilter]];
+      [self setContentsCenter: [layer contentsCenter]];
+      [self setEdgeAntialiasingMask: [layer edgeAntialiasingMask]];
+      [self setMinificationFilterBias: [layer minificationFilterBias]];
+      [self setAllowsEdgeAntialiasing: [layer allowsEdgeAntialiasing]];
+      [self setAllowsGroupOpacity: [layer allowsGroupOpacity]];
+      [self setDrawsAsynchronously: [layer drawsAsynchronously]];
+
       [self setShadowColor: [layer shadowColor]];
       [self setShadowOffset: [layer shadowOffset]];
       [self setShadowOpacity: [layer shadowOpacity]];
@@ -476,6 +525,11 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
   CGColorRelease(_borderColor);
   [_contentsGravity release];
   [_fillMode release];
+  [_mask setSuperlayer: nil];
+  [_mask release];
+  [_filters release];
+  [_backgroundFilters release];
+  [_compositingFilter release];
 
   [_backingStore release];
   [_animations release];
@@ -515,6 +569,7 @@ GSCA_OBSERVABLE_SETTER(setAnchorPoint, CGPoint, anchorPoint, CGPointEqualToPoint
 GSCA_OBSERVABLE_SETTER(setTransform, CATransform3D, transform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setSublayerTransform, CATransform3D, sublayerTransform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
+GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToRect)
 
 #else
 
@@ -650,6 +705,29 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   // NOTE: -takeNoteThatNextFrameTime is called due to the application not redrawing when
   // implicit animations are not created.
   [self takeNoteThatNextFrameTimeChanged];
+}
+
+- (CALayer *) mask
+{
+  return _mask;
+}
+
+/* A mask is not a sublayer, but it does have this layer as its superlayer,
+   so that a mask written in a coordinate system relative to this one can be
+   converted.  A layer that was somewhere else in the tree leaves it. */
+- (void) setMask: (CALayer *)mask
+{
+  if (mask == _mask)
+    return;
+
+  [self willChangeValueForKey: @"mask"];
+  [mask retain];
+  [mask removeFromSuperlayer];
+  [_mask setSuperlayer: nil];
+  [_mask release];
+  _mask = mask;
+  [_mask setSuperlayer: self];
+  [self didChangeValueForKey: @"mask"];
 }
 
 /* ***************** */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -228,6 +228,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       || [key isEqualToString: @"transform"]
       || [key isEqualToString: @"sublayerTransform"]
       || [key isEqualToString: @"shadowOffset"]
+      || [key isEqualToString: @"contentsRect"]
       || [key isEqualToString: @"contentsCenter"])
     {
       return NO;
@@ -569,6 +570,7 @@ GSCA_OBSERVABLE_SETTER(setAnchorPoint, CGPoint, anchorPoint, CGPointEqualToPoint
 GSCA_OBSERVABLE_SETTER(setTransform, CATransform3D, transform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setSublayerTransform, CATransform3D, sublayerTransform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
+GSCA_OBSERVABLE_SETTER(setContentsRect, CGRect, contentsRect, CGRectEqualToRect)
 GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToRect)
 
 #else

--- a/Tests/quartzcore/CALayer/masking.m
+++ b/Tests/quartzcore/CALayer/masking.m
@@ -1,0 +1,180 @@
+/* The layer properties that describe masking, filtering and edge
+   antialiasing.  Every expected value here was measured against Apple
+   QuartzCore, including the ones that are not obvious: a layer allows both
+   edge antialiasing and group opacity from the start, all four edges are in
+   the antialiasing mask, the contents centre is the unit rectangle, and a
+   layer used as a mask takes the masking layer as its superlayer without
+   becoming one of its sublayers. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+static BOOL eq(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+  if (d < 0) d = -d;
+  return d < 1e-4;
+}
+
+static BOOL req(CGRect r, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
+{
+  return eq(r.origin.x, x) && eq(r.origin.y, y)
+      && eq(r.size.width, w) && eq(r.size.height, h);
+}
+
+static void defaults(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([l allowsEdgeAntialiasing] == YES,
+       "a new layer allows edge antialiasing");
+  PASS([l allowsGroupOpacity] == YES, "a new layer allows group opacity");
+  PASS([l edgeAntialiasingMask] == (kCALayerLeftEdge | kCALayerRightEdge
+                                    | kCALayerBottomEdge | kCALayerTopEdge),
+       "all four edges are antialiased to begin with");
+  PASS([l drawsAsynchronously] == NO, "a new layer does not draw off thread");
+  PASS(eq([l minificationFilterBias], 0),
+       "a new layer has no minification filter bias");
+  PASS([l filters] == nil, "a new layer has no filters");
+  PASS([l compositingFilter] == nil, "a new layer has no compositing filter");
+  PASS([l backgroundFilters] == nil, "a new layer has no background filters");
+  PASS([l mask] == nil, "a new layer has no mask");
+  PASS(req([l contentsCenter], 0, 0, 1, 1),
+       "the contents centre starts as the whole unit rectangle");
+}
+
+static void edgeConstants(void)
+{
+  PASS(kCALayerLeftEdge == 1, "the left edge is bit zero");
+  PASS(kCALayerRightEdge == 2, "the right edge is bit one");
+  PASS(kCALayerBottomEdge == 4, "the bottom edge is bit two");
+  PASS(kCALayerTopEdge == 8, "the top edge is bit three");
+}
+
+static void roundTrips(void)
+{
+  CALayer *l = [CALayer layer];
+
+  [l setAllowsEdgeAntialiasing: NO];
+  PASS([l allowsEdgeAntialiasing] == NO, "edge antialiasing can be turned off");
+  [l setAllowsGroupOpacity: NO];
+  PASS([l allowsGroupOpacity] == NO, "group opacity can be turned off");
+  [l setDrawsAsynchronously: YES];
+  PASS([l drawsAsynchronously] == YES, "asynchronous drawing can be asked for");
+  [l setEdgeAntialiasingMask: kCALayerLeftEdge | kCALayerTopEdge];
+  PASS([l edgeAntialiasingMask] == (kCALayerLeftEdge | kCALayerTopEdge),
+       "the edge mask reads back the edges it was given");
+  [l setMinificationFilterBias: 0.25];
+  PASS(eq([l minificationFilterBias], 0.25),
+       "the minification filter bias reads back what was set");
+
+  [l setContentsCenter: CGRectMake(0.25, 0.25, 0.5, 0.5)];
+  PASS(req([l contentsCenter], 0.25, 0.25, 0.5, 0.5),
+       "the contents centre reads back what was set");
+  [l setContentsCenter: CGRectMake(-1, -1, 4, 4)];
+  PASS(req([l contentsCenter], -1, -1, 4, 4),
+       "a contents centre outside the unit rectangle is kept unchecked");
+}
+
+static void filters(void)
+{
+  CALayer *l = [CALayer layer];
+  NSMutableArray *given = [NSMutableArray arrayWithObject: @"one"];
+
+  [l setFilters: given];
+  PASS([[l filters] count] == 1, "the filter array holds what it was given");
+  PASS([l filters] != given, "setting the filters copies the array");
+  [given addObject: @"two"];
+  PASS([[l filters] count] == 1,
+       "so a later change to the original does not reach the layer");
+  [l setFilters: nil];
+  PASS([l filters] == nil, "the filters can be taken away again");
+
+  [l setBackgroundFilters: [NSArray arrayWithObject: @"one"]];
+  PASS([[l backgroundFilters] count] == 1,
+       "the background filter array holds what it was given");
+
+  id filter = [NSObject new];
+  [l setCompositingFilter: filter];
+  PASS([l compositingFilter] == filter,
+       "the compositing filter is the object it was given");
+  [filter release];
+  [l setCompositingFilter: nil];
+  PASS([l compositingFilter] == nil,
+       "the compositing filter can be taken away again");
+}
+
+static void mask(void)
+{
+  CALayer *host = [CALayer layer];
+  CALayer *m = [CALayer layer];
+
+  [host setMask: m];
+  PASS([host mask] == m, "the mask is the layer it was given");
+  PASS([m superlayer] == host, "a mask takes the masked layer as superlayer");
+  PASS([[host sublayers] count] == 0, "but it does not become a sublayer");
+
+  [host setMask: nil];
+  PASS([host mask] == nil, "the mask can be taken away");
+  PASS([m superlayer] == nil, "which leaves the old mask with no superlayer");
+
+  CALayer *parent = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  [parent addSublayer: child];
+  CALayer *other = [CALayer layer];
+  [other setMask: child];
+  PASS([child superlayer] == other,
+       "a layer already in a tree takes the masking layer as superlayer");
+  PASS([[parent sublayers] count] == 0, "and leaves the tree it was in");
+}
+
+static void classDefaults(void)
+{
+  id v;
+
+  v = [CALayer defaultValueForKey: @"allowsEdgeAntialiasing"];
+  PASS(v != nil && [v boolValue] == YES,
+       "the class default allows edge antialiasing");
+  v = [CALayer defaultValueForKey: @"allowsGroupOpacity"];
+  PASS(v != nil && [v boolValue] == YES,
+       "the class default allows group opacity");
+  v = [CALayer defaultValueForKey: @"edgeAntialiasingMask"];
+  PASS(v != nil && [v unsignedIntValue] == 15,
+       "the class default antialiases all four edges");
+  v = [CALayer defaultValueForKey: @"drawsAsynchronously"];
+  PASS(v != nil && [v boolValue] == NO,
+       "the class default does not draw off thread");
+  v = [CALayer defaultValueForKey: @"contentsCenter"];
+  PASS(v != nil, "the class has a default contents centre");
+
+  PASS([CALayer defaultValueForKey: @"minificationFilterBias"] == nil,
+       "the class has no default minification filter bias");
+  PASS([CALayer defaultValueForKey: @"filters"] == nil,
+       "the class has no default filters");
+  PASS([CALayer defaultValueForKey: @"compositingFilter"] == nil,
+       "the class has no default compositing filter");
+  PASS([CALayer defaultValueForKey: @"backgroundFilters"] == nil,
+       "the class has no default background filters");
+  PASS([CALayer defaultValueForKey: @"mask"] == nil,
+       "the class has no default mask");
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("layer masking and filtering")
+
+  defaults();
+  edgeConstants();
+  roundTrips();
+  filters();
+  mask();
+  classDefaults();
+
+  END_SET("layer masking and filtering")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/masking.m
+++ b/Tests/quartzcore/CALayer/masking.m
@@ -75,6 +75,13 @@ static void roundTrips(void)
   [l setContentsCenter: CGRectMake(-1, -1, 4, 4)];
   PASS(req([l contentsCenter], -1, -1, 4, 4),
        "a contents centre outside the unit rectangle is kept unchecked");
+
+  /* contentsRect is the same shape of property and had the same defect. */
+  PASS(req([l contentsRect], 0, 0, 1, 1),
+       "the contents rectangle starts as the whole unit rectangle");
+  [l setContentsRect: CGRectMake(0.25, 0.25, 0.5, 0.5)];
+  PASS(req([l contentsRect], 0.25, 0.25, 0.5, 0.5),
+       "the contents rectangle reads back what was set");
 }
 
 static void filters(void)


### PR DESCRIPTION
CALayer is missing ten properties Apple declares: mask, filters,
backgroundFilters, compositingFilter, contentsCenter, edgeAntialiasingMask,
minificationFilterBias, allowsEdgeAntialiasing, allowsGroupOpacity and
drawsAsynchronously.

They are added as stored properties with the defaults Apple answers: edge
antialiasing and group opacity are on, all four edges are in the antialiasing
mask, and the contents centre is the unit rectangle. CAEdgeAntialiasingMask
and the four kCALayer edge constants are new in CALayer.h. -setMask: takes
the masked layer as the mask's superlayer and removes the mask from any tree
it was in, as Apple does; a mask does not become a sublayer.

The second commit fixes a defect the first one uncovered. -setContentsRect:
read back uninitialised memory: contentsRect was the one struct-typed key
registered for implicit animation that +automaticallyNotifiesObserversForKey:
did not exclude, so GNUstep replaced its setter with one that mishandles a
CGRect argument.

The renderer reads none of the new properties yet, so a mask or a filter
changes nothing on screen.

Tests/quartzcore/CALayer/masking.m, 47 assertions, runs on Apple. Before the
change that file does not build and the suite is 305 passed, 9 dashed. After
it is 352 passed, 9 dashed, none failed.
