### PR TITLE
Fix: compile CAOpenGLLayer against its own interface

### DIFF
--- a/Source/CAOpenGLLayer.m
+++ b/Source/CAOpenGLLayer.m
@@ -24,5 +24,7 @@
    Boston, MA 02110-1301, USA.
 */
 
+#import "QuartzCore/CAOpenGLLayer.h"
+
 @implementation CAOpenGLLayer
 @end

--- a/Tests/quartzcore/CAOpenGLLayer/layer.m
+++ b/Tests/quartzcore/CAOpenGLLayer/layer.m
@@ -1,0 +1,45 @@
+/* CAOpenGLLayer is a CALayer.  None of the class's own drawing is checked
+   here: its defining methods take a CGL context, which this framework has no
+   portable equivalent for.  What is checked is that the class exists and
+   behaves as the layer it is declared to be. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAOpenGLLayer.h>
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("a GL layer is a layer")
+
+  CAOpenGLLayer *layer = nil;
+
+  PASS([CAOpenGLLayer superclass] == [CALayer class],
+       "a GL layer comes from CALayer");
+
+  PASS_RUNS(layer = [CAOpenGLLayer layer];,
+            "and answers the layer its class is asked for");
+
+  if (layer == nil)
+    {
+      SKIP("there is no layer to ask anything of")
+    }
+
+  PASS([layer isKindOfClass: [CALayer class]], "which is a CALayer");
+
+  [layer setBounds: CGRectMake(0, 0, 40, 30)];
+  PASS(CGRectEqualToRect([layer bounds], CGRectMake(0, 0, 40, 30)),
+       "keeping the bounds it is given");
+
+  [layer setOpacity: 0.5];
+  PASS([layer opacity] == 0.5, "and the opacity it is given");
+
+  PASS([[layer sublayers] count] == 0, "starting with no sublayers");
+
+  END_SET("a GL layer is a layer")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
Source/CAOpenGLLayer.m imports nothing, so @implementation CAOpenGLLayer compiles with no @interface in scope and the class is built as a root class instead of a CALayer subclass. [CAOpenGLLayer layer] raises NSInvalidArgumentException, so the class cannot be used at all. CATransformLayer had the same break, fixed in #103.

The file now imports QuartzCore/CAOpenGLLayer.h. Nothing else changes.

The methods that define the class are still not implemented. They take a CGL context and pixel format, which this framework has no portable equivalent for, so the test checks only that the class comes from CALayer and behaves as one.

Tests: Tests/quartzcore/CAOpenGLLayer/layer.m.

Before: 305 passed, 0 failed. After: 311 passed, 0 failed. 9 dashed hopes either way. Without the change the first 2 assertions fail and the rest of the set cannot run.
