### PR TITLE
Feature: place the contents by gravity, and clip a layer that masks its bounds

### DIFF
--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -143,6 +143,8 @@ typedef unsigned int CAEdgeAntialiasingMask;
   NSMutableDictionary *_animations;
   NSMutableArray *_animationKeys;
   NSMutableArray *_observedKeyPaths;
+  NSMutableArray *_archivingKeyPaths;
+  NSMutableSet *_valuesThatWereSet;
   CABackingStore * _backingStore;
 
   /* TODO: add CAGLSimpleFramebuffer ivars for storing:
@@ -233,6 +235,9 @@ typedef unsigned int CAEdgeAntialiasingMask;
 
 - (CGAffineTransform) affineTransform;
 - (void) setAffineTransform: (CGAffineTransform)affineTransform;
+
+- (BOOL) contentsAreFlipped;
+- (BOOL) shouldArchiveValueForKey: (NSString *)key;
 
 @property (nonatomic, assign) CGColorRef borderColor; /* retained by CG */
 @property (nonatomic, assign) CGFloat contentsScale;

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -240,6 +240,7 @@ typedef unsigned int CAAutoresizingMask;
 - (void) setNeedsDisplay;
 - (void) setNeedsDisplayInRect: (CGRect)r;
 - (void) drawInContext: (CGContextRef)context;
+- (void) renderInContext: (CGContextRef)context;
 - (BOOL) needsLayout;
 - (void) setNeedsLayout;
 - (void) layoutIfNeeded;

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -62,6 +62,19 @@ enum
 };
 typedef unsigned int CAEdgeAntialiasingMask;
 
+/* which parts of a layer give way when its superlayer is resized */
+enum
+{
+  kCALayerNotSizable = 0,
+  kCALayerMinXMargin = 1U << 0,
+  kCALayerWidthSizable = 1U << 1,
+  kCALayerMaxXMargin = 1U << 2,
+  kCALayerMinYMargin = 1U << 3,
+  kCALayerHeightSizable = 1U << 4,
+  kCALayerMaxYMargin = 1U << 5
+};
+typedef unsigned int CAAutoresizingMask;
+
 @class CAAnimation;
 @class CARenderer;
 
@@ -116,6 +129,7 @@ typedef unsigned int CAEdgeAntialiasingMask;
   id _compositingFilter;
   CGRect _contentsCenter;
   CAEdgeAntialiasingMask _edgeAntialiasingMask;
+  CAAutoresizingMask _autoresizingMask;
   float _minificationFilterBias;
   BOOL _allowsEdgeAntialiasing;
   BOOL _allowsGroupOpacity;
@@ -239,6 +253,9 @@ typedef unsigned int CAEdgeAntialiasingMask;
 - (BOOL) contentsAreFlipped;
 - (BOOL) shouldArchiveValueForKey: (NSString *)key;
 
+- (void) resizeWithOldSuperlayerSize: (CGSize)size;
+- (void) resizeSublayersWithOldSize: (CGSize)size;
+
 @property (nonatomic, assign) CGColorRef borderColor; /* retained by CG */
 @property (nonatomic, assign) CGFloat contentsScale;
 @property (nonatomic, assign) CGFloat anchorPointZ;
@@ -254,6 +271,7 @@ typedef unsigned int CAEdgeAntialiasingMask;
 @property (assign)                   BOOL allowsEdgeAntialiasing;
 @property (assign)                   BOOL allowsGroupOpacity;
 @property (assign)                   BOOL drawsAsynchronously;
+@property (assign)                   CAAutoresizingMask autoresizingMask;
 @end
 
 @interface NSObject (CALayerActions)

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -181,7 +181,7 @@ typedef unsigned int CAEdgeAntialiasingMask;
 @property (assign,getter=isGeometryFlipped) BOOL geometryFlipped; /* not supported yet */
 @property (nonatomic, assign)        CGColorRef backgroundColor; /* retained by CG */
 @property (assign)                   BOOL masksToBounds;
-@property (assign)                   CGRect contentsRect;
+@property (NONATOMIC_GSONLY,assign)  CGRect contentsRect;
 @property (assign,getter=isHidden)   BOOL hidden;
 @property (copy)                     NSString *contentsGravity;
 @property (assign)                   BOOL needsDisplayOnBoundsChange;
@@ -243,7 +243,7 @@ typedef unsigned int CAEdgeAntialiasingMask;
 @property (copy)                     NSArray *filters;
 @property (retain)                   id compositingFilter;
 @property (copy)                     NSArray *backgroundFilters;
-@property (assign)                   CGRect contentsCenter;
+@property (NONATOMIC_GSONLY,assign)  CGRect contentsCenter;
 @property (assign)                   CAEdgeAntialiasingMask edgeAntialiasingMask;
 @property (assign)                   float minificationFilterBias;
 @property (assign)                   BOOL allowsEdgeAntialiasing;

--- a/Headers/QuartzCore/CALayer.h
+++ b/Headers/QuartzCore/CALayer.h
@@ -52,6 +52,16 @@ extern NSString *const kCAOnOrderIn;
 extern NSString *const kCAOnOrderOut;
 extern NSString *const kCATransition;
 
+/* the edges of a layer, for -edgeAntialiasingMask */
+enum
+{
+  kCALayerLeftEdge = 1U << 0,
+  kCALayerRightEdge = 1U << 1,
+  kCALayerBottomEdge = 1U << 2,
+  kCALayerTopEdge = 1U << 3
+};
+typedef unsigned int CAEdgeAntialiasingMask;
+
 @class CAAnimation;
 @class CARenderer;
 
@@ -99,6 +109,17 @@ extern NSString *const kCATransition;
   id _modelLayer;
   CGColorRef _borderColor;
   CGFloat _contentsScale;
+
+  CALayer * _mask;
+  NSArray * _filters;
+  NSArray * _backgroundFilters;
+  id _compositingFilter;
+  CGRect _contentsCenter;
+  CAEdgeAntialiasingMask _edgeAntialiasingMask;
+  float _minificationFilterBias;
+  BOOL _allowsEdgeAntialiasing;
+  BOOL _allowsGroupOpacity;
+  BOOL _drawsAsynchronously;
 
   CGColorRef _shadowColor;
   CGSize _shadowOffset;
@@ -216,6 +237,18 @@ extern NSString *const kCATransition;
 @property (nonatomic, assign) CGColorRef borderColor; /* retained by CG */
 @property (nonatomic, assign) CGFloat contentsScale;
 @property (nonatomic, assign) CGFloat anchorPointZ;
+
+/* The renderer does not read any of the following yet. */
+@property (retain)                   CALayer *mask;
+@property (copy)                     NSArray *filters;
+@property (retain)                   id compositingFilter;
+@property (copy)                     NSArray *backgroundFilters;
+@property (assign)                   CGRect contentsCenter;
+@property (assign)                   CAEdgeAntialiasingMask edgeAntialiasingMask;
+@property (assign)                   float minificationFilterBias;
+@property (assign)                   BOOL allowsEdgeAntialiasing;
+@property (assign)                   BOOL allowsGroupOpacity;
+@property (assign)                   BOOL drawsAsynchronously;
 @end
 
 @interface NSObject (CALayerActions)

--- a/Source/CAArchivingObserver.h
+++ b/Source/CAArchivingObserver.h
@@ -1,0 +1,35 @@
+/* CAArchivingObserver.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+/* Notes on a layer which of its properties have been given a value, which is
+   what -[CALayer shouldArchiveValueForKey:] answers. */
+@interface CAArchivingObserver : NSObject
+{
+}
+
++ (CAArchivingObserver *)sharedObserver;
+- (void)observeValueForKeyPath: (NSString *)keyPath ofObject: (id)object change: (NSDictionary *)change context: (void *)context;
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CAArchivingObserver.m
+++ b/Source/CAArchivingObserver.m
@@ -1,0 +1,52 @@
+/* CAArchivingObserver.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#import "CAArchivingObserver.h"
+#import "CALayer+FrameworkPrivate.h"
+#import "QuartzCore/CALayer.h"
+
+static CAArchivingObserver * sharedObserver;
+
+@implementation CAArchivingObserver
++ (CAArchivingObserver *)sharedObserver
+{
+  if (!sharedObserver)
+    {
+      sharedObserver = [CAArchivingObserver new];
+    }
+
+  return sharedObserver;
+}
+
+- (void) observeValueForKeyPath: (NSString *)keyPath
+                       ofObject: (id)object
+                         change: (NSDictionary *)change
+                        context: (void *)context
+{
+  [(CALayer *)object noteValueWasSetForKey: keyPath];
+}
+
+@end
+
+/* vim: set cindent cinoptions=>4,n-2,{2,^-2,:2,=2,g0,h2,p5,t0,+2,(0,u0,w1,m1 expandtabs shiftwidth=2 tabstop=8: */

--- a/Source/CAGravity.h
+++ b/Source/CAGravity.h
@@ -1,0 +1,33 @@
+/* CAGravity.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import <Foundation/Foundation.h>
+#if GNUSTEP
+#import <CoreGraphics/CoreGraphics.h>
+#endif
+
+/* The rectangle, in a layer's bounds coordinates, that contents of the given
+   size occupy under the given gravity.  Both renderers ask this so that they
+   place the contents the same way. */
+CGRect CAGravityDestinationRect(NSString *gravity, CGRect bounds,
+                                CGSize contentsSize);

--- a/Source/CAGravity.m
+++ b/Source/CAGravity.m
@@ -1,0 +1,85 @@
+/* CAGravity.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   This file is part of QuartzCore.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#import "CAGravity.h"
+#import "QuartzCore/CALayer.h"
+
+CGRect
+CAGravityDestinationRect(NSString *gravity, CGRect bounds,
+                         CGSize contentsSize)
+{
+  CGSize size = contentsSize;
+  CGFloat x, y;
+
+  if (contentsSize.width <= 0 || contentsSize.height <= 0
+      || bounds.size.width <= 0 || bounds.size.height <= 0)
+    return CGRectZero;
+
+  /* The three resizing gravities decide a size; the other nine keep the
+     contents at their own size and only decide where they sit. */
+  if ([gravity isEqualToString: kCAGravityResize])
+    {
+      return bounds;
+    }
+  else if ([gravity isEqualToString: kCAGravityResizeAspect]
+           || [gravity isEqualToString: kCAGravityResizeAspectFill])
+    {
+      CGFloat wide = bounds.size.width / contentsSize.width;
+      CGFloat high = bounds.size.height / contentsSize.height;
+      CGFloat scale;
+
+      if ([gravity isEqualToString: kCAGravityResizeAspect])
+        scale = wide < high ? wide : high;
+      else
+        scale = wide > high ? wide : high;
+
+      size.width = contentsSize.width * scale;
+      size.height = contentsSize.height * scale;
+    }
+
+  /* Left, right, top and bottom pin one axis and centre the other. */
+  if ([gravity isEqualToString: kCAGravityLeft]
+      || [gravity isEqualToString: kCAGravityTopLeft]
+      || [gravity isEqualToString: kCAGravityBottomLeft])
+    x = 0;
+  else if ([gravity isEqualToString: kCAGravityRight]
+           || [gravity isEqualToString: kCAGravityTopRight]
+           || [gravity isEqualToString: kCAGravityBottomRight])
+    x = bounds.size.width - size.width;
+  else
+    x = (bounds.size.width - size.width) / 2.0;
+
+  if ([gravity isEqualToString: kCAGravityBottom]
+      || [gravity isEqualToString: kCAGravityBottomLeft]
+      || [gravity isEqualToString: kCAGravityBottomRight])
+    y = 0;
+  else if ([gravity isEqualToString: kCAGravityTop]
+           || [gravity isEqualToString: kCAGravityTopLeft]
+           || [gravity isEqualToString: kCAGravityTopRight])
+    y = bounds.size.height - size.height;
+  else
+    y = (bounds.size.height - size.height) / 2.0;
+
+  return CGRectMake(bounds.origin.x + x, bounds.origin.y + y,
+                    size.width, size.height);
+}

--- a/Source/CALayer+FrameworkPrivate.h
+++ b/Source/CALayer+FrameworkPrivate.h
@@ -47,6 +47,8 @@
 - (CFTimeInterval) activeTime;
 - (CFTimeInterval) localTime;
 
+- (void) noteValueWasSetForKey: (NSString *)key;
+
 @property (retain) CABackingStore * backingStore;
 @property (assign) CARenderer * renderer;
 @end

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -796,6 +796,109 @@ GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToR
   [self didChangeValueForKey: @"mask"];
 }
 
