### PR TITLE
Fix: give a presentation layer the class of the layer it stands for

### DIFF
--- a/Source/CALayer.m
+++ b/Source/CALayer.m
@@ -744,7 +744,12 @@ GSCA_OBSERVABLE_SETTER(setShadowOffset, CGSize, shadowOffset, CGSizeEqualToSize)
     {
       [self displayIfNeeded];
 
-      _presentationLayer = [[CALayer alloc] initWithLayer: self];
+      /* A presentation layer stands for the layer it is made from while that
+         layer animates, so it is a layer of the same class: a subclass that
+         draws content of its own draws none of it when a plain CALayer stands
+         for it.  A subclass with state of its own copies it by overriding
+         -initWithLayer:. */
+      _presentationLayer = [[[self class] alloc] initWithLayer: self];
       [_presentationLayer setModelLayer: self];
       assert([_presentationLayer isPresentationLayer]);
 

--- a/Source/CAShapeLayer.m
+++ b/Source/CAShapeLayer.m
@@ -49,4 +49,31 @@ NSString *const kCALineCapSquare = @"square";
 @synthesize lineJoin = _lineJoin;
 @synthesize lineDashPhase = _lineDashPhase;
 @synthesize lineDashPattern = _lineDashPattern;
+
+/* The shadow copy a presentation layer is made from carries what the shape
+   draws, or the layer standing in for this one draws nothing. */
+- (id) initWithLayer: (CALayer *)layer
+{
+  if ((self = [super initWithLayer: layer]) != nil)
+    {
+      if ([layer isKindOfClass: [CAShapeLayer class]])
+        {
+          CAShapeLayer *shape = (CAShapeLayer *)layer;
+
+          [self setPath: [shape path]];
+          [self setFillColor: [shape fillColor]];
+          [self setFillRule: [shape fillRule]];
+          [self setStrokeColor: [shape strokeColor]];
+          [self setStrokeStart: [shape strokeStart]];
+          [self setStrokeEnd: [shape strokeEnd]];
+          [self setLineWidth: [shape lineWidth]];
+          [self setMiterLimit: [shape miterLimit]];
+          [self setLineCap: [shape lineCap]];
+          [self setLineJoin: [shape lineJoin]];
+          [self setLineDashPhase: [shape lineDashPhase]];
+          [self setLineDashPattern: [shape lineDashPattern]];
+        }
+    }
+  return self;
+}
 @end

--- a/Tests/quartzcore/CALayer/TestInfo
+++ b/Tests/quartzcore/CALayer/TestInfo
@@ -1,3 +1,6 @@
 # A standalone layer answers nil from -animationKeys throughout on Apple, so
-# the implicit animation this file checks cannot be observed there.
-APPLE_SKIP_TESTS="implicit.m"
+# the implicit animation this file checks cannot be observed there.  Apple
+# answers nil from -presentationLayer as well, before and after -display and
+# while an animation is running, so a presentation layer cannot be looked at
+# there either.
+APPLE_SKIP_TESTS="implicit.m presentation.m"

--- a/Tests/quartzcore/CALayer/presentation.m
+++ b/Tests/quartzcore/CALayer/presentation.m
@@ -1,0 +1,84 @@
+/* A presentation layer stands for the layer it was made from while that layer
+   animates, so it has to be a layer of the same class: a subclass that draws
+   content of its own draws none of it when a plain CALayer stands for it.
+
+   -initWithLayer: is what makes that copy here, so a subclass carries its own
+   properties across by overriding it.
+
+   Apple answers nil from -presentationLayer without a render server behind
+   the layer, before and after -display and while an animation runs, and its
+   -initWithLayer: copies nothing at all, so neither half of this can be
+   checked against it and the file is named in APPLE_SKIP_TESTS. */
+#import <Foundation/Foundation.h>
+#include "Testing.h"
+
+#import <QuartzCore/CALayer.h>
+#import <QuartzCore/CAShapeLayer.h>
+
+static CGPathRef rectPath(void)
+{
+  CGMutablePathRef path = CGPathCreateMutable();
+
+  CGPathAddRect(path, NULL, CGRectMake(0, 0, 10, 10));
+  return path;
+}
+
+int main(void)
+{
+  NSAutoreleasePool *pool = [NSAutoreleasePool new];
+
+  START_SET("the class a presentation layer is")
+
+  CALayer *plain = [CALayer layer];
+  CAShapeLayer *shape = [CAShapeLayer layer];
+  CALayer *standsForPlain;
+  CALayer *standsForShape;
+
+  [plain setBounds: CGRectMake(0, 0, 40, 30)];
+  standsForPlain = [plain presentationLayer];
+  PASS(standsForPlain != nil, "a layer answers a presentation layer");
+  PASS([standsForPlain modelLayer] == plain,
+       "which answers the layer it stands for");
+  PASS(CGRectEqualToRect([standsForPlain bounds], CGRectMake(0, 0, 40, 30)),
+       "and carries that layer's bounds");
+  PASS([standsForPlain isMemberOfClass: [CALayer class]],
+       "and is a layer of the same class");
+
+  [shape setBounds: CGRectMake(0, 0, 40, 30)];
+  standsForShape = [shape presentationLayer];
+  PASS([standsForShape isKindOfClass: [CAShapeLayer class]],
+       "a shape layer is stood for by a shape layer");
+  PASS([standsForShape modelLayer] == shape,
+       "which answers the shape layer it stands for");
+
+  END_SET("the class a presentation layer is")
+
+  START_SET("what the copy carries")
+
+  CAShapeLayer *shape = [CAShapeLayer layer];
+  CGPathRef path = rectPath();
+  CAShapeLayer *copy;
+
+  [shape setBounds: CGRectMake(0, 0, 40, 30)];
+  [shape setPath: path];
+  [shape setLineWidth: 7];
+  [shape setStrokeStart: 0.25];
+  [shape setLineCap: kCALineCapRound];
+
+  copy = [[CAShapeLayer alloc] initWithLayer: shape];
+  PASS([copy path] == path, "the copy carries the path it was made from");
+  PASS([copy lineWidth] == 7, "and the line width");
+  PASS([copy strokeStart] == 0.25, "and where the stroke starts");
+  PASS([[copy lineCap] isEqualToString: kCALineCapRound],
+       "and the cap its line ends with");
+  PASS(CGRectEqualToRect([copy bounds], CGRectMake(0, 0, 40, 30)),
+       "along with the bounds a plain layer carries");
+
+  [copy release];
+  CGPathRelease(path);
+
+  END_SET("what the copy carries")
+
+  [pool release];
+  return 0;
+}


### PR DESCRIPTION
-presentationLayer builds its copy with [[CALayer alloc] initWithLayer: self], so the layer standing in for an animating layer is a plain CALayer whatever class the model layer is. A CAShapeLayer is stood for by something that has no path and draws nothing, and CARenderer draws the presentation layer.

The copy is now [[[self class] alloc] initWithLayer: self]. CAShapeLayer overrides -initWithLayer: to carry its path, colours, rule, stroke ends, line width, miter limit, cap, join and dash across, which is what that method is for. The other subclasses here have no state of their own yet; one that gains some overrides -initWithLayer: the same way.

Apple answers nil from -presentationLayer without a render server behind the layer, before and after -display and while an animation runs, and its own -initWithLayer: copies nothing, so none of this can be checked against it. The test is named in APPLE_SKIP_TESTS with that reason.

Tests: Tests/quartzcore/CALayer/presentation.m.

Before: 305 passed, 0 failed. After: 316 passed, 0 failed. 9 dashed hopes either way. Without the change 5 assertions fail.
