### PR TITLE
Build Quartzcore on Windows

### DIFF
--- a/CAAppKitBridge/GNUmakefile.preamble
+++ b/CAAppKitBridge/GNUmakefile.preamble
@@ -1,1 +1,7 @@
 VERSION = 0.1
+
+# clang 19 and later make -Wincompatible-pointer-types an error by
+# default.  The CoreFoundation and Foundation types here are toll-free
+# bridged, so the static types differ where the objects do not.
+ADDITIONAL_OBJCFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+ADDITIONAL_CFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion

--- a/GNUmakefile.preamble
+++ b/GNUmakefile.preamble
@@ -1,1 +1,21 @@
 VERSION = 0.1
+
+# clang 19 and later make -Wincompatible-pointer-types an error by
+# default.  The CoreFoundation and Foundation types here are toll-free
+# bridged, so the static types differ where the objects do not.
+ADDITIONAL_OBJCFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+ADDITIONAL_CFLAGS += -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
+
+# QuartzCore draws through opal.  A PE DLL must resolve every symbol at link
+# time, unlike an ELF shared library.  NB this belongs in the TOP LEVEL
+# preamble: Source/GNUmakefile.preamble is never parsed.
+ADDITIONAL_OBJC_LIBS += -lopal
+
+# CARenderer draws with OpenGL.  The Unix names -lGL and -lGLU do not exist
+# on Windows; the system libraries are opengl32 and glu32.
+ADDITIONAL_OBJC_LIBS += -lopengl32 -lglu32
+
+# opengl32.dll exports only OpenGL 1.1; everything from GL 2.0 on has to come
+# from wglGetProcAddress or a loader.  libepoxy exports the real gl* names and
+# dispatches at runtime, so the shader calls resolve.
+ADDITIONAL_OBJC_LIBS += -lepoxy

--- a/Source/CABackingStore.h
+++ b/Source/CABackingStore.h
@@ -44,7 +44,14 @@
 #import <OpenGL/gl.h>
 #import <OpenGL/glu.h>
 #else
+#if defined(_WIN32)
+/* opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points cannot be
+ * linked directly.  epoxy declares them and dispatches at runtime.
+ */
+#import <epoxy/gl.h>
+#else
 #import <GL/gl.h>
+#endif
 #import <GL/glu.h>
 #endif
 

--- a/Source/CARenderer.m
+++ b/Source/CARenderer.m
@@ -35,9 +35,18 @@
 #import "CARenderer+FrameworkPrivate.h"
 #if !(__APPLE__)
 #define GL_GLEXT_PROTOTYPES 1
+#if defined(_WIN32)
+/* opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points cannot be
+ * linked directly.  epoxy declares them and dispatches at runtime.
+ */
+#import <epoxy/gl.h>
+#else
 #import <GL/gl.h>
+#endif
 #import <GL/glu.h>
+#if !defined(_WIN32)
 #import <GL/glext.h>
+#endif
 #else
 #import <OpenGL/OpenGL.h>
 #import <OpenGL/gl.h>

--- a/Source/GLHelpers/CAGLProgram.h
+++ b/Source/GLHelpers/CAGLProgram.h
@@ -31,9 +31,18 @@
 #import <OpenGL/glu.h>
 #else
 #define GL_GLEXT_PROTOTYPES 1
+#if defined(_WIN32)
+/* opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points cannot be
+ * linked directly.  epoxy declares them and dispatches at runtime.
+ */
+#import <epoxy/gl.h>
+#else
 #import <GL/gl.h>
+#endif
 #import <GL/glu.h>
+#if !defined(_WIN32)
 #import <GL/glext.h>
+#endif
 #endif
 
 @interface CAGLProgram : NSObject

--- a/Source/GLHelpers/CAGLShader.h
+++ b/Source/GLHelpers/CAGLShader.h
@@ -31,9 +31,18 @@
 #import <OpenGL/glu.h>
 #else
 #define GL_GLEXT_PROTOTYPES 1
+#if defined(_WIN32)
+/* opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points cannot be
+ * linked directly.  epoxy declares them and dispatches at runtime.
+ */
+#import <epoxy/gl.h>
+#else
 #import <GL/gl.h>
+#endif
 #import <GL/glu.h>
+#if !defined(_WIN32)
 #import <GL/glext.h>
+#endif
 #endif
 
 @interface CAGLShader : NSObject

--- a/Source/GLHelpers/CAGLSimpleFramebuffer.h
+++ b/Source/GLHelpers/CAGLSimpleFramebuffer.h
@@ -37,9 +37,18 @@
 #import <Foundation/Foundation.h>
 #if !(__APPLE__)
 #define GL_GLEXT_PROTOTYPES 1
+#if defined(_WIN32)
+/* opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points cannot be
+ * linked directly.  epoxy declares them and dispatches at runtime.
+ */
+#import <epoxy/gl.h>
+#else
 #import <GL/gl.h>
+#endif
 #import <GL/glu.h>
+#if !defined(_WIN32)
 #import <GL/glext.h>
+#endif
 #else
 #import <OpenGL/OpenGL.h>
 #import <OpenGL/gl.h>

--- a/Source/GLHelpers/CAGLTexture.h
+++ b/Source/GLHelpers/CAGLTexture.h
@@ -31,9 +31,18 @@
 #import <OpenGL/glu.h>
 #else
 #define GL_GLEXT_PROTOTYPES 1
+#if defined(_WIN32)
+/* opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points cannot be
+ * linked directly.  epoxy declares them and dispatches at runtime.
+ */
+#import <epoxy/gl.h>
+#else
 #import <GL/gl.h>
+#endif
 #import <GL/glu.h>
+#if !defined(_WIN32)
 #import <GL/glext.h>
+#endif
 #endif
 #import <CoreGraphics/CGImage.h>
 


### PR DESCRIPTION
Three things stop QuartzCore building on Windows.

The framework calls into opal and never declares the dependency. Only the Demo and Tests makefiles carry -lopal. An ELF shared library tolerates the undefined symbols and resolves them at load; a PE DLL must resolve everything at link time.

opengl32 exports only OpenGL 1.1, so the GL 2.0 entry points the renderer uses cannot be linked. libepoxy declares them and dispatches at runtime, and its header sets the include guard so GL/glu.h still supplies the GLU calls.

The bridged CoreFoundation and Foundation types need the pointer diagnostic returned to a warning, as clang 19 and later make it an error.

ADDITIONAL_OBJC_LIBS is composed after the library directories, which is where a resolvable -l has to sit.

Built and installed on MSYS2 ucrt64 with clang 22.