+/* *************************** */
+/* MARK: - Drawing into a context */
+
+/* Move the coordinate system to where a sublayer stands in its superlayer:
+   to the sublayer's position, turned by its transform about its anchor
+   point, back by the anchor point, and back again by the origin of the
+   sublayer's own bounds, so that afterwards the sublayer's bounds
+   coordinates are the coordinates of the context. */
+static void
+CALayerPlaceInContext(CALayer * layer, CGContextRef context)
+{
+  CGRect bounds = [layer bounds];
+  CGPoint anchor = [layer anchorPoint];
+  CGPoint position = [layer position];
+
+  CGContextTranslateCTM(context, position.x, position.y);
+  CGContextConcatCTM(context, CALayerAffineOf([layer transform]));
+  CGContextTranslateCTM(context, -anchor.x * bounds.size.width,
+                        -anchor.y * bounds.size.height);
+  CGContextTranslateCTM(context, -bounds.origin.x, -bounds.origin.y);
+}
+
+/* Turn the coordinate system by the layer's sublayerTransform, about the
+   layer's anchor point, before its sublayers are drawn. */
+static void
+CALayerApplySublayerTransform(CALayer * layer, CGContextRef context)
+{
+  CGRect bounds = [layer bounds];
+  CGPoint anchor = [layer anchorPoint];
+  CGFloat pivotX = bounds.origin.x + anchor.x * bounds.size.width;
+  CGFloat pivotY = bounds.origin.y + anchor.y * bounds.size.height;
+
+  CGContextTranslateCTM(context, pivotX, pivotY);
+  CGContextConcatCTM(context, CALayerAffineOf([layer sublayerTransform]));
+  CGContextTranslateCTM(context, -pivotX, -pivotY);
+}
+
+/* The layer is drawn in the coordinates of the context as they stand, so
+   where the layer itself is positioned in its own superlayer, and any
+   transform on it, do not come into it.  Its sublayers are placed around it
+   as usual, which is what moves the coordinate system for the calls further
+   down. */
+- (void) renderInContext: (CGContextRef)context
+{
+  CGRect area = [self bounds];
+  id layerContents = [self contents];
+  CALayer * sublayer;
+
+  if (context == NULL || [self isHidden] || [self opacity] <= 0.0)
+    return;
+
+  CGContextSaveGState(context);
+  CGContextSetAlpha(context, [self opacity]);
+
+  if ([self masksToBounds])
+    {
+      CGContextClipToRect(context, area);
+    }
+
+  if ([self backgroundColor])
+    {
+      CGContextSetFillColorWithColor(context, [self backgroundColor]);
+      CGContextFillRect(context, area);
+    }
+
+  /* The contents are whatever -display left there, which is a backing store
+     of this framework's own or an image the caller set.  Nothing is drawn
+     for a layer that was never displayed, and -drawInContext: is not called
+     from here. */
+#if GNUSTEP
+  if ([layerContents isKindOfClass: NSClassFromString(@"CGImage")])
+#else
+  if ([layerContents isKindOfClass: NSClassFromString(@"__NSCFType")]
+      && CFGetTypeID(layerContents) == CGImageGetTypeID())
+#endif
+    {
+      CGContextDrawImage(context, area, (CGImageRef)layerContents);
+    }
+  else if ([layerContents isKindOfClass: [CABackingStore class]])
+    {
+      CGImageRef image;
+
+      image = CGBitmapContextCreateImage([(CABackingStore *)layerContents
+                                           context]);
+      if (image)
+        {
+          CGContextDrawImage(context, area, image);
+          CGImageRelease(image);
+        }
+    }
+
+  CALayerApplySublayerTransform(self, context);
+  for (sublayer in [self sublayers])
+    {
+      CGContextSaveGState(context);
+      CALayerPlaceInContext(sublayer, context);
+      [sublayer renderInContext: context];
+      CGContextRestoreGState(context);
+    }
+
+  CGContextRestoreGState(context);
+}
+
 /* ******************** */
 /* MARK: - Autoresizing */
 

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -122,6 +122,16 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 @synthesize borderColor=_borderColor;
 @synthesize contentsScale=_contentsScale;
 
+@synthesize filters=_filters;
+@synthesize backgroundFilters=_backgroundFilters;
+@synthesize compositingFilter=_compositingFilter;
+@synthesize contentsCenter=_contentsCenter;
+@synthesize edgeAntialiasingMask=_edgeAntialiasingMask;
+@synthesize minificationFilterBias=_minificationFilterBias;
+@synthesize allowsEdgeAntialiasing=_allowsEdgeAntialiasing;
+@synthesize allowsGroupOpacity=_allowsGroupOpacity;
+@synthesize drawsAsynchronously=_drawsAsynchronously;
+
 @synthesize shadowColor=_shadowColor;
 @synthesize shadowOffset=_shadowOffset;
 @synthesize shadowOpacity=_shadowOpacity;
@@ -217,7 +227,8 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       || [key isEqualToString: @"anchorPoint"]
       || [key isEqualToString: @"transform"]
       || [key isEqualToString: @"sublayerTransform"]
-      || [key isEqualToString: @"shadowOffset"])
+      || [key isEqualToString: @"shadowOffset"]
+      || [key isEqualToString: @"contentsCenter"])
     {
       return NO;
     }
@@ -283,6 +294,30 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
     {
       return [NSNumber numberWithFloat: 3.0];
     }
+  if ([key isEqualToString: @"contentsCenter"])
+    {
+      CGRect rect = CGRectMake(0.0, 0.0, 1.0, 1.0);
+      return [NSValue valueWithBytes: &rect objCType: @encode(CGRect)];
+    }
+  if ([key isEqualToString: @"allowsEdgeAntialiasing"])
+    {
+      return [NSNumber numberWithBool: YES];
+    }
+  if ([key isEqualToString: @"allowsGroupOpacity"])
+    {
+      return [NSNumber numberWithBool: YES];
+    }
+  if ([key isEqualToString: @"edgeAntialiasingMask"])
+    {
+      return [NSNumber numberWithUnsignedInt: kCALayerLeftEdge
+                                              | kCALayerRightEdge
+                                              | kCALayerBottomEdge
+                                              | kCALayerTopEdge];
+    }
+  if ([key isEqualToString: @"drawsAsynchronously"])
+    {
+      return [NSNumber numberWithBool: NO];
+    }
 
   /* CAMediaTiming */
   if ([key isEqualToString:@"duration"])
@@ -331,6 +366,9 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 
         @"shadowColor", @"shadowOffset", @"shadowOpacity",
         @"shadowPath", @"shadowRadius",
+
+        @"contentsCenter", @"allowsEdgeAntialiasing", @"allowsGroupOpacity",
+        @"edgeAntialiasingMask", @"drawsAsynchronously",
 
         @"bounds", @"position" };
 
@@ -431,6 +469,17 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       [self setNeedsDisplayOnBoundsChange: [layer needsDisplayOnBoundsChange]];
       [self setZPosition: [layer zPosition]];
 
+      [self setMask: [layer mask]];
+      [self setFilters: [layer filters]];
+      [self setBackgroundFilters: [layer backgroundFilters]];
+      [self setCompositingFilter: [layer compositingFilter]];
+      [self setContentsCenter: [layer contentsCenter]];
+      [self setEdgeAntialiasingMask: [layer edgeAntialiasingMask]];
+      [self setMinificationFilterBias: [layer minificationFilterBias]];
+      [self setAllowsEdgeAntialiasing: [layer allowsEdgeAntialiasing]];
+      [self setAllowsGroupOpacity: [layer allowsGroupOpacity]];
+      [self setDrawsAsynchronously: [layer drawsAsynchronously]];
+
       [self setShadowColor: [layer shadowColor]];
       [self setShadowOffset: [layer shadowOffset]];
       [self setShadowOpacity: [layer shadowOpacity]];
@@ -476,6 +525,11 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
   CGColorRelease(_borderColor);
   [_contentsGravity release];
   [_fillMode release];
+  [_mask setSuperlayer: nil];
+  [_mask release];
+  [_filters release];
+  [_backgroundFilters release];
+  [_compositingFilter release];
 
   [_backingStore release];
   [_animations release];
@@ -515,6 +569,7 @@ GSCA_OBSERVABLE_SETTER(setAnchorPoint, CGPoint, anchorPoint, CGPointEqualToPoint
 GSCA_OBSERVABLE_SETTER(setTransform, CATransform3D, transform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setSublayerTransform, CATransform3D, sublayerTransform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
+GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToRect)
 
 #else
 
@@ -650,6 +705,29 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
   // NOTE: -takeNoteThatNextFrameTime is called due to the application not redrawing when
   // implicit animations are not created.
   [self takeNoteThatNextFrameTimeChanged];
+}
+
+- (CALayer *) mask
+{
+  return _mask;
+}
+
+/* A mask is not a sublayer, but it does have this layer as its superlayer,
+   so that a mask written in a coordinate system relative to this one can be
+   converted.  A layer that was somewhere else in the tree leaves it. */
+- (void) setMask: (CALayer *)mask
+{
+  if (mask == _mask)
+    return;
+
+  [self willChangeValueForKey: @"mask"];
+  [mask retain];
+  [mask removeFromSuperlayer];
+  [_mask setSuperlayer: nil];
+  [_mask release];
+  _mask = mask;
+  [_mask setSuperlayer: self];
+  [self didChangeValueForKey: @"mask"];
 }
 
 /* ***************** */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -116,7 +116,6 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 @synthesize masksToBounds=_masksToBounds;
 @synthesize contentsRect=_contentsRect;
 @synthesize hidden=_hidden;
-@synthesize contentsGravity=_contentsGravity;
 @synthesize needsDisplayOnBoundsChange=_needsDisplayOnBoundsChange;
 @synthesize zPosition=_zPosition;
 @synthesize actions=_actions;
@@ -298,6 +297,10 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
     {
       return [NSNumber numberWithFloat: 3.0];
     }
+  if ([key isEqualToString: @"contentsGravity"])
+    {
+      return kCAGravityResize;
+    }
   if ([key isEqualToString: @"contentsCenter"])
     {
       CGRect rect = CGRectMake(0.0, 0.0, 1.0, 1.0);
@@ -373,6 +376,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
         @"shadowColor", @"shadowOffset", @"shadowOpacity",
         @"shadowPath", @"shadowRadius",
 
+        @"contentsGravity",
         @"contentsCenter", @"allowsEdgeAntialiasing", @"allowsGroupOpacity",
         @"edgeAntialiasingMask", @"drawsAsynchronously",
 
@@ -999,6 +1003,39 @@ CALayerResizeAxis(struct CALayerAxis axis, CGFloat delta,
     {
       [sublayer resizeWithOldSuperlayerSize: size];
     }
+}
+
+- (NSString *) contentsGravity
+{
+  return _contentsGravity;
+}
+
+/* Apple keeps a name it knows and answers center for anything else, which is
+   not the same as the default. */
+- (void) setContentsGravity: (NSString *)gravity
+{
+  static NSArray * known = nil;
+  NSString * chosen;
+
+  if (known == nil)
+    {
+      known = [[NSArray alloc] initWithObjects: kCAGravityResize,
+               kCAGravityResizeAspect, kCAGravityResizeAspectFill,
+               kCAGravityCenter, kCAGravityTop, kCAGravityBottom,
+               kCAGravityLeft, kCAGravityRight, kCAGravityTopLeft,
+               kCAGravityTopRight, kCAGravityBottomLeft,
+               kCAGravityBottomRight, nil];
+    }
+
+  chosen = [known containsObject: gravity] ? gravity : kCAGravityCenter;
+  if (chosen == _contentsGravity)
+    return;
+
+  [self willChangeValueForKey: @"contentsGravity"];
+  chosen = [chosen copy];
+  [_contentsGravity release];
+  _contentsGravity = chosen;
+  [self didChangeValueForKey: @"contentsGravity"];
 }
 
 /* ******************************* */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -228,6 +228,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       || [key isEqualToString: @"transform"]
       || [key isEqualToString: @"sublayerTransform"]
       || [key isEqualToString: @"shadowOffset"]
+      || [key isEqualToString: @"contentsRect"]
       || [key isEqualToString: @"contentsCenter"])
     {
       return NO;
@@ -569,6 +570,7 @@ GSCA_OBSERVABLE_SETTER(setAnchorPoint, CGPoint, anchorPoint, CGPointEqualToPoint
 GSCA_OBSERVABLE_SETTER(setTransform, CATransform3D, transform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setSublayerTransform, CATransform3D, sublayerTransform, CATransform3DEqualToTransform)
 GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
+GSCA_OBSERVABLE_SETTER(setContentsRect, CGRect, contentsRect, CGRectEqualToRect)
 GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToRect)
 
 #else

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -34,6 +34,7 @@
 #import "CALayer+FrameworkPrivate.h"
 #import "CAAnimation+FrameworkPrivate.h"
 #import "CAImplicitAnimationObserver.h"
+#import "CAArchivingObserver.h"
 #import <objc/runtime.h>
 #import "CALayer+DynamicProperties.h"
 #import "QuartzCore/CATransaction.h"
@@ -71,6 +72,7 @@ NSString *const kCATransition = @"transition";
 @property (retain) CABackingStore * backingStore;
 @property (nonatomic, assign) CARenderer * renderer;
 @property (nonatomic, retain) NSMutableDictionary *dynamicPropertyValueDict;
+@property (readonly) NSSet * valuesThatWereSet;
 
 - (void)setModelLayer: (id)modelLayer;
 @end
@@ -354,6 +356,8 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       _animationKeys = [[NSMutableArray alloc] init];
       _sublayers = [[NSMutableArray alloc] init];
       _observedKeyPaths = [[NSMutableArray alloc] init];
+      _archivingKeyPaths = [[NSMutableArray alloc] init];
+      _valuesThatWereSet = [[NSMutableSet alloc] init];
       _dynamicPropertyValueDict = [[NSMutableDictionary alloc] init];
 
       /* TODO: list all properties below */
@@ -424,6 +428,42 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
           [_observedKeyPaths addObject: keys[i]];
         }
 
+      /* Every property whose value a layer archives once it has been given
+         one.  frame is not among them because it is derived from bounds,
+         position and anchorPoint, and neither are the read-only ones. */
+      static NSString * archivable[] = {
+        @"delegate", @"contents", @"layoutManager", @"sublayers",
+        @"bounds", @"anchorPoint", @"anchorPointZ", @"position",
+        @"transform", @"sublayerTransform", @"opacity", @"opaque",
+        @"shouldRasterize", @"geometryFlipped", @"masksToBounds",
+        @"contentsRect", @"contentsScale", @"hidden", @"contentsGravity",
+        @"needsDisplayOnBoundsChange", @"zPosition", @"actions", @"style",
+
+        @"backgroundColor", @"borderColor",
+        @"shadowColor", @"shadowOffset", @"shadowOpacity", @"shadowPath",
+        @"shadowRadius",
+
+        @"mask", @"filters", @"backgroundFilters", @"compositingFilter",
+        @"contentsCenter", @"edgeAntialiasingMask", @"minificationFilterBias",
+        @"allowsEdgeAntialiasing", @"allowsGroupOpacity",
+        @"drawsAsynchronously",
+
+        @"beginTime", @"timeOffset", @"repeatCount", @"repeatDuration",
+        @"autoreverses", @"fillMode", @"duration", @"speed" };
+
+      for (int i = 0; i < sizeof(archivable)/sizeof(archivable[0]); i++)
+        {
+          [self addObserver: [CAArchivingObserver sharedObserver]
+                 forKeyPath: archivable[i]
+                    options: 0
+                    context: nil];
+          [_archivingKeyPaths addObject: archivable[i]];
+        }
+
+      /* Apple takes these two from the application bundle rather than from
+         the class, so a layer has been given them before anyone sets one. */
+      [_valuesThatWereSet addObject: @"allowsEdgeAntialiasing"];
+      [_valuesThatWereSet addObject: @"allowsGroupOpacity"];
     }
   return self;
 }
@@ -505,6 +545,12 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       /* private or publicly read-only properties */
       [self setAnimations: [layer animations]];
       [self setAnimationKeys: [layer animationKeys]];
+
+      /* A shadow copy archives what the layer it shadows archives, not
+         everything the copying above has just gone through. */
+      [_valuesThatWereSet release];
+      _valuesThatWereSet
+        = [[NSMutableSet alloc] initWithSet: [layer valuesThatWereSet]];
     }
   return self;
 }
@@ -516,9 +562,16 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       [self removeObserver: [CAImplicitAnimationObserver sharedObserver]
                 forKeyPath: keyPath];
     }
+  for(NSString *keyPath in _archivingKeyPaths)
+    {
+      [self removeObserver: [CAArchivingObserver sharedObserver]
+                forKeyPath: keyPath];
+    }
   CGColorRelease(_shadowColor);
   CGPathRelease(_shadowPath);
   [_observedKeyPaths release];
+  [_archivingKeyPaths release];
+  [_valuesThatWereSet release];
   [_layoutManager release];
   [_contents release];
   [_sublayers release];
@@ -730,6 +783,46 @@ GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToR
   _mask = mask;
   [_mask setSuperlayer: self];
   [self didChangeValueForKey: @"mask"];
+}
+
+/* ******************************* */
+/* MARK: - Flipping and archiving  */
+
+/* Each layer between this one and the root turns the contents over, so an
+   even number of them leaves the contents the way up they started. */
+- (BOOL) contentsAreFlipped
+{
+  BOOL flipped = NO;
+  CALayer * layer = self;
+
+  while (layer)
+    {
+      if ([layer isGeometryFlipped])
+        flipped = !flipped;
+      layer = [layer superlayer];
+    }
+  return flipped;
+}
+
+- (NSSet *) valuesThatWereSet
+{
+  return _valuesThatWereSet;
+}
+
+- (void) noteValueWasSetForKey: (NSString *)key
+{
+  [_valuesThatWereSet addObject: key];
+}
+
+/* A layer archives a property once that property has been given a value.
+   One that still holds what the class handed it is not worth writing out,
+   and neither is one derived from properties that are. */
+- (BOOL) shouldArchiveValueForKey: (NSString *)key
+{
+  if (key == nil)
+    return NO;
+
+  return [_valuesThatWereSet containsObject: key];
 }
 
 /* ***************** */
@@ -1018,6 +1111,7 @@ GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToR
   [layer removeFromSuperlayer];
   [mutableSublayers addObject: layer];
   [layer setSuperlayer: self];
+  [self noteValueWasSetForKey: @"sublayers"];
 }
 
 - (void)removeFromSuperlayer

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -133,6 +133,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
 @synthesize allowsEdgeAntialiasing=_allowsEdgeAntialiasing;
 @synthesize allowsGroupOpacity=_allowsGroupOpacity;
 @synthesize drawsAsynchronously=_drawsAsynchronously;
+@synthesize autoresizingMask=_autoresizingMask;
 
 @synthesize shadowColor=_shadowColor;
 @synthesize shadowOffset=_shadowOffset;
@@ -446,7 +447,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
         @"mask", @"filters", @"backgroundFilters", @"compositingFilter",
         @"contentsCenter", @"edgeAntialiasingMask", @"minificationFilterBias",
         @"allowsEdgeAntialiasing", @"allowsGroupOpacity",
-        @"drawsAsynchronously",
+        @"drawsAsynchronously", @"autoresizingMask",
 
         @"beginTime", @"timeOffset", @"repeatCount", @"repeatDuration",
         @"autoreverses", @"fillMode", @"duration", @"speed" };
@@ -520,6 +521,7 @@ CALayerApplyAbout(CGAffineTransform t, CGPoint p, CGPoint pivot)
       [self setAllowsEdgeAntialiasing: [layer allowsEdgeAntialiasing]];
       [self setAllowsGroupOpacity: [layer allowsGroupOpacity]];
       [self setDrawsAsynchronously: [layer drawsAsynchronously]];
+      [self setAutoresizingMask: [layer autoresizingMask]];
 
       [self setShadowColor: [layer shadowColor]];
       [self setShadowOffset: [layer shadowOffset]];
@@ -682,10 +684,14 @@ GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToR
 
 - (void) setBounds: (CGRect)bounds
 {
+  CGSize oldSize;
+
   bounds = CGRectStandardize(bounds);
 
   if (CGRectEqualToRect(bounds, _bounds))
     return;
+
+  oldSize = _bounds.size;
 
 #if !GNUSTEP
   _bounds = bounds;
@@ -695,6 +701,11 @@ GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToR
   _bounds = bounds;
   [self didChangeValueForKey: @"bounds"];
 #endif
+
+  if (!CGSizeEqualToSize(oldSize, bounds.size))
+    {
+      [self resizeSublayersWithOldSize: oldSize];
+    }
 
   if ([self needsDisplayOnBoundsChange])
     {
@@ -783,6 +794,108 @@ GSCA_OBSERVABLE_SETTER(setContentsCenter, CGRect, contentsCenter, CGRectEqualToR
   _mask = mask;
   [_mask setSuperlayer: self];
   [self didChangeValueForKey: @"mask"];
+}
+
+/* ******************** */
+/* MARK: - Autoresizing */
+
+/* One axis of the layer, described as the margin before it, its own extent,
+   and the margin after it. */
+struct CALayerAxis
+{
+  CGFloat before;
+  CGFloat extent;
+  CGFloat after;
+};
+
+/* Share `delta` out among whichever of the three parts give way.
+
+   Each part is worth a third of the change.  A part that does not give way
+   hands its third to the margins that do, or, where neither margin does, to
+   the extent.  So a layer whose leading margin and extent both give way sees
+   two thirds of the change in the margin and one third in the extent, while
+   one whose margins both give way and whose extent does not sees half in
+   each margin. */
+static struct CALayerAxis
+CALayerResizeAxis(struct CALayerAxis axis, CGFloat delta,
+                  BOOL beforeGivesWay, BOOL extentGivesWay,
+                  BOOL afterGivesWay)
+{
+  int margins = (beforeGivesWay ? 1 : 0) + (afterGivesWay ? 1 : 0);
+  CGFloat extentShare;
+  CGFloat marginShare;
+
+  if (!beforeGivesWay && !extentGivesWay && !afterGivesWay)
+    return axis;
+
+  if (extentGivesWay)
+    extentShare = margins ? delta / 3.0 : delta;
+  else
+    extentShare = 0.0;
+
+  marginShare = margins ? (delta - extentShare) / margins : 0.0;
+
+  if (beforeGivesWay)
+    axis.before += marginShare;
+  if (extentGivesWay)
+    axis.extent += extentShare;
+  if (afterGivesWay)
+    axis.after += marginShare;
+
+  return axis;
+}
+
+- (void) resizeWithOldSuperlayerSize: (CGSize)size
+{
+  CGSize now = [[self superlayer] bounds].size;
+  CGRect frame = [self frame];
+  struct CALayerAxis x, y;
+  BOOL resizesX, resizesY;
+
+  resizesX = (_autoresizingMask & (kCALayerMinXMargin | kCALayerWidthSizable
+                                   | kCALayerMaxXMargin)) != 0;
+  resizesY = (_autoresizingMask & (kCALayerMinYMargin | kCALayerHeightSizable
+                                   | kCALayerMaxYMargin)) != 0;
+  if (!resizesX && !resizesY)
+    return;
+
+  x.before = frame.origin.x;
+  x.extent = frame.size.width;
+  x.after = size.width - x.before - x.extent;
+  y.before = frame.origin.y;
+  y.extent = frame.size.height;
+  y.after = size.height - y.before - y.extent;
+
+  x = CALayerResizeAxis(x, now.width - size.width,
+                        (_autoresizingMask & kCALayerMinXMargin) != 0,
+                        (_autoresizingMask & kCALayerWidthSizable) != 0,
+                        (_autoresizingMask & kCALayerMaxXMargin) != 0);
+  y = CALayerResizeAxis(y, now.height - size.height,
+                        (_autoresizingMask & kCALayerMinYMargin) != 0,
+                        (_autoresizingMask & kCALayerHeightSizable) != 0,
+                        (_autoresizingMask & kCALayerMaxYMargin) != 0);
+
+  /* Apple lands the layer on whole points: the leading margin goes down to
+     the point below and the extent takes up the slack. */
+  if (resizesX)
+    {
+      frame.origin.x = floor(x.before);
+      frame.size.width = ceil(now.width - frame.origin.x - x.after);
+    }
+  if (resizesY)
+    {
+      frame.origin.y = floor(y.before);
+      frame.size.height = ceil(now.height - frame.origin.y - y.after);
+    }
+  [self setFrame: frame];
+}
+
+- (void) resizeSublayersWithOldSize: (CGSize)size
+{
+  for (CALayer * sublayer in [NSArray arrayWithArray: _sublayers])
+    {
+      [sublayer resizeWithOldSuperlayerSize: size];
+    }
 }
 
 /* ******************************* */

--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -35,6 +35,7 @@
 #import "CAAnimation+FrameworkPrivate.h"
 #import "CAImplicitAnimationObserver.h"
 #import "CAArchivingObserver.h"
+#import "CAGravity.h"
 #import <objc/runtime.h>
 #import "CALayer+DynamicProperties.h"
 #import "QuartzCore/CATransaction.h"
@@ -876,7 +877,14 @@ CALayerApplySublayerTransform(CALayer * layer, CGContextRef context)
       && CFGetTypeID(layerContents) == CGImageGetTypeID())
 #endif
     {
-      CGContextDrawImage(context, area, (CGImageRef)layerContents);
+      CGImageRef given = (CGImageRef)layerContents;
+
+      CGContextDrawImage(context,
+                         CAGravityDestinationRect(
+                           [self contentsGravity], area,
+                           CGSizeMake(CGImageGetWidth(given),
+                                      CGImageGetHeight(given))),
+                         given);
     }
   else if ([layerContents isKindOfClass: [CABackingStore class]])
     {
@@ -886,7 +894,12 @@ CALayerApplySublayerTransform(CALayer * layer, CGContextRef context)
                                            context]);
       if (image)
         {
-          CGContextDrawImage(context, area, image);
+          CGContextDrawImage(context,
+                             CAGravityDestinationRect(
+                               [self contentsGravity], area,
+                               CGSizeMake(CGImageGetWidth(image),
+                                          CGImageGetHeight(image))),
+                             image);
           CGImageRelease(image);
         }
     }

--- a/Source/CARenderer.m
+++ b/Source/CARenderer.m
@@ -33,6 +33,7 @@
 #import "CATransaction+FrameworkPrivate.h"
 #import "CABackingStore.h"
 #import "CARenderer+FrameworkPrivate.h"
+#import "CAGravity.h"
 #if !(__APPLE__)
 #define GL_GLEXT_PROTOTYPES 1
 #import <GL/gl.h>
@@ -777,11 +778,41 @@
             }
         }
 
+      /* The contents sit where the gravity puts them, which is not
+         necessarily over the whole of the layer, so they get vertices of
+         their own rather than the ones the background was drawn with. */
+      CGRect dest = CAGravityDestinationRect(
+                      [layer contentsGravity],
+                      CGRectMake(0, 0, [layer bounds].size.width,
+                                 [layer bounds].size.height),
+                      CGSizeMake([texture width], [texture height]));
+      GLfloat contentsVertices[] = {
+        CGRectGetMinX(dest), CGRectGetMinY(dest),
+        CGRectGetMaxX(dest), CGRectGetMinY(dest),
+        CGRectGetMaxX(dest), CGRectGetMaxY(dest),
+
+        CGRectGetMaxX(dest), CGRectGetMaxY(dest),
+        CGRectGetMinX(dest), CGRectGetMaxY(dest),
+        CGRectGetMinX(dest), CGRectGetMinY(dest),
+      };
+
+      /* The vertices above were shifted by the anchor point after they were
+         built; these are built afterwards and need the same shift. */
+      for (int i = 0; i < 6; i++)
+        {
+          contentsVertices[i*2 + 0] -= [layer anchorPoint].x
+                                       * [layer bounds].size.width;
+          contentsVertices[i*2 + 1] -= [layer anchorPoint].y
+                                       * [layer bounds].size.height;
+        }
+      glVertexPointer(2, GL_FLOAT, 0, contentsVertices);
+
       [texture bind];
       glColorPointer(4, GL_FLOAT, 0, whiteColor);
       glDrawArrays(GL_TRIANGLES, 0, 6);
       [texture unbind];
 
+      glVertexPointer(2, GL_FLOAT, 0, vertices);
     }
 
   transform = CATransform3DConcat ([layer sublayerTransform], transform);

--- a/Source/CARenderer.m
+++ b/Source/CARenderer.m
@@ -70,6 +70,65 @@
                        options: options;
 @end
 
+/* The window-coordinate box a layer's own quad occupies under the given
+   transform, or NO when that transform turns or skews it, where an
+   axis-aligned scissor cannot say what to clip.
+
+   The quad is the bounds size shifted by the anchor point, which is what
+   -_renderLayer:withTransform: draws, not the bounds rectangle itself. */
+static BOOL
+CARendererScissorBox(CATransform3D transform, CGRect bounds, CGPoint anchor,
+                     GLint out[4])
+{
+  GLint viewport[4];
+  GLdouble projection[16];
+  CGFloat corners[4][2];
+  CGFloat minX, minY, maxX, maxY;
+  CGFloat left = -anchor.x * bounds.size.width;
+  CGFloat bottom = -anchor.y * bounds.size.height;
+  CGFloat right = left + bounds.size.width;
+  CGFloat top = bottom + bounds.size.height;
+  int i;
+
+  if (fabs(transform.m12) > 1e-6 || fabs(transform.m21) > 1e-6)
+    return NO;
+
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  glGetDoublev(GL_PROJECTION_MATRIX, projection);
+
+  corners[0][0] = left;  corners[0][1] = bottom;
+  corners[1][0] = right; corners[1][1] = bottom;
+  corners[2][0] = right; corners[2][1] = top;
+  corners[3][0] = left;  corners[3][1] = top;
+
+  minX = minY = 1e30;
+  maxX = maxY = -1e30;
+  for (i = 0; i < 4; i++)
+    {
+      CGFloat ex = corners[i][0] * transform.m11
+                   + corners[i][1] * transform.m21 + transform.m41;
+      CGFloat ey = corners[i][0] * transform.m12
+                   + corners[i][1] * transform.m22 + transform.m42;
+      CGFloat cx = ex * projection[0] + ey * projection[4] + projection[12];
+      CGFloat cy = ex * projection[1] + ey * projection[5] + projection[13];
+      CGFloat wx = viewport[0] + (cx + 1.0) / 2.0 * viewport[2];
+      CGFloat wy = viewport[1] + (cy + 1.0) / 2.0 * viewport[3];
+
+      if (wx < minX) minX = wx;
+      if (wx > maxX) maxX = wx;
+      if (wy < minY) minY = wy;
+      if (wy > maxY) maxY = wy;
+    }
+
+  out[0] = (GLint)floor(minX);
+  out[1] = (GLint)floor(minY);
+  out[2] = (GLint)ceil(maxX) - out[0];
+  out[3] = (GLint)ceil(maxY) - out[1];
+  if (out[2] < 0) out[2] = 0;
+  if (out[3] < 0) out[3] = 0;
+  return YES;
+}
+
 @implementation CARenderer
 @synthesize layer=_layer;
 @synthesize bounds=_bounds;
@@ -386,6 +445,10 @@
     glLoadMatrixd((GLdouble*)&transform);
   else
     glLoadMatrixf((GLfloat*)&transform);
+
+  /* Kept for the scissor below, which clips where this layer is, not where
+     its sublayers end up. */
+  CATransform3D ownTransform = transform;
 
   // if the layer was offscreen-rendered, render just the texture
   CAGLTexture * texture = [[layer backingStore] offscreenRenderTexture];
@@ -817,10 +880,50 @@
 
   transform = CATransform3DConcat ([layer sublayerTransform], transform);
   transform = CATransform3DTranslate (transform, -[layer bounds].size.width/2, -[layer bounds].size.height/2, 0);
-  for (CALayer * sublayer in [layer sublayers])
-    {
-      [self _renderLayer: sublayer withTransform: transform];
-    }
+
+  {
+    GLboolean hadScissor = glIsEnabled(GL_SCISSOR_TEST);
+    GLint previous[4] = { 0, 0, 0, 0 };
+    GLint box[4];
+    BOOL clipping = NO;
+
+    if ([layer masksToBounds]
+        && CARendererScissorBox(ownTransform, [layer bounds],
+                                [layer anchorPoint], box))
+      {
+        glGetIntegerv(GL_SCISSOR_BOX, previous);
+        if (hadScissor)
+          {
+            /* Masks inside masks clip to what both of them allow. */
+            GLint x = box[0] > previous[0] ? box[0] : previous[0];
+            GLint y = box[1] > previous[1] ? box[1] : previous[1];
+            GLint r = (box[0] + box[2]) < (previous[0] + previous[2])
+                        ? (box[0] + box[2]) : (previous[0] + previous[2]);
+            GLint t = (box[1] + box[3]) < (previous[1] + previous[3])
+                        ? (box[1] + box[3]) : (previous[1] + previous[3]);
+
+            box[0] = x; box[1] = y;
+            box[2] = r > x ? r - x : 0;
+            box[3] = t > y ? t - y : 0;
+          }
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(box[0], box[1], box[2], box[3]);
+        clipping = YES;
+      }
+
+    for (CALayer * sublayer in [layer sublayers])
+      {
+        [self _renderLayer: sublayer withTransform: transform];
+      }
+
+    if (clipping)
+      {
+        if (hadScissor)
+          glScissor(previous[0], previous[1], previous[2], previous[3]);
+        else
+          glDisable(GL_SCISSOR_TEST);
+      }
+  }
 }
 
 - (void) _determineAndScheduleRasterizationForLayer: (CALayer*)layer

--- a/Source/CARenderer.m
+++ b/Source/CARenderer.m
@@ -260,6 +260,17 @@
 
   [_GLContext makeCurrentContext];
 
+  /* A layer's vertices are its bounds, in points.  Without a projection
+     they are taken as normalised device coordinates, where anything two
+     units or more across covers the whole drawable.  Map the renderer's
+     bounds onto it instead, so that a point is a point. */
+  glMatrixMode(GL_PROJECTION);
+  glPushMatrix();
+  glLoadIdentity();
+  glOrtho(CGRectGetMinX(_bounds), CGRectGetMaxX(_bounds),
+          CGRectGetMinY(_bounds), CGRectGetMaxY(_bounds),
+          -1.0, 1.0);
+
   glMatrixMode(GL_MODELVIEW);
 
   glEnableClientState(GL_VERTEX_ARRAY);
@@ -276,6 +287,9 @@
        withTransform: CATransform3DIdentity];
 
   /* Restore defaults */
+  glMatrixMode(GL_PROJECTION);
+  glPopMatrix();
+
   glMatrixMode(GL_MODELVIEW);
   glClearColor(0.0, 0.0, 0.0, 0.0);
   glDisableClientState(GL_VERTEX_ARRAY);

--- a/Tests/quartzcore/CAGravity/TestInfo
+++ b/Tests/quartzcore/CAGravity/TestInfo
@@ -1,0 +1,3 @@
+# CAGravityDestinationRect is internal to this framework, so there is nothing
+# for it to be compared against on Apple.
+APPLE_SKIP_TESTS="gravity.m"

--- a/Tests/quartzcore/CAGravity/gravity.m
+++ b/Tests/quartzcore/CAGravity/gravity.m
@@ -1,0 +1,68 @@
+/* Where the contents of a layer land inside its bounds, for each gravity.
+   The expected rectangles were measured against Apple QuartzCore with bounds
+   80x60 and a contents image 20x10. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+/* Declared here rather than imported: the header is private to the
+   framework and is not installed. */
+CGRect CAGravityDestinationRect(NSString *gravity, CGRect bounds,
+                                CGSize contentsSize);
+
+static BOOL eq(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+  if (d < 0) d = -d;
+  return d < 1e-4;
+}
+
+static BOOL is(NSString *gravity, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
+{
+  CGRect r = CAGravityDestinationRect(gravity, CGRectMake(0, 0, 80, 60),
+                                      CGSizeMake(20, 10));
+
+  return eq(r.origin.x, x) && eq(r.origin.y, y)
+      && eq(r.size.width, w) && eq(r.size.height, h);
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("where the contents go")
+
+  PASS(is(kCAGravityResize, 0, 0, 80, 60),
+       "resize fills the bounds");
+  PASS(is(kCAGravityResizeAspect, 0, 10, 80, 40),
+       "resizeAspect fits inside and centres what is left over");
+  PASS(is(kCAGravityResizeAspectFill, -20, 0, 120, 60),
+       "resizeAspectFill covers the bounds and overflows");
+  PASS(is(kCAGravityCenter, 30, 25, 20, 10),
+       "center places the contents unscaled in the middle");
+  PASS(is(kCAGravityTop, 30, 50, 20, 10), "top puts them against the top");
+  PASS(is(kCAGravityBottom, 30, 0, 20, 10), "bottom against the bottom");
+  PASS(is(kCAGravityLeft, 0, 25, 20, 10), "left against the left");
+  PASS(is(kCAGravityRight, 60, 25, 20, 10), "right against the right");
+  PASS(is(kCAGravityTopLeft, 0, 50, 20, 10), "topLeft into that corner");
+  PASS(is(kCAGravityTopRight, 60, 50, 20, 10), "topRight into that one");
+  PASS(is(kCAGravityBottomLeft, 0, 0, 20, 10), "bottomLeft into that one");
+  PASS(is(kCAGravityBottomRight, 60, 0, 20, 10),
+       "and bottomRight into the last");
+
+  PASS(is(@"not a gravity", 30, 25, 20, 10),
+       "a name it does not know is treated as center");
+  PASS(is(nil, 30, 25, 20, 10), "and so is no name at all");
+
+  CGRect empty = CAGravityDestinationRect(kCAGravityResize,
+                                          CGRectMake(0, 0, 80, 60),
+                                          CGSizeMake(0, 10));
+  PASS(eq(empty.size.width, 0) && eq(empty.size.height, 0),
+       "contents with no width occupy nothing");
+
+  END_SET("where the contents go")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/archiving.m
+++ b/Tests/quartzcore/CALayer/archiving.m
@@ -1,0 +1,161 @@
+/* -contentsAreFlipped and -shouldArchiveValueForKey:, both measured against
+   Apple QuartzCore.  A layer's contents are flipped when an odd number of
+   layers between it and the root have their geometry flipped, and a layer
+   archives a property once that property has been given a value, with
+   allowsEdgeAntialiasing and allowsGroupOpacity archived from the start
+   because Apple takes them from the application bundle. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+static void flipping(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([l contentsAreFlipped] == NO, "a new layer does not flip its contents");
+  [l setGeometryFlipped: YES];
+  PASS([l contentsAreFlipped] == YES,
+       "flipped geometry flips the contents with it");
+
+  CALayer *a = [CALayer layer];
+  CALayer *b = [CALayer layer];
+  CALayer *c = [CALayer layer];
+  [a addSublayer: b];
+  [b addSublayer: c];
+
+  PASS([c contentsAreFlipped] == NO,
+       "a layer under two unflipped layers is unflipped");
+
+  [a setGeometryFlipped: YES];
+  PASS([b contentsAreFlipped] == YES && [c contentsAreFlipped] == YES,
+       "one flipped ancestor flips everything below it");
+
+  [b setGeometryFlipped: YES];
+  PASS([b contentsAreFlipped] == NO && [c contentsAreFlipped] == NO,
+       "a second flip along the same path cancels the first");
+
+  [c setGeometryFlipped: YES];
+  PASS([c contentsAreFlipped] == YES, "and a third flips it again");
+
+  [c removeFromSuperlayer];
+  PASS([c contentsAreFlipped] == YES,
+       "a flipped layer with no superlayer flips its own contents");
+}
+
+static void freshLayer(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([l shouldArchiveValueForKey: @"position"] == NO,
+       "a new layer does not archive its position");
+  PASS([l shouldArchiveValueForKey: @"bounds"] == NO,
+       "a new layer does not archive its bounds");
+  PASS([l shouldArchiveValueForKey: @"delegate"] == NO,
+       "a new layer does not archive its delegate");
+  PASS([l shouldArchiveValueForKey: @"contents"] == NO,
+       "a new layer does not archive its contents");
+  PASS([l shouldArchiveValueForKey: @"opacity"] == NO,
+       "a new layer does not archive its opacity");
+  PASS([l shouldArchiveValueForKey: @"hidden"] == NO,
+       "a new layer does not archive whether it is hidden");
+  PASS([l shouldArchiveValueForKey: @"transform"] == NO,
+       "a new layer does not archive its transform");
+  PASS([l shouldArchiveValueForKey: @"mask"] == NO,
+       "a new layer does not archive its mask");
+  PASS([l shouldArchiveValueForKey: @"filters"] == NO,
+       "a new layer does not archive its filters");
+  PASS([l shouldArchiveValueForKey: @"contentsCenter"] == NO,
+       "a new layer does not archive its contents centre");
+  PASS([l shouldArchiveValueForKey: @"style"] == NO,
+       "a new layer does not archive its style");
+  PASS([l shouldArchiveValueForKey: @"actions"] == NO,
+       "a new layer does not archive its actions");
+  PASS([l shouldArchiveValueForKey: @"sublayers"] == NO,
+       "a new layer does not archive its sublayers");
+  PASS([l shouldArchiveValueForKey: @"superlayer"] == NO,
+       "a new layer does not archive its superlayer");
+
+  PASS([l shouldArchiveValueForKey: @"allowsEdgeAntialiasing"] == YES,
+       "a new layer does archive whether it allows edge antialiasing");
+  PASS([l shouldArchiveValueForKey: @"allowsGroupOpacity"] == YES,
+       "a new layer does archive whether it allows group opacity");
+
+  PASS([l shouldArchiveValueForKey: @"notAKeyAtAll"] == NO,
+       "a key the layer does not have is not archived");
+  PASS([l shouldArchiveValueForKey: @""] == NO,
+       "an empty key is not archived");
+  PASS([l shouldArchiveValueForKey: nil] == NO, "and neither is no key");
+}
+
+static void afterSetting(void)
+{
+  CALayer *l = [CALayer layer];
+  [l setOpacity: 0.5];
+  PASS([l shouldArchiveValueForKey: @"opacity"] == YES,
+       "a layer archives an opacity it was given");
+
+  CALayer *h = [CALayer layer];
+  [h setHidden: YES];
+  PASS([h shouldArchiveValueForKey: @"hidden"] == YES,
+       "and archives that it was hidden");
+
+  CALayer *b = [CALayer layer];
+  [b setBounds: CGRectMake(0, 0, 10, 10)];
+  PASS([b shouldArchiveValueForKey: @"bounds"] == YES,
+       "a layer archives bounds it was given");
+  PASS([b shouldArchiveValueForKey: @"position"] == NO,
+       "and does not archive a position nobody set");
+
+  CALayer *f = [CALayer layer];
+  [f setFrame: CGRectMake(1, 2, 3, 4)];
+  PASS([f shouldArchiveValueForKey: @"bounds"] == YES
+       && [f shouldArchiveValueForKey: @"position"] == YES,
+       "setting the frame gives the layer both bounds and position");
+  PASS([f shouldArchiveValueForKey: @"frame"] == NO,
+       "the frame itself is never archived");
+
+  CALayer *k = [CALayer layer];
+  [k setValue: [NSNumber numberWithFloat: 0.25] forKey: @"opacity"];
+  PASS([k shouldArchiveValueForKey: @"opacity"] == YES,
+       "a value given through key value coding is archived too");
+
+  CALayer *m = [CALayer layer];
+  [m setMask: [CALayer layer]];
+  [m setFilters: [NSArray array]];
+  [m setContentsCenter: CGRectMake(0, 0, 0.5, 0.5)];
+  PASS([m shouldArchiveValueForKey: @"mask"] == YES,
+       "a layer archives a mask it was given");
+  PASS([m shouldArchiveValueForKey: @"filters"] == YES,
+       "and filters it was given");
+  PASS([m shouldArchiveValueForKey: @"contentsCenter"] == YES,
+       "and a contents centre it was given");
+
+  CALayer *parent = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  [parent addSublayer: child];
+  PASS([parent shouldArchiveValueForKey: @"sublayers"] == YES,
+       "adding a sublayer gives the superlayer sublayers to archive");
+  PASS([child shouldArchiveValueForKey: @"superlayer"] == NO,
+       "while the sublayer still does not archive its superlayer");
+
+  CALayer *shape = (CALayer *)[CAShapeLayer layer];
+  PASS([shape shouldArchiveValueForKey: @"path"] == NO,
+       "a subclass does not archive a property nobody set either");
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("flipping and archiving")
+
+  flipping();
+  freshLayer();
+  afterSetting();
+
+  END_SET("flipping and archiving")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/autoresizing.m
+++ b/Tests/quartzcore/CALayer/autoresizing.m
@@ -1,0 +1,262 @@
+/* A layer resized because its superlayer was.  Every frame expected here was
+   measured against Apple QuartzCore.
+
+   The superlayer goes from 100x100 to 200x300 and the sublayer starts at
+   frame (10, 20, 50, 40), so the horizontal parts are 10 / 50 / 40 and the
+   vertical parts are 20 / 40 / 40.  No two of them are the same size, which
+   is what shows that the change is shared out by which parts give way and
+   not by how big they are: a leading margin of 10 and an extent of 50 take
+   66 and 34 of a change of 100. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+static BOOL eq(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+  if (d < 0) d = -d;
+  return d < 1e-4;
+}
+
+static BOOL req(CGRect r, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
+{
+  return eq(r.origin.x, x) && eq(r.origin.y, y)
+      && eq(r.size.width, w) && eq(r.size.height, h);
+}
+
+/* Build the tree, change the superlayer bounds once, answer the frame. */
+static CGRect resized(unsigned mask, CGFloat newWidth, CGFloat newHeight)
+{
+  CALayer *sup = [CALayer layer];
+  CALayer *sub = [CALayer layer];
+
+  [sup setBounds: CGRectMake(0, 0, 100, 100)];
+  [sub setFrame: CGRectMake(10, 20, 50, 40)];
+  [sub setAutoresizingMask: mask];
+  [sup addSublayer: sub];
+  [sup setBounds: CGRectMake(0, 0, newWidth, newHeight)];
+  return [sub frame];
+}
+
+static void constants(void)
+{
+  PASS(kCALayerNotSizable == 0, "a layer that does not give way is zero");
+  PASS(kCALayerMinXMargin == 1, "the leading horizontal margin is bit zero");
+  PASS(kCALayerWidthSizable == 2, "the width is bit one");
+  PASS(kCALayerMaxXMargin == 4, "the trailing horizontal margin is bit two");
+  PASS(kCALayerMinYMargin == 8, "the leading vertical margin is bit three");
+  PASS(kCALayerHeightSizable == 16, "the height is bit four");
+  PASS(kCALayerMaxYMargin == 32, "the trailing vertical margin is bit five");
+}
+
+static void property(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([l autoresizingMask] == kCALayerNotSizable,
+       "a new layer does not give way at all");
+  [l setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  PASS([l autoresizingMask] == (kCALayerWidthSizable | kCALayerHeightSizable),
+       "the mask reads back what it was given");
+  [l setAutoresizingMask: 255];
+  PASS([l autoresizingMask] == 255, "including bits with no meaning");
+  [l setAutoresizingMask: 0];
+  PASS([l autoresizingMask] == 0, "and it can be put back to zero");
+  PASS([CALayer defaultValueForKey: @"autoresizingMask"] == nil,
+       "the class has no default mask");
+}
+
+static void onePartAtATime(void)
+{
+  PASS(req(resized(kCALayerNotSizable, 200, 300), 10, 20, 50, 40),
+       "a layer that gives way nowhere does not move");
+  PASS(req(resized(kCALayerMinXMargin, 200, 300), 110, 20, 50, 40),
+       "a leading horizontal margin alone takes the whole change");
+  PASS(req(resized(kCALayerWidthSizable, 200, 300), 10, 20, 150, 40),
+       "a width alone takes the whole change");
+  PASS(req(resized(kCALayerMaxXMargin, 200, 300), 10, 20, 50, 40),
+       "a trailing horizontal margin alone leaves the frame where it is");
+  PASS(req(resized(kCALayerMinYMargin, 200, 300), 10, 220, 50, 40),
+       "a leading vertical margin alone takes the whole change");
+  PASS(req(resized(kCALayerHeightSizable, 200, 300), 10, 20, 50, 240),
+       "a height alone takes the whole change");
+  PASS(req(resized(kCALayerMaxYMargin, 200, 300), 10, 20, 50, 40),
+       "a trailing vertical margin alone leaves the frame where it is");
+}
+
+static void sharedOut(void)
+{
+  PASS(req(resized(kCALayerMinXMargin | kCALayerWidthSizable, 200, 300),
+           76, 20, 84, 40),
+       "a leading margin and a width take two thirds and one third");
+  PASS(req(resized(kCALayerWidthSizable | kCALayerMaxXMargin, 200, 300),
+           10, 20, 84, 40),
+       "a width and a trailing margin take one third and two thirds");
+  PASS(req(resized(kCALayerMinXMargin | kCALayerMaxXMargin, 200, 300),
+           60, 20, 50, 40),
+       "two margins with a fixed width take half each");
+  PASS(req(resized(kCALayerMinXMargin | kCALayerWidthSizable
+                   | kCALayerMaxXMargin, 200, 300), 43, 20, 84, 40),
+       "all three take a third each");
+
+  PASS(req(resized(kCALayerMinYMargin | kCALayerHeightSizable, 200, 300),
+           10, 153, 50, 107),
+       "the vertical parts are shared out the same way");
+  PASS(req(resized(kCALayerMinYMargin | kCALayerMaxYMargin, 200, 300),
+           10, 120, 50, 40),
+       "two vertical margins with a fixed height take half each");
+  PASS(req(resized(kCALayerMinYMargin | kCALayerHeightSizable
+                   | kCALayerMaxYMargin, 200, 300), 10, 86, 50, 108),
+       "and all three vertical parts take a third each");
+
+  PASS(req(resized(kCALayerWidthSizable | kCALayerHeightSizable, 200, 300),
+           10, 20, 150, 240),
+       "the two axes are worked out independently");
+  PASS(req(resized(63, 200, 300), 43, 86, 84, 108),
+       "a layer that gives way everywhere moves on both axes at once");
+}
+
+static void otherChanges(void)
+{
+  PASS(req(resized(kCALayerMinXMargin | kCALayerWidthSizable, 400, 100),
+           210, 20, 150, 40),
+       "a change of 300 divides exactly, two thirds and one third");
+  PASS(req(resized(kCALayerMinXMargin | kCALayerWidthSizable, 110, 100),
+           16, 20, 54, 40),
+       "a change of 10 puts the margin on the point below");
+  PASS(req(resized(kCALayerMinXMargin | kCALayerWidthSizable, 50, 25),
+           -24, 20, 34, 40),
+       "a superlayer that shrinks pulls the layer off its leading edge");
+  PASS(req(resized(kCALayerWidthSizable | kCALayerHeightSizable, 50, 25),
+           10, -15, 0, 35),
+       "and can leave it with no width at all");
+}
+
+static void whenItHappens(void)
+{
+  CALayer *sup = [CALayer layer];
+  CALayer *sub = [CALayer layer];
+  [sup setBounds: CGRectMake(0, 0, 100, 100)];
+  [sub setFrame: CGRectMake(10, 20, 50, 40)];
+  [sub setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  [sup addSublayer: sub];
+  [sup setBounds: CGRectMake(30, 40, 100, 100)];
+  PASS(req([sub frame], 10, 20, 50, 40),
+       "moving the bounds without resizing them moves nothing");
+
+  CALayer *fsup = [CALayer layer];
+  CALayer *fsub = [CALayer layer];
+  [fsup setBounds: CGRectMake(0, 0, 100, 100)];
+  [fsub setFrame: CGRectMake(10, 20, 50, 40)];
+  [fsub setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  [fsup addSublayer: fsub];
+  [fsup setFrame: CGRectMake(0, 0, 200, 300)];
+  PASS(req([fsub frame], 10, 20, 150, 240),
+       "setting the superlayer frame resizes the sublayer too");
+
+  CALayer *lsup = [CALayer layer];
+  CALayer *lsub = [CALayer layer];
+  [lsup setBounds: CGRectMake(0, 0, 100, 100)];
+  [lsub setFrame: CGRectMake(10, 20, 50, 40)];
+  [lsup addSublayer: lsub];
+  [lsup setBounds: CGRectMake(0, 0, 200, 300)];
+  [lsub setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  PASS(req([lsub frame], 10, 20, 50, 40),
+       "a mask given after the change does not act on it");
+
+  CALayer *asup = [CALayer layer];
+  CALayer *asub = [CALayer layer];
+  [asup setBounds: CGRectMake(0, 0, 200, 300)];
+  [asub setFrame: CGRectMake(10, 20, 50, 40)];
+  [asub setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  [asup addSublayer: asub];
+  PASS(req([asub frame], 10, 20, 50, 40),
+       "and a layer added afterwards keeps the frame it was given");
+}
+
+static void sentDirectly(void)
+{
+  CALayer *sup = [CALayer layer];
+  CALayer *sub = [CALayer layer];
+  [sup setBounds: CGRectMake(0, 0, 200, 300)];
+  [sub setFrame: CGRectMake(10, 20, 50, 40)];
+  [sub setAutoresizingMask: kCALayerMinXMargin | kCALayerWidthSizable];
+  [sup addSublayer: sub];
+  [sub resizeWithOldSuperlayerSize: CGSizeMake(100, 100)];
+  PASS(req([sub frame], 76, 20, 84, 40),
+       "the layer can be told its superlayer size changed");
+
+  CALayer *ssup = [CALayer layer];
+  CALayer *ssub = [CALayer layer];
+  [ssup setBounds: CGRectMake(0, 0, 200, 300)];
+  [ssub setFrame: CGRectMake(10, 20, 50, 40)];
+  [ssub setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  [ssup addSublayer: ssub];
+  [ssup resizeSublayersWithOldSize: CGSizeMake(100, 100)];
+  PASS(req([ssub frame], 10, 20, 150, 240),
+       "or the superlayer can pass it on to all of them");
+
+  CALayer *nsup = [CALayer layer];
+  CALayer *nsub = [CALayer layer];
+  [nsup setBounds: CGRectMake(0, 0, 100, 100)];
+  [nsub setFrame: CGRectMake(10, 20, 50, 40)];
+  [nsub setAutoresizingMask: kCALayerWidthSizable];
+  [nsup addSublayer: nsub];
+  [nsup resizeSublayersWithOldSize: CGSizeMake(100, 100)];
+  PASS(req([nsub frame], 10, 20, 50, 40),
+       "a size that did not change moves nothing");
+}
+
+static void downTheTree(void)
+{
+  CALayer *sup = [CALayer layer];
+  CALayer *mid = [CALayer layer];
+  CALayer *leaf = [CALayer layer];
+
+  [sup setBounds: CGRectMake(0, 0, 100, 100)];
+  [mid setFrame: CGRectMake(0, 0, 100, 100)];
+  [mid setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  [sup addSublayer: mid];
+  [leaf setFrame: CGRectMake(10, 20, 50, 40)];
+  [leaf setAutoresizingMask: kCALayerWidthSizable | kCALayerHeightSizable];
+  [mid addSublayer: leaf];
+
+  [sup setBounds: CGRectMake(0, 0, 200, 300)];
+  PASS(req([mid frame], 0, 0, 200, 300), "the layer between the two resizes");
+  PASS(req([leaf frame], 10, 20, 150, 240),
+       "and carries the change on down to its own sublayers");
+}
+
+static void archiving(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([l shouldArchiveValueForKey: @"autoresizingMask"] == NO,
+       "a new layer does not archive a mask nobody set");
+  [l setAutoresizingMask: kCALayerWidthSizable];
+  PASS([l shouldArchiveValueForKey: @"autoresizingMask"] == YES,
+       "and does archive one it was given");
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("autoresizing")
+
+  constants();
+  property();
+  onePartAtATime();
+  sharedOut();
+  otherChanges();
+  whenItHappens();
+  sentDirectly();
+  downTheTree();
+  archiving();
+
+  END_SET("autoresizing")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/masking.m
+++ b/Tests/quartzcore/CALayer/masking.m
@@ -1,0 +1,180 @@
+/* The layer properties that describe masking, filtering and edge
+   antialiasing.  Every expected value here was measured against Apple
+   QuartzCore, including the ones that are not obvious: a layer allows both
+   edge antialiasing and group opacity from the start, all four edges are in
+   the antialiasing mask, the contents centre is the unit rectangle, and a
+   layer used as a mask takes the masking layer as its superlayer without
+   becoming one of its sublayers. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/QuartzCore.h>
+
+static BOOL eq(CGFloat a, CGFloat b)
+{
+  CGFloat d = a - b;
+  if (d < 0) d = -d;
+  return d < 1e-4;
+}
+
+static BOOL req(CGRect r, CGFloat x, CGFloat y, CGFloat w, CGFloat h)
+{
+  return eq(r.origin.x, x) && eq(r.origin.y, y)
+      && eq(r.size.width, w) && eq(r.size.height, h);
+}
+
+static void defaults(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([l allowsEdgeAntialiasing] == YES,
+       "a new layer allows edge antialiasing");
+  PASS([l allowsGroupOpacity] == YES, "a new layer allows group opacity");
+  PASS([l edgeAntialiasingMask] == (kCALayerLeftEdge | kCALayerRightEdge
+                                    | kCALayerBottomEdge | kCALayerTopEdge),
+       "all four edges are antialiased to begin with");
+  PASS([l drawsAsynchronously] == NO, "a new layer does not draw off thread");
+  PASS(eq([l minificationFilterBias], 0),
+       "a new layer has no minification filter bias");
+  PASS([l filters] == nil, "a new layer has no filters");
+  PASS([l compositingFilter] == nil, "a new layer has no compositing filter");
+  PASS([l backgroundFilters] == nil, "a new layer has no background filters");
+  PASS([l mask] == nil, "a new layer has no mask");
+  PASS(req([l contentsCenter], 0, 0, 1, 1),
+       "the contents centre starts as the whole unit rectangle");
+}
+
+static void edgeConstants(void)
+{
+  PASS(kCALayerLeftEdge == 1, "the left edge is bit zero");
+  PASS(kCALayerRightEdge == 2, "the right edge is bit one");
+  PASS(kCALayerBottomEdge == 4, "the bottom edge is bit two");
+  PASS(kCALayerTopEdge == 8, "the top edge is bit three");
+}
+
+static void roundTrips(void)
+{
+  CALayer *l = [CALayer layer];
+
+  [l setAllowsEdgeAntialiasing: NO];
+  PASS([l allowsEdgeAntialiasing] == NO, "edge antialiasing can be turned off");
+  [l setAllowsGroupOpacity: NO];
+  PASS([l allowsGroupOpacity] == NO, "group opacity can be turned off");
+  [l setDrawsAsynchronously: YES];
+  PASS([l drawsAsynchronously] == YES, "asynchronous drawing can be asked for");
+  [l setEdgeAntialiasingMask: kCALayerLeftEdge | kCALayerTopEdge];
+  PASS([l edgeAntialiasingMask] == (kCALayerLeftEdge | kCALayerTopEdge),
+       "the edge mask reads back the edges it was given");
+  [l setMinificationFilterBias: 0.25];
+  PASS(eq([l minificationFilterBias], 0.25),
+       "the minification filter bias reads back what was set");
+
+  [l setContentsCenter: CGRectMake(0.25, 0.25, 0.5, 0.5)];
+  PASS(req([l contentsCenter], 0.25, 0.25, 0.5, 0.5),
+       "the contents centre reads back what was set");
+  [l setContentsCenter: CGRectMake(-1, -1, 4, 4)];
+  PASS(req([l contentsCenter], -1, -1, 4, 4),
+       "a contents centre outside the unit rectangle is kept unchecked");
+}
+
+static void filters(void)
+{
+  CALayer *l = [CALayer layer];
+  NSMutableArray *given = [NSMutableArray arrayWithObject: @"one"];
+
+  [l setFilters: given];
+  PASS([[l filters] count] == 1, "the filter array holds what it was given");
+  PASS([l filters] != given, "setting the filters copies the array");
+  [given addObject: @"two"];
+  PASS([[l filters] count] == 1,
+       "so a later change to the original does not reach the layer");
+  [l setFilters: nil];
+  PASS([l filters] == nil, "the filters can be taken away again");
+
+  [l setBackgroundFilters: [NSArray arrayWithObject: @"one"]];
+  PASS([[l backgroundFilters] count] == 1,
+       "the background filter array holds what it was given");
+
+  id filter = [NSObject new];
+  [l setCompositingFilter: filter];
+  PASS([l compositingFilter] == filter,
+       "the compositing filter is the object it was given");
+  [filter release];
+  [l setCompositingFilter: nil];
+  PASS([l compositingFilter] == nil,
+       "the compositing filter can be taken away again");
+}
+
+static void mask(void)
+{
+  CALayer *host = [CALayer layer];
+  CALayer *m = [CALayer layer];
+
+  [host setMask: m];
+  PASS([host mask] == m, "the mask is the layer it was given");
+  PASS([m superlayer] == host, "a mask takes the masked layer as superlayer");
+  PASS([[host sublayers] count] == 0, "but it does not become a sublayer");
+
+  [host setMask: nil];
+  PASS([host mask] == nil, "the mask can be taken away");
+  PASS([m superlayer] == nil, "which leaves the old mask with no superlayer");
+
+  CALayer *parent = [CALayer layer];
+  CALayer *child = [CALayer layer];
+  [parent addSublayer: child];
+  CALayer *other = [CALayer layer];
+  [other setMask: child];
+  PASS([child superlayer] == other,
+       "a layer already in a tree takes the masking layer as superlayer");
+  PASS([[parent sublayers] count] == 0, "and leaves the tree it was in");
+}
+
+static void classDefaults(void)
+{
+  id v;
+
+  v = [CALayer defaultValueForKey: @"allowsEdgeAntialiasing"];
+  PASS(v != nil && [v boolValue] == YES,
+       "the class default allows edge antialiasing");
+  v = [CALayer defaultValueForKey: @"allowsGroupOpacity"];
+  PASS(v != nil && [v boolValue] == YES,
+       "the class default allows group opacity");
+  v = [CALayer defaultValueForKey: @"edgeAntialiasingMask"];
+  PASS(v != nil && [v unsignedIntValue] == 15,
+       "the class default antialiases all four edges");
+  v = [CALayer defaultValueForKey: @"drawsAsynchronously"];
+  PASS(v != nil && [v boolValue] == NO,
+       "the class default does not draw off thread");
+  v = [CALayer defaultValueForKey: @"contentsCenter"];
+  PASS(v != nil, "the class has a default contents centre");
+
+  PASS([CALayer defaultValueForKey: @"minificationFilterBias"] == nil,
+       "the class has no default minification filter bias");
+  PASS([CALayer defaultValueForKey: @"filters"] == nil,
+       "the class has no default filters");
+  PASS([CALayer defaultValueForKey: @"compositingFilter"] == nil,
+       "the class has no default compositing filter");
+  PASS([CALayer defaultValueForKey: @"backgroundFilters"] == nil,
+       "the class has no default background filters");
+  PASS([CALayer defaultValueForKey: @"mask"] == nil,
+       "the class has no default mask");
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("layer masking and filtering")
+
+  defaults();
+  edgeConstants();
+  roundTrips();
+  filters();
+  mask();
+  classDefaults();
+
+  END_SET("layer masking and filtering")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/masking.m
+++ b/Tests/quartzcore/CALayer/masking.m
@@ -75,6 +75,13 @@ static void roundTrips(void)
   [l setContentsCenter: CGRectMake(-1, -1, 4, 4)];
   PASS(req([l contentsCenter], -1, -1, 4, 4),
        "a contents centre outside the unit rectangle is kept unchecked");
+
+  /* contentsRect is the same shape of property and had the same defect. */
+  PASS(req([l contentsRect], 0, 0, 1, 1),
+       "the contents rectangle starts as the whole unit rectangle");
+  [l setContentsRect: CGRectMake(0.25, 0.25, 0.5, 0.5)];
+  PASS(req([l contentsRect], 0.25, 0.25, 0.5, 0.5),
+       "the contents rectangle reads back what was set");
 }
 
 static void filters(void)

--- a/Tests/quartzcore/CALayer/render.m
+++ b/Tests/quartzcore/CALayer/render.m
@@ -405,6 +405,63 @@ static void whatTheDelegateDrew(void)
   CGContextRelease(context);
 }
 
+/* An opaque image of the given size, to be put in a layer's contents. */
+static CGImageRef blueImage(int w, int h)
+{
+  CGColorSpaceRef space = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
+  CGContextRef c = CGBitmapContextCreate(NULL, w, h, 8, w * 4, space,
+#if GNUSTEP
+                                         kCGImageAlphaPremultipliedFirst);
+#else
+                                         kCGImageAlphaPremultipliedLast);
+#endif
+  CGColorRef blue = CGColorCreateGenericRGB(0, 0, 1, 1);
+  CGImageRef image;
+
+  CGColorSpaceRelease(space);
+  memset(CGBitmapContextGetData(c), 0, w * h * 4);
+  CGContextSetFillColorWithColor(c, blue);
+  CGContextFillRect(c, CGRectMake(0, 0, w, h));
+  image = CGBitmapContextCreateImage(c);
+  CGColorRelease(blue);
+  CGContextRelease(c);
+  return image;
+}
+
+/* Render a layer 80x60 holding a 20x10 image under one gravity, and say
+   whether exactly the given rectangle was painted. */
+static BOOL gravityPaints(NSString *gravity, int x0, int y0, int x1, int y1)
+{
+  CGContextRef context = newContext();
+  CGImageRef image = blueImage(20, 10);
+  CALayer *l = [CALayer layer];
+  BOOL ok;
+
+  [l setBounds: CGRectMake(0, 0, 80, 60)];
+  [l setContents: (id)image];
+  [l setContentsGravity: gravity];
+  [l renderInContext: context];
+  ok = paintedExactly(context, x0, y0, x1, y1);
+
+  CGImageRelease(image);
+  CGContextRelease(context);
+  return ok;
+}
+
+static void gravityPlacement(void)
+{
+  PASS(gravityPaints(kCAGravityResize, 0, 0, 80, 60),
+       "resize stretches the contents over the whole bounds");
+  PASS(gravityPaints(kCAGravityResizeAspect, 0, 10, 80, 50),
+       "resizeAspect fits them inside and centres what is left over");
+  PASS(gravityPaints(kCAGravityCenter, 30, 25, 50, 35),
+       "center leaves them their own size in the middle");
+  PASS(gravityPaints(kCAGravityTop, 30, 50, 50, 60),
+       "top puts them against the top edge");
+  PASS(gravityPaints(kCAGravityBottomLeft, 0, 0, 20, 10),
+       "and bottomLeft into that corner");
+}
+
 static void gravityNames(void)
 {
   CALayer *l = [CALayer layer];
@@ -443,6 +500,7 @@ int main(void)
   sublayerPlacement();
   whatTheDelegateDrew();
   gravityNames();
+  gravityPlacement();
   nothingBadHappens();
 
   END_SET("rendering a layer tree into a context")

--- a/Tests/quartzcore/CALayer/render.m
+++ b/Tests/quartzcore/CALayer/render.m
@@ -1,0 +1,435 @@
+/* -renderInContext: draws a layer and everything under it into a Core
+   Graphics context.  Every expected value here was measured against Apple
+   QuartzCore.
+
+   The assertions are about which pixels are painted, not about what is in
+   each byte of them: Opal and Apple lay a pixel out differently, Opal taking
+   only premultiplied-first, so a test that read a particular byte would
+   answer differently on the two for reasons that have nothing to do with
+   this method.  A pixel counts as painted when any of its four bytes is not
+   zero, which for an opaque colour on a cleared context is exact. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#include <string.h>
+
+#define SIDE 100
+
+static CGContextRef newContext(void)
+{
+  CGColorSpaceRef space = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
+  CGContextRef context;
+
+  context = CGBitmapContextCreate(NULL, SIDE, SIDE, 8, SIDE * 4, space,
+#if GNUSTEP
+                                  kCGImageAlphaPremultipliedFirst);
+#else
+                                  kCGImageAlphaPremultipliedLast);
+#endif
+  CGColorSpaceRelease(space);
+  if (context)
+    {
+      memset(CGBitmapContextGetData(context), 0, SIDE * SIDE * 4);
+    }
+  return context;
+}
+
+/* Whether the pixel at (x, y) had anything drawn on it.  y counts up from
+   the bottom, the way the layer geometry does. */
+static BOOL painted(CGContextRef context, int x, int y)
+{
+  unsigned char *data = CGBitmapContextGetData(context);
+  unsigned char *pixel;
+
+  if (!data || x < 0 || y < 0 || x >= SIDE || y >= SIDE)
+    return NO;
+  pixel = data + ((SIDE - 1 - y) * SIDE + x) * 4;
+  return pixel[0] || pixel[1] || pixel[2] || pixel[3];
+}
+
+static int paintedCount(CGContextRef context)
+{
+  int x, y, n = 0;
+
+  for (y = 0; y < SIDE; y++)
+    for (x = 0; x < SIDE; x++)
+      if (painted(context, x, y))
+        n++;
+  return n;
+}
+
+/* Whether everything painted lies in x [x0, x1) by y [y0, y1) and fills it. */
+static BOOL paintedExactly(CGContextRef context, int x0, int y0,
+                           int x1, int y1)
+{
+  int x, y;
+
+  for (y = 0; y < SIDE; y++)
+    for (x = 0; x < SIDE; x++)
+      {
+        BOOL inside = (x >= x0 && x < x1 && y >= y0 && y < y1);
+
+        if (painted(context, x, y) != inside)
+          return NO;
+      }
+  return YES;
+}
+
+static BOOL fullyPainted(CGContextRef context)
+{
+  unsigned char *data = CGBitmapContextGetData(context);
+  int i;
+
+  for (i = 0; i < SIDE * SIDE; i++)
+    {
+      unsigned char *p = data + i * 4;
+
+      if (p[0] || p[1] || p[2] || p[3])
+        {
+          if (p[0] != 255 && p[1] != 255 && p[2] != 255 && p[3] != 255)
+            return NO;
+        }
+    }
+  return YES;
+}
+
+static CGColorRef opaque(CGFloat r, CGFloat g, CGFloat b)
+{
+  return CGColorCreateGenericRGB(r, g, b, 1.0);
+}
+
+static void whereTheLayerLands(void)
+{
+  CGContextRef context = newContext();
+  CALayer *l = [CALayer layer];
+  CGColorRef red = opaque(1, 0, 0);
+
+  PASS(context != NULL, "a bitmap context can be made to draw into");
+
+  [l setFrame: CGRectMake(10, 20, 30, 40)];
+  [l setBackgroundColor: red];
+  [l renderInContext: context];
+  PASS(paintedExactly(context, 0, 0, 30, 40),
+       "the layer asked to render is drawn at the origin of the context, "
+       "not where its own frame puts it");
+  CGContextRelease(context);
+
+  /* Its bounds origin, however, is where its own drawing goes. */
+  context = newContext();
+  CALayer *b = [CALayer layer];
+  [b setBounds: CGRectMake(10, 10, 20, 20)];
+  [b setPosition: CGPointMake(50, 50)];
+  [b setBackgroundColor: red];
+  [b renderInContext: context];
+  PASS(paintedExactly(context, 10, 10, 30, 30),
+       "a bounds origin moves that drawing, a position does not");
+  CGContextRelease(context);
+
+  /* Nor does a transform on the layer that was asked. */
+  context = newContext();
+  CALayer *t = [CALayer layer];
+  [t setFrame: CGRectMake(10, 10, 20, 20)];
+  [t setBackgroundColor: red];
+  [t setTransform: CATransform3DMakeTranslation(30, 0, 0)];
+  [t renderInContext: context];
+  PASS(paintedExactly(context, 0, 0, 20, 20),
+       "and neither does a transform on it");
+
+  CGColorRelease(red);
+  CGContextRelease(context);
+}
+
+static void nothingToDraw(void)
+{
+  CGColorRef red = opaque(1, 0, 0);
+  CGContextRef context = newContext();
+  CALayer *bare = [CALayer layer];
+
+  [bare setFrame: CGRectMake(10, 20, 30, 40)];
+  [bare renderInContext: context];
+  PASS(paintedCount(context) == 0,
+       "a layer with no colour and no contents paints nothing");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *hidden = [CALayer layer];
+  [hidden setFrame: CGRectMake(10, 20, 30, 40)];
+  [hidden setBackgroundColor: red];
+  [hidden setHidden: YES];
+  [hidden renderInContext: context];
+  PASS(paintedCount(context) == 0, "a hidden layer paints nothing");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *clear = [CALayer layer];
+  [clear setFrame: CGRectMake(10, 20, 30, 40)];
+  [clear setBackgroundColor: red];
+  [clear setOpacity: 0.0];
+  [clear renderInContext: context];
+  PASS(paintedCount(context) == 0, "and neither does one at zero opacity");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *half = [CALayer layer];
+  [half setFrame: CGRectMake(10, 20, 30, 40)];
+  [half setBackgroundColor: red];
+  [half setOpacity: 0.5];
+  [half renderInContext: context];
+  PASS(paintedCount(context) == 30 * 40,
+       "one at half opacity paints the same area");
+  PASS(!fullyPainted(context), "but no part of it at full strength");
+
+  CGColorRelease(red);
+  CGContextRelease(context);
+}
+
+static void sublayers(void)
+{
+  CGColorRef red = opaque(1, 0, 0);
+  CGColorRef blue = opaque(0, 0, 1);
+  CGContextRef context = newContext();
+  CALayer *parent = [CALayer layer];
+  CALayer *child = [CALayer layer];
+
+  [parent setFrame: CGRectMake(10, 10, 40, 40)];
+  [parent setBackgroundColor: red];
+  [child setFrame: CGRectMake(5, 5, 10, 10)];
+  [child setBackgroundColor: blue];
+  [parent addSublayer: child];
+  [parent renderInContext: context];
+  PASS(paintedExactly(context, 0, 0, 40, 40),
+       "a sublayer inside its superlayer adds nothing to what is painted");
+  CGContextRelease(context);
+
+  /* A sublayer is placed by its own frame, so it can fall outside. */
+  context = newContext();
+  CALayer *p = [CALayer layer];
+  CALayer *k = [CALayer layer];
+  [p setFrame: CGRectMake(10, 10, 20, 20)];
+  [k setFrame: CGRectMake(10, 10, 20, 20)];
+  [k setBackgroundColor: red];
+  [p addSublayer: k];
+  [p renderInContext: context];
+  PASS(paintedExactly(context, 10, 10, 30, 30),
+       "a sublayer outside its superlayer is still drawn");
+  CGContextRelease(context);
+
+  context = newContext();
+  [p setMasksToBounds: YES];
+  [p renderInContext: context];
+  PASS(paintedExactly(context, 10, 10, 20, 20),
+       "unless the superlayer masks to its bounds, which cuts it down");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *hp = [CALayer layer];
+  CALayer *hk = [CALayer layer];
+  [hp setFrame: CGRectMake(0, 0, 100, 100)];
+  [hk setFrame: CGRectMake(10, 10, 20, 20)];
+  [hk setBackgroundColor: red];
+  [hk setHidden: YES];
+  [hp addSublayer: hk];
+  [hp renderInContext: context];
+  PASS(paintedCount(context) == 0, "a hidden sublayer is left out too");
+  CGContextRelease(context);
+
+  /* The last sublayer added is drawn over the ones before it. */
+  context = newContext();
+  CGContextRef alone = newContext();
+  CALayer *op = [CALayer layer];
+  CALayer *first = [CALayer layer];
+  CALayer *second = [CALayer layer];
+  [op setFrame: CGRectMake(0, 0, 100, 100)];
+  [first setFrame: CGRectMake(10, 10, 20, 20)];
+  [first setBackgroundColor: red];
+  [second setFrame: CGRectMake(10, 10, 20, 20)];
+  [second setBackgroundColor: blue];
+  [op addSublayer: first];
+  [op addSublayer: second];
+  [op renderInContext: context];
+
+  CALayer *ap = [CALayer layer];
+  CALayer *only = [CALayer layer];
+  [ap setFrame: CGRectMake(0, 0, 100, 100)];
+  [only setFrame: CGRectMake(10, 10, 20, 20)];
+  [only setBackgroundColor: blue];
+  [ap addSublayer: only];
+  [ap renderInContext: alone];
+
+  PASS(memcmp((unsigned char *)CGBitmapContextGetData(context)
+              + ((SIDE - 1 - 15) * SIDE + 15) * 4,
+              (unsigned char *)CGBitmapContextGetData(alone)
+              + ((SIDE - 1 - 15) * SIDE + 15) * 4, 4) == 0,
+       "where two sublayers overlap, the one added later is on top");
+
+  CGContextRelease(context);
+  CGContextRelease(alone);
+  CGColorRelease(red);
+  CGColorRelease(blue);
+}
+
+static void theBoundsOrigin(void)
+{
+  CGColorRef red = opaque(1, 0, 0);
+  CGContextRef context = newContext();
+  CALayer *parent = [CALayer layer];
+  CALayer *child = [CALayer layer];
+
+  [parent setFrame: CGRectMake(0, 0, 60, 60)];
+  [parent setBounds: CGRectMake(10, 10, 60, 60)];
+  [child setFrame: CGRectMake(10, 10, 20, 20)];
+  [child setBackgroundColor: red];
+  [parent addSublayer: child];
+  [parent renderInContext: context];
+  PASS(paintedExactly(context, 10, 10, 30, 30),
+       "the bounds origin of the layer that was asked does not move its "
+       "sublayers");
+  CGContextRelease(context);
+
+  /* One further down does move them. */
+  context = newContext();
+  CALayer *root = [CALayer layer];
+  CALayer *middle = [CALayer layer];
+  CALayer *leaf = [CALayer layer];
+  [root setFrame: CGRectMake(0, 0, 100, 100)];
+  [middle setFrame: CGRectMake(0, 0, 60, 60)];
+  [middle setBounds: CGRectMake(10, 10, 60, 60)];
+  [leaf setFrame: CGRectMake(10, 10, 20, 20)];
+  [leaf setBackgroundColor: red];
+  [middle addSublayer: leaf];
+  [root addSublayer: middle];
+  [root renderInContext: context];
+  PASS(paintedExactly(context, 0, 0, 20, 20),
+       "a bounds origin below that one does move them");
+
+  CGColorRelease(red);
+  CGContextRelease(context);
+}
+
+static void sublayerPlacement(void)
+{
+  CGColorRef red = opaque(1, 0, 0);
+  CGContextRef context = newContext();
+  CALayer *p = [CALayer layer];
+  CALayer *k = [CALayer layer];
+
+  [p setFrame: CGRectMake(0, 0, 100, 100)];
+  [k setFrame: CGRectMake(10, 10, 20, 20)];
+  [k setBackgroundColor: red];
+  [k setTransform: CATransform3DMakeTranslation(30, 0, 0)];
+  [p addSublayer: k];
+  [p renderInContext: context];
+  PASS(paintedExactly(context, 40, 10, 60, 30),
+       "a transform on a sublayer does move it");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *ap = [CALayer layer];
+  CALayer *ak = [CALayer layer];
+  [ap setFrame: CGRectMake(0, 0, 100, 100)];
+  [ak setBounds: CGRectMake(0, 0, 20, 20)];
+  [ak setPosition: CGPointMake(50, 50)];
+  [ak setAnchorPoint: CGPointMake(0, 0)];
+  [ak setBackgroundColor: red];
+  [ap addSublayer: ak];
+  [ap renderInContext: context];
+  PASS(paintedExactly(context, 50, 50, 70, 70),
+       "a sublayer anchored at its corner sits with that corner on its "
+       "position");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *cp = [CALayer layer];
+  CALayer *ck = [CALayer layer];
+  [cp setFrame: CGRectMake(0, 0, 100, 100)];
+  [ck setBounds: CGRectMake(0, 0, 20, 20)];
+  [ck setPosition: CGPointMake(50, 50)];
+  [ck setBackgroundColor: red];
+  [cp addSublayer: ck];
+  [cp renderInContext: context];
+  PASS(paintedExactly(context, 40, 40, 60, 60),
+       "and one anchored at its centre sits around it");
+  CGContextRelease(context);
+
+  context = newContext();
+  CALayer *sp = [CALayer layer];
+  CALayer *sk = [CALayer layer];
+  [sp setFrame: CGRectMake(0, 0, 100, 100)];
+  [sk setFrame: CGRectMake(10, 10, 20, 20)];
+  [sk setBackgroundColor: red];
+  [sp addSublayer: sk];
+  [sp setSublayerTransform: CATransform3DMakeTranslation(30, 0, 0)];
+  [sp renderInContext: context];
+  PASS(paintedExactly(context, 40, 10, 60, 30),
+       "a sublayer transform moves the sublayers under it");
+
+  CGColorRelease(red);
+  CGContextRelease(context);
+}
+
+@interface Painter : NSObject
+@end
+
+@implementation Painter
+- (void) drawLayer: (CALayer *)layer inContext: (CGContextRef)context
+{
+  CGColorRef green = CGColorCreateGenericRGB(0, 1, 0, 1);
+
+  CGContextSetFillColorWithColor(context, green);
+  CGContextFillRect(context, CGRectMake(0, 0, 10, 10));
+  CGColorRelease(green);
+}
+@end
+
+static void whatTheDelegateDrew(void)
+{
+  CGContextRef context = newContext();
+  CALayer *l = [CALayer layer];
+  Painter *painter = [[Painter new] autorelease];
+
+  [l setFrame: CGRectMake(0, 0, 40, 40)];
+  [l setDelegate: painter];
+  [l renderInContext: context];
+  PASS(paintedCount(context) == 0,
+       "a layer that was never displayed paints nothing, since rendering "
+       "does not ask the delegate to draw");
+  CGContextRelease(context);
+
+  context = newContext();
+  [l display];
+  [l renderInContext: context];
+  PASS(paintedExactly(context, 0, 0, 10, 10),
+       "once it has been displayed, what the delegate drew is what appears");
+
+  CGContextRelease(context);
+}
+
+static void nothingBadHappens(void)
+{
+  CALayer *l = [CALayer layer];
+
+  [l setFrame: CGRectMake(0, 0, 10, 10)];
+  PASS_RUNS([l renderInContext: NULL],
+            "rendering into no context at all is not an error");
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("rendering a layer tree into a context")
+
+  whereTheLayerLands();
+  nothingToDraw();
+  sublayers();
+  theBoundsOrigin();
+  sublayerPlacement();
+  whatTheDelegateDrew();
+  nothingBadHappens();
+
+  END_SET("rendering a layer tree into a context")
+
+  [pool release];
+  return 0;
+}

--- a/Tests/quartzcore/CALayer/render.m
+++ b/Tests/quartzcore/CALayer/render.m
@@ -405,6 +405,22 @@ static void whatTheDelegateDrew(void)
   CGContextRelease(context);
 }
 
+static void gravityNames(void)
+{
+  CALayer *l = [CALayer layer];
+
+  PASS([[l contentsGravity] isEqualToString: kCAGravityResize],
+       "a new layer resizes its contents to its bounds");
+
+  [l setContentsGravity: kCAGravityTopLeft];
+  PASS([[l contentsGravity] isEqualToString: kCAGravityTopLeft],
+       "a gravity it knows is kept");
+
+  [l setContentsGravity: @"not a gravity"];
+  PASS([[l contentsGravity] isEqualToString: kCAGravityCenter],
+       "one it does not know becomes center, not the default");
+}
+
 static void nothingBadHappens(void)
 {
   CALayer *l = [CALayer layer];
@@ -426,6 +442,7 @@ int main(void)
   theBoundsOrigin();
   sublayerPlacement();
   whatTheDelegateDrew();
+  gravityNames();
   nothingBadHappens();
 
   END_SET("rendering a layer tree into a context")

--- a/Tests/quartzcore/CARenderer/renderer.m
+++ b/Tests/quartzcore/CARenderer/renderer.m
@@ -16,6 +16,100 @@
 #import <AppKit/AppKit.h>
 #import <QuartzCore/CARenderer.h>
 #import <QuartzCore/CALayer.h>
+#import <QuartzCore/CATransaction.h>
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
+
+#define VIEW_W 64
+#define VIEW_H 48
+#define MAX_PIXELS (1024 * 1024 * 4)
+
+/* The drawable is not necessarily the size the window was asked for, so the
+   area to read back is taken from the viewport rather than assumed. */
+static int drawableW = VIEW_W;
+static int drawableH = VIEW_H;
+
+/* An opaque image of the given size, for a layer's contents. */
+static CGImageRef solidImage(int w, int h)
+{
+  CGColorSpaceRef space = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
+  CGContextRef c = CGBitmapContextCreate(NULL, w, h, 8, w * 4, space,
+                                         kCGImageAlphaPremultipliedFirst);
+  CGColorRef colour = CGColorCreateGenericRGB(0, 0, 1, 1);
+  CGImageRef image;
+
+  CGColorSpaceRelease(space);
+  memset(CGBitmapContextGetData(c), 0, w * h * 4);
+  CGContextSetFillColorWithColor(c, colour);
+  CGContextFillRect(c, CGRectMake(0, 0, w, h));
+  image = CGBitmapContextCreateImage(c);
+  CGColorRelease(colour);
+  CGContextRelease(c);
+  return image;
+}
+
+/* Read the drawable back into `into`, having measured it first. */
+static void readDrawable(unsigned char *into)
+{
+  GLint viewport[4] = { 0, 0, VIEW_W, VIEW_H };
+
+  glFinish();
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  drawableW = viewport[2] > 0 ? viewport[2] : VIEW_W;
+  drawableH = viewport[3] > 0 ? viewport[3] : VIEW_H;
+  if (drawableW * drawableH * 4 > MAX_PIXELS)
+    {
+      drawableW = VIEW_W;
+      drawableH = VIEW_H;
+    }
+  memset(into, 0, drawableW * drawableH * 4);
+  glReadPixels(0, 0, drawableW, drawableH, GL_RGBA, GL_UNSIGNED_BYTE, into);
+}
+
+/* The box of the pixels that differ between two readings.
+
+   Two frames are compared rather than one frame examined for a colour,
+   because a window's drawable does not come back transparent where nothing
+   was drawn, and the channel order a texture ends up in on Opal is not the
+   one the image was built with.  A difference does not care about either. */
+static BOOL changedBox(const unsigned char *before, const unsigned char *after,
+                       int *x0, int *y0, int *x1, int *y1, int *count)
+{
+  int x, y;
+
+  *x0 = drawableW; *y0 = drawableH; *x1 = -1; *y1 = -1; *count = 0;
+  for (y = 0; y < drawableH; y++)
+    for (x = 0; x < drawableW; x++)
+      {
+        long o = (y * drawableW + x) * 4;
+
+        if (memcmp(before + o, after + o, 4) != 0)
+          {
+            (*count)++;
+            if (x < *x0) *x0 = x;
+            if (y < *y0) *y0 = y;
+            if (x > *x1) *x1 = x;
+            if (y > *y1) *y1 = y;
+          }
+      }
+  return *x1 >= 0;
+}
+
+/* Draw one frame of a renderer holding the given layer. */
+static void renderFrame(CARenderer *renderer, CALayer *layer)
+{
+  [renderer setLayer: layer];
+  [renderer setBounds: CGRectMake(0, 0, VIEW_W, VIEW_H)];
+  [renderer addUpdateRect: CGRectMake(0, 0, VIEW_W, VIEW_H)];
+  glClearColor(0.0, 0.0, 0.0, 0.0);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  [renderer beginFrameAtTime: 0.0 timeStamp: NULL];
+  [renderer render];
+  [renderer endFrame];
+}
 
 /* Builds a window with a drawable, or answers nil having touched nothing
    that could block.  The reason is written into *why. */
@@ -211,6 +305,81 @@ int main(void)
             "ending a frame that was never begun does nothing");
 
   END_SET("beginning and ending a frame")
+
+  START_SET("where the renderer puts the contents")
+
+  const char *whyDraw = "";
+  NSOpenGLContext *drawContext = usableContext(&whyDraw);
+  CARenderer *drawer;
+  CGImageRef image;
+  int x0, y0, x1, y1, n;
+  static unsigned char empty[MAX_PIXELS];
+  static unsigned char drawn[MAX_PIXELS];
+
+  if (drawContext == nil)
+    {
+      SKIP("%s", whyDraw)
+    }
+
+  drawer = [CARenderer rendererWithNSOpenGLContext: drawContext options: nil];
+  if (drawer == nil)
+    {
+      SKIP("there is no renderer to draw with")
+    }
+
+  image = solidImage(16, 8);
+
+  /* Giving a layer its geometry asks for an implicit animation, and a frame
+     begun afterwards renders the presentation layer part way through it,
+     which is not where the layer was put.  These are laid out with actions
+     switched off so that what is drawn is what was asked for. */
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+
+  CALayer *bare = [CALayer layer];
+  [bare setBounds: CGRectMake(0, 0, VIEW_W, VIEW_H)];
+  [bare setPosition: CGPointMake(VIEW_W / 2.0, VIEW_H / 2.0)];
+
+  CALayer *stretched = [CALayer layer];
+  [stretched setBounds: CGRectMake(0, 0, VIEW_W, VIEW_H)];
+  [stretched setPosition: CGPointMake(VIEW_W / 2.0, VIEW_H / 2.0)];
+  [stretched setContents: (id)image];
+  [stretched setContentsGravity: kCAGravityResize];
+
+  CALayer *centred = [CALayer layer];
+  [centred setBounds: CGRectMake(0, 0, VIEW_W, VIEW_H)];
+  [centred setPosition: CGPointMake(VIEW_W / 2.0, VIEW_H / 2.0)];
+  [centred setContents: (id)image];
+  [centred setContentsGravity: kCAGravityCenter];
+
+  [CATransaction commit];
+
+  renderFrame(drawer, bare);
+  readDrawable(empty);
+
+  /* A point of the layer is this many pixels of the drawable. */
+  CGFloat scaleX, scaleY;
+
+  renderFrame(drawer, stretched);
+  readDrawable(drawn);
+  scaleX = (CGFloat)drawableW / VIEW_W;
+  scaleY = (CGFloat)drawableH / VIEW_H;
+  PASS(changedBox(empty, drawn, &x0, &y0, &x1, &y1, &n)
+       && n == drawableW * drawableH,
+       "resize draws the contents over the whole layer");
+
+  renderFrame(drawer, centred);
+  readDrawable(drawn);
+  changedBox(empty, drawn, &x0, &y0, &x1, &y1, &n);
+  PASS(x0 == (int)(24 * scaleX) && x1 == (int)(40 * scaleX) - 1
+       && y0 == (int)(20 * scaleY) && y1 == (int)(28 * scaleY) - 1,
+       "center leaves them their own size in the middle of it");
+  PASS(n == (int)(16 * scaleX) * (int)(8 * scaleY),
+       "and paints no more than the contents are");
+
+  CGImageRelease(image);
+
+  END_SET("where the renderer puts the contents")
 
   [pool release];
   return 0;

--- a/Tests/quartzcore/CARenderer/renderer.m
+++ b/Tests/quartzcore/CARenderer/renderer.m
@@ -381,6 +381,75 @@ int main(void)
 
   END_SET("where the renderer puts the contents")
 
+  START_SET("a layer that masks its sublayers to its bounds")
+
+  const char *whyMask = "";
+  NSOpenGLContext *maskContext = usableContext(&whyMask);
+  CARenderer *masker;
+  CGImageRef maskImage;
+  int mx0, my0, mx1, my1, loose, cut;
+  static unsigned char blank[MAX_PIXELS];
+  static unsigned char shown[MAX_PIXELS];
+
+  if (maskContext == nil)
+    {
+      SKIP("%s", whyMask)
+    }
+
+  masker = [CARenderer rendererWithNSOpenGLContext: maskContext options: nil];
+  if (masker == nil)
+    {
+      SKIP("there is no renderer to draw with")
+    }
+
+  maskImage = solidImage(16, 16);
+
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+
+  CALayer *emptyRoot = [CALayer layer];
+  [emptyRoot setBounds: CGRectMake(0, 0, VIEW_W, VIEW_H)];
+  [emptyRoot setPosition: CGPointMake(VIEW_W / 2.0, VIEW_H / 2.0)];
+
+  /* A root the size of the drawable, holding a sublayer that hangs off its
+     right hand side, so that masking has something to cut off. */
+  CALayer *root = [CALayer layer];
+  [root setBounds: CGRectMake(0, 0, 32, 32)];
+  [root setPosition: CGPointMake(16, 16)];
+  CALayer *hangingOff = [CALayer layer];
+  [hangingOff setBounds: CGRectMake(0, 0, 16, 16)];
+  [hangingOff setPosition: CGPointMake(32, 16)];
+  [hangingOff setContents: (id)maskImage];
+  [hangingOff setContentsGravity: kCAGravityResize];
+  [root addSublayer: hangingOff];
+
+  [CATransaction commit];
+
+  renderFrame(masker, emptyRoot);
+  readDrawable(blank);
+
+  renderFrame(masker, root);
+  readDrawable(shown);
+  changedBox(blank, shown, &mx0, &my0, &mx1, &my1, &loose);
+  PASS(mx0 == 24 && mx1 == 39 && my0 == 8 && my1 == 23 && loose == 256,
+       "a sublayer hanging off its superlayer is drawn whole");
+
+  [CATransaction begin];
+  [CATransaction setDisableActions: YES];
+  [root setMasksToBounds: YES];
+  [CATransaction commit];
+
+  renderFrame(masker, root);
+  readDrawable(shown);
+  changedBox(blank, shown, &mx0, &my0, &mx1, &my1, &cut);
+  PASS(mx0 == 24 && mx1 == 31 && my0 == 8 && my1 == 23,
+       "and is cut off at the edge once the superlayer masks to its bounds");
+  PASS(cut == 128, "which leaves half of it, the half that was inside");
+
+  CGImageRelease(maskImage);
+
+  END_SET("a layer that masks its sublayers to its bounds")
+
   [pool release];
   return 0;
 }


### PR DESCRIPTION
A layer ignores contentsGravity: whatever it holds is stretched over its
bounds. The renderer also ignores masksToBounds, so a sublayer hanging off its
superlayer is drawn whole.

A new CAGravityDestinationRect works out where the contents belong, and both
-renderInContext: and the OpenGL renderer ask it, which keeps the two paths
drawing the same thing. contentsGravity also had no default here: it read as
nil where Apple answers resize, so every layer behaved as though centred once
gravity was honoured. It now starts as resize, and the setter keeps only a
name it knows, answering center for anything else as Apple does.

The renderer clips with glScissor when a layer masks to its bounds. That is
correct while the layer is not turned or skewed, and nothing is clipped when
it is, since an axis-aligned scissor cannot say what to cut. Masks inside
masks clip to what both allow.

Stacked on #95, with #73 merged in because its projection is what makes a
pixel a pixel.

Tests/quartzcore/CAGravity/gravity.m, and additions to CALayer/render.m and
CARenderer/renderer.m. Before the change the suite is 474 passed with 12
failed; after, 486 passed, 9 dashed, none failed.
